### PR TITLE
Make component destructor the default constructor

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -80,7 +80,7 @@ public:
 
 	/** Destructor
 	 */
-	~component();
+	~component() = default;
 
 	component& set_type(component_type ct);
 

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -35,9 +35,6 @@ component::component() : type(static_cast<component_type>(1)), label(""), style(
 {
 }
 
-component::~component() {
-}
-
 
 component& component::fill_from_json(nlohmann::json* j) {
 


### PR DESCRIPTION
I couldn't link to the library on Mac when building the master branch, as clang complained about the `component` constructor. This PR just sets the constructor to `default`, which fixes the issue.

This is just a preface to another PR I'm gonna make, to load the attachments in the message_create event. :D