### PR TITLE
added pins_get to get channel pins

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -218,6 +218,9 @@ public:
 
 	void channel_invites_get(const class channel &c, command_completion_event_t callback);
 
+	/** Get a channel's pins */
+	void pins_get(snowflake channel_id, command_completion_event_t callback);
+
 	/** Get a guild */
 	void guild_get(snowflake g, command_completion_event_t callback);
 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -213,7 +213,7 @@ void cluster::channel_edit_position(const class channel &c, command_completion_e
 
 void cluster::channel_edit_permissions(const class channel &c, snowflake overwrite_id, uint32_t allow, uint32_t deny, bool member, command_completion_event_t callback) {
 	json j({ {"allow", std::to_string(allow)}, {"deny", std::to_string(deny)}, {"type", member ? 1 : 0}  });
-	this->post_rest("/api/channel", std::to_string(c.id) + "/permissions/" + std::to_string(overwrite_id), m_put, j.dump(), [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest("/api/channels", std::to_string(c.id) + "/permissions/" + std::to_string(overwrite_id), m_put, j.dump(), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("channel", channel().fill_from_json(&j), http));
 		}
@@ -229,7 +229,7 @@ void cluster::invite_get(const std::string &invitecode, command_completion_event
 }
 
 void cluster::channel_invites_get(const class channel &c, command_completion_event_t callback) {
-	this->post_rest("/api/channel", std::to_string(c.id) + "/invites", m_get, "", [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest("/api/channels", std::to_string(c.id) + "/invites", m_get, "", [callback](json &j, const http_request_completion_t& http) {
 		invite_map invites;
 		for (auto & curr_invite : j) {
 			invites[SnowflakeNotNull(&curr_invite, "id")] = invite().fill_from_json(&curr_invite);

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -240,6 +240,16 @@ void cluster::channel_invites_get(const class channel &c, command_completion_eve
 	});
 }
 
+void cluster::pins_get(snowflake channel_id, command_completion_event_t callback) {
+	this->post_rest("/api/channels", std::to_string(channel_id) + "/pins", m_get, "", [callback](json &j, const http_request_completion_t& http) {
+		message_map pins_messages;
+		for (auto & curr_message : j) {
+			pins_messages[SnowflakeNotNull(&curr_message, "id")] = message().fill_from_json(&curr_message);
+		}
+		callback(confirmation_callback_t("message_map", pins_messages, http));
+	});
+}
+
 void cluster::invite_delete(const std::string &invitecode, command_completion_event_t callback) {
 	this->post_rest("/api/invites", dpp::url_encode(invitecode), m_delete, "", [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -50,7 +50,7 @@ int main(int argc, char const *argv[])
 		log->info("[G:{} U:{} R:{} C:{}] <{}#{:04d}> {}", dpp::get_guild_count(), dpp::get_user_count(), dpp::get_role_count(), dpp::get_channel_count(), event.msg->author->username, event.msg->author->discriminator, content);
 
 		/* Crappy command handler example */
-		if (content == ".dotest" && event.msg->guild_id == 825407338755653642) {
+		if (content == ".dotest" && (event.msg->guild_id == 825407338755653642 || event.msg->guild_id == 828433613343162459)) {
 
 			/* Fill a message object for a reply */
 			dpp::message reply;


### PR DESCRIPTION
added pins_get to get channel pins

example test code:

```c++
bot.pins_get(event.msg->channel_id, [log, &bot](const dpp::confirmation_callback_t& completion) {
    dpp::message_map pins = std::get<dpp::message_map>(completion.value);
    log->debug("Pins got! number of pins={} http status={}", std::distance(std::begin(pins), std::end(pins)), completion.http_info.status);
});
```

this PR also includes fixes to `channel_edit_permissions` and `channel_invites_get`, as they were using the `/api/channel` endpoint instead of `/api/channels`

pins_get has been tested, the fixes to `channel_edit_permissions` and `channel_invites_get` have **not** been tested.