### PR TITLE
Implement json deserializers for interaction events

### DIFF
--- a/include/dpp/discordevents.h
+++ b/include/dpp/discordevents.h
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,55 +24,56 @@
 
 namespace dpp {
 
-/** @brief Returns a snowflake id from a json field value, if defined, else returns 0 
+/** @brief Returns a snowflake id from a json field value, if defined, else returns 0
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-uint64_t SnowflakeNotNull(nlohmann::json* j, const char *keyname);
+uint64_t SnowflakeNotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a string from a json field value, if defined, else returns an empty string.
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-std::string StringNotNull(nlohmann::json* j, const char *keyname);
+std::string StringNotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a 64 bit unsigned integer from a json field value, if defined, else returns 0.
  * DO NOT use this for snowflakes, as usually snowflakes are wrapped in a string!
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-uint64_t Int64NotNull(nlohmann::json* j, const char *keyname);
+uint64_t Int64NotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a 32 bit unsigned integer from a json field value, if defined, else returns 0
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-uint32_t Int32NotNull(nlohmann::json* j, const char *keyname);
+uint32_t Int32NotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a 16 bit unsigned integer from a json field value, if defined, else returns 0
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-uint16_t Int16NotNull(nlohmann::json* j, const char *keyname);
+uint16_t Int16NotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns an 8 bit unsigned integer from a json field value, if defined, else returns 0
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-uint8_t Int8NotNull(nlohmann::json* j, const char *keyname);
+uint8_t Int8NotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a boolean value from a json field value, if defined, else returns false
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-bool BoolNotNull(nlohmann::json* j, const char *keyname);
+bool BoolNotNull(const nlohmann::json* j, const char *keyname);
 
 /** @brief Returns a time_t from an ISO8601 timestamp field in a json value, if defined, else returns
  * epoch value of 0.
  * @param j nlohmann::json instance to retrieve value from
  * @param keyname key name to check for a value
  */
-time_t TimestampNotNull(nlohmann::json* j, const char *keyname);
+time_t TimestampNotNull(const nlohmann::json* j, const char *keyname);
+
 
 /** @brief Base64 encode data.
  * @param buf Raw buffer

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +83,7 @@ typedef std::unordered_map<snowflake, class guild_member*> members_container;
  * @brief Represents a guild on Discord (AKA a server)
  */
 class guild : public managed {
-public:	
+public:
 	/** Shard ID of the guild */
 	uint16_t shard_id;
 
@@ -201,7 +201,7 @@ public:
 	/**
 	 * @brief Get the base permissions for a member on this guild,
 	 * before permission overwrites are applied.
-	 * 
+	 *
 	 * @param member member to get permissions for
 	 * @return uint64_t permissions bitmask
 	 */
@@ -210,7 +210,7 @@ public:
 	/**
 	 * @brief Get the permission overwrites for a member
 	 * merged into a bitmask.
-	 * 
+	 *
 	 * @param base_permissions base permissions before overwrites,
 	 * from channel::base_permissions
 	 * @param member Member to fetch permissions for
@@ -226,7 +226,7 @@ public:
 
 	/**
 	 * @brief Connect to a voice channel another guild member is in
-	 * 
+	 *
 	 * @param user_id User id to join
 	 * @return True if the user specified is in a vc, false if they aren't
 	 */
@@ -315,7 +315,7 @@ public:
 
 	/**
 	 * @brief Build a guild widget from json
-	 * 
+	 *
 	 * @param j json to build from
 	 * @return guild_widget& reference to self
 	 */
@@ -323,7 +323,7 @@ public:
 
 	/**
 	 * @brief Build json for a guild widget
-	 * 
+	 *
 	 * @return std::string guild widget stringified json
 	 */
 	std::string build_json() const;
@@ -382,9 +382,18 @@ public:
 
 };
 
+/**
+ * @brief helper function to deserialize a guild_member from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param gm guild_member to be deserialized
+ */
+void from_json(const nlohmann::json& j, guild_member& gm);
+
 /** A container of guild members */
 typedef std::unordered_map<snowflake, guild_member> guild_member_map;
 
 
 };
-

--- a/include/dpp/slashcommand.h
+++ b/include/dpp/slashcommand.h
@@ -100,12 +100,12 @@ void to_json(nlohmann::json& j, const command_option_choice& choice);
  * options.
  */
 struct command_option {
-	command_option_type type;			//< Option type (what type of value is accepted)
-	std::string name;				//< Option name (1-32 chars)
-	std::string description;			//< Option description (1-100 chars)
-	bool required;					//< True if this is a mandatory parameter
-	std::vector<command_option_choice> choices;	//< List of choices for multiple choice command
-	std::vector<command_option> options;		//< Sub-commands
+	command_option_type type;                    //!< Option type (what type of value is accepted)
+	std::string name;                            //!< Option name (1-32 chars)
+	std::string description;                     //!< Option description (1-100 chars)
+	bool required;                               //!< True if this is a mandatory parameter
+	std::vector<command_option_choice> choices;  //!< List of choices for multiple choice command
+	std::vector<command_option> options;         //!< Sub-commands
 
 	/**
 	 * @brief Construct a new command option object
@@ -236,11 +236,21 @@ struct command_resolved {
  * the command on a channel or in DM.
  */
 struct command_data_option {
-	std::string				name;		//< the name of the parameter
-	command_option_type			type;		//< value of ApplicationCommandOptionType
-	command_value				value;		//< Optional: the value of the pair
-	std::vector<command_data_option>	options;	//< Optional: present if this option is a group or subcommand
+	std::string name;                          //!< the name of the parameter
+	command_option_type type;                  //!< value of ApplicationCommandOptionType
+	command_value value;                       //!< Optional: the value of the pair
+	std::vector<command_data_option> options;  //!< Optional: present if this option is a group or subcommand
 };
+
+/**
+ * @brief helper function to deserialize a command_data_option from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param cdo command_data_option to be deserialized
+ */
+void from_json(const nlohmann::json& j, command_data_option& cdo);
 
 /** Types of interaction in the dpp::interaction class
  */
@@ -256,11 +266,21 @@ enum interaction_type {
  * with the interaction.
  */
 struct command_interaction {
-	snowflake id;					//< the ID of the invoked command
-	std::string name;				//< the name of the invoked command
-	command_resolved resolved;			//< Optional: converted users + roles + channels
-	std::vector<command_data_option> options;	//< Optional: the params + values from the user
+	snowflake id;                              //!< the ID of the invoked command
+	std::string name;                          //!< the name of the invoked command
+	command_resolved resolved;                 //!< Optional: converted users + roles + channels
+	std::vector<command_data_option> options;  //!< Optional: the params + values from the user
 };
+
+/**
+ * @brief helper function to deserialize a command_interaction from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param ci command_interaction to be deserialized
+ */
+void from_json(const nlohmann::json& j, command_interaction& ci);
 
 /**
  * @brief A button click for a button component
@@ -271,20 +291,30 @@ struct button_interaction {
 };
 
 /**
+ * @brief helper function to deserialize a button_interaction from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param bi button_interaction to be deserialized
+ */
+void from_json(const nlohmann::json& j, button_interaction& bi);
+
+/**
  * @brief An interaction represents a user running a command and arrives
  * via the dpp::cluster::on_interaction_create event.
  */
 class interaction : public managed {
 public:
-	snowflake	application_id;					//< id of the application this interaction is for
-	uint8_t		type;						//< the type of interaction
-	std::variant<command_interaction, button_interaction> data;	//< Optional: the command data payload
-	snowflake	guild_id;					//< Optional: the guild it was sent from
-	snowflake	channel_id;					//< Optional: the channel it was sent from
-	guild_member	member;						//< Optional: guild member data for the invoking user, including permissions
-	user		usr;						//< Optional: user object for the invoking user, if invoked in a DM
-	std::string	token;						//< a continuation token for responding to the interaction
-	uint8_t		version;					//< read-only property, always 1
+	snowflake application_id;                                   //!< id of the application this interaction is for
+	uint8_t	type;                                               //!< the type of interaction
+	std::variant<command_interaction, button_interaction> data; //!< Optional: the command data payload
+	snowflake guild_id;                                         //!< Optional: the guild it was sent from
+	snowflake channel_id;                                       //!< Optional: the channel it was sent from
+	guild_member member;                                        //!< Optional: guild member data for the invoking user, including permissions
+	user usr;                                                   //!< Optional: user object for the invoking user, if invoked in a DM
+	std::string token;                                          //!< a continuation token for responding to the interaction
+	uint8_t version;                                            //!< read-only property, always 1
 
 	/**
 	 * @brief Fill object properties from JSON
@@ -301,8 +331,17 @@ public:
 	 * @return std::string JSON string
 	 */
 	std::string build_json(bool with_id = false) const;
-
 };
+
+/**
+ * @brief helper function to deserialize an interaction from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param i interaction to be deserialized
+ */
+void from_json(const nlohmann::json& j, interaction& i);
 
 /**
  * @brief Represents an application command, created by your bot

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ enum user_flags {
 	u_house_balanace =	0b00000000001000000000000,
 	/// User is an early supporter
 	u_early_supporter =	0b00000000010000000000000,
-	/// User is a team user 
+	/// User is a team user
 	u_team_user =		0b00000000100000000000000,
 	/// User is has Bug Hunter level 2
 	u_bughunter_2 =		0b00000001000000000000000,
@@ -104,137 +104,146 @@ public:
 
 	/**
 	 * @brief Get the avatar url of the user object
-	 * 
+	 *
 	 * @return std::string avatar url
 	 */
 	std::string get_avatar_url() const;
 
 	/**
 	 * @brief User is a bot
-	 * 
+	 *
 	 * @return True if the user is a bot
 	 */
 	bool is_bot() const;
 	/**
 	 * @brief User is a system user (Clyde)
-	 * 
+	 *
 	 * @return true  if user is a system user
 	 */
 	bool is_system() const;
 	/**
 	 * @brief User has multi-factor authentication enabled
-	 * 
+	 *
 	 * @return true if multi-factor is enabled
 	 */
 	bool is_mfa_enabled() const;
 	/**
 	 * @brief Return true if user has verified account
-	 * 
+	 *
 	 * @return true if verified
 	 */
 	bool is_verified() const;
 	/**
 	 * @brief Return true if user has full nitro.
 	 * This is mutually exclusive with full nitro.
-	 * 
+	 *
 	 * @return true if user has full nitro
 	 */
 	bool has_nitro_full() const;
 	/**
 	 * @brief Return true if user has nitro classic.
 	 * This is mutually exclusive with nitro classic.
-	 * 
+	 *
 	 * @return true  if user has nitro classic
 	 */
 	bool has_nitro_classic() const;
 	/**
 	 * @brief Return true if user is a discord employee
-	 * 
+	 *
 	 * @return true if user is discord staff
 	 */
 	bool is_discord_employee() const;
 	/**
 	 * @brief Return true if user owns a partnered server
-	 * 
+	 *
 	 * @return true if user has partnered server
 	 */
 	bool is_partnered_owner() const;
 	/**
 	 * @brief Return true if user has hypesquad events
-	 * 
+	 *
 	 * @return true if has hypesquad events
 	 */
 	bool has_hypesquad_events() const;
 	/**
 	 * @brief Return true if user has the bughunter level 1 badge
-	 * 
+	 *
 	 * @return true if has bughunter level 1
 	 */
 	bool is_bughunter_1() const;
 	/**
 	 * @brief Return true if user is in house bravery
-	 * 
+	 *
 	 * @return true if in house bravery
 	 */
 	bool is_house_bravery() const;
 	/**
 	 * @brief Return true if user is in house brilliance
-	 * 
+	 *
 	 * @return true if in house brilliance
 	 */
 	bool is_house_brilliance() const;
 	/**
 	 * @brief Return true if user is in house balance
-	 * 
+	 *
 	 * @return true if in house brilliance
 	 */
 	bool is_house_balanace() const;
 	/**
 	 * @brief Return true if user is an early supporter
-	 * 
+	 *
 	 * @return true if early supporter
 	 */
 	bool is_early_supporter() const;
 	/**
 	 * @brief Return true if user is a team user
-	 * 
+	 *
 	 * @return true if a team user
 	 */
 	bool is_team_user() const;
 	/**
 	 * @brief Return true if user has the bughunter level 2 badge
-	 * 
+	 *
 	 * @return true if has bughunter level 2
 	 */
 	bool is_bughunter_2() const;
 	/**
 	 * @brief Return true if user has the verified bot badge
-	 * 
+	 *
 	 * @return true if verified bot
 	 */
 	bool is_verified_bot() const;
 	/**
 	 * @brief Return true if user is an early verified bot developer
-	 * 
+	 *
 	 * @return true if verified bot developer
 	 */
 	bool is_verified_bot_dev() const;
 	/**
 	 * @brief Return true if user is a certified moderator
-	 * 
+	 *
 	 * @return true if certified moderator
 	 */
 	bool is_certified_moderator() const;
 	/**
 	 * @brief Return true if user has an animated icon
-	 * 
+	 *
 	 * @return true if icon is animated (gif)
 	 */
 	bool has_animated_icon() const;
 };
 
+/**
+ * @brief helper function to deserialize a user from json
+ *
+ * @see https://github.com/nlohmann/json#arbitrary-types-conversions
+ *
+ * @param j output json object
+ * @param u user to be deserialized
+ */
+void from_json(const nlohmann::json& j, user& u);
+
 /** A group of users */
 typedef std::unordered_map<snowflake, user> user_map;
 
 };
-

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,8 +50,7 @@ char* strptime(const char* s, const char* f, struct tm* tm) {
 
 namespace dpp {
 
-uint64_t SnowflakeNotNull(json* j, const char *keyname)
-{
+uint64_t SnowflakeNotNull(const json* j, const char *keyname) {
 	/* Snowflakes are a special case. Pun intended.
 	 * Because discord drinks the javascript kool-aid, they have to send 64 bit integers as strings as js can't deal with them
 	 * even though we can. So, all snowflakes are sent and received wrapped as string values and must be read by nlohmann::json
@@ -67,8 +66,7 @@ uint64_t SnowflakeNotNull(json* j, const char *keyname)
 	}
 }
 
-std::string StringNotNull(json* j, const char *keyname)
-{
+std::string StringNotNull(const json* j, const char *keyname) {
 	/* Returns empty string if the value is not a string, or is null or not defined */
 	auto k = j->find(keyname);
 	if (k != j->end()) {
@@ -78,8 +76,7 @@ std::string StringNotNull(json* j, const char *keyname)
 	}
 }
 
-uint64_t Int64NotNull(json* j, const char *keyname)
-{
+uint64_t Int64NotNull(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {
 		return !k->is_null() && !k->is_string() ? k->get<uint64_t>() : 0;
@@ -88,8 +85,7 @@ uint64_t Int64NotNull(json* j, const char *keyname)
 	}
 }
 
-uint32_t Int32NotNull(json* j, const char *keyname)
-{
+uint32_t Int32NotNull(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {
 		return !k->is_null() && !k->is_string() ? k->get<uint32_t>() : 0;
@@ -98,8 +94,7 @@ uint32_t Int32NotNull(json* j, const char *keyname)
 	}
 }
 
-uint16_t Int16NotNull(json* j, const char *keyname)
-{
+uint16_t Int16NotNull(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {
 		return !k->is_null() && !k->is_string() ? k->get<uint16_t>() : 0;
@@ -108,8 +103,7 @@ uint16_t Int16NotNull(json* j, const char *keyname)
 	}
 }
 
-uint8_t Int8NotNull(json* j, const char *keyname)
-{
+uint8_t Int8NotNull(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {
 		return !k->is_null() && !k->is_string() ? k->get<uint8_t>() : 0;
@@ -118,8 +112,7 @@ uint8_t Int8NotNull(json* j, const char *keyname)
 	}
 }
 
-bool BoolNotNull(json* j, const char *keyname)
-{
+bool BoolNotNull(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {
 		return !k->is_null() ? (k->get<bool>() == true) : false;
@@ -128,8 +121,7 @@ bool BoolNotNull(json* j, const char *keyname)
 	}
 }
 
-std::string base64_encode(unsigned char const* buf, unsigned int buffer_length)
-{
+std::string base64_encode(unsigned char const* buf, unsigned int buffer_length) {
 	/* Quick and dirty base64 encode */
 	static const char to_base64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 	size_t ret_size = buffer_length + 2;
@@ -156,7 +148,7 @@ std::string base64_encode(unsigned char const* buf, unsigned int buffer_length)
 	return ret;
 }
 
-time_t TimestampNotNull(json* j, const char* keyname)
+time_t TimestampNotNull(const json* j, const char* keyname)
 {
 	/* Parses discord ISO 8061 timestamps to time_t, accounting for local time adjustment.
 	 * Note that discord timestamps contain a decimal seconds part, which time_t and struct tm
@@ -239,8 +231,5 @@ void DiscordClient::HandleEvent(const std::string &event, json &j, const std::st
 		log(dpp::ll_debug, fmt::format("Unhandled event: {}, {}", event, j.dump()));
 	}
 }
-
-
-
 
 };

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,24 +99,33 @@ guild_member::guild_member() :
 }
 
 guild_member& guild_member::fill_from_json(nlohmann::json* j, const guild* g, const user* u) {
-	if (g)
+	if (g) {
 		this->guild_id = g->id;
-	if (u)
+	}
+
+	if (u) {
 		this->user_id = u->id;
-	std::string nick = StringNotNull(j, "nick");
-	if (!nick.empty()) {
-		this->nickname = nick;
 	}
-	this->joined_at = TimestampNotNull(j, "joined_at");
-	this->premium_since = TimestampNotNull(j, "premium_since");
-	roles = {};
-	for (auto & role : (*j)["roles"]) {
-		this->roles.push_back(from_string<uint64_t>(role.get<std::string>(), std::dec));
-	}
-	this->flags |= BoolNotNull(j, "deaf") ? dpp::gm_deaf : 0;
-	this->flags |= BoolNotNull(j, "mute") ? dpp::gm_mute : 0;
-	this->flags |= BoolNotNull(j, "pending") ? dpp::gm_pending : 0;
+
+	j->get_to(*this);
 	return *this;
+}
+
+void from_json(const nlohmann::json& j, guild_member& gm) {
+	gm.nickname = StringNotNull(&j, "nick");
+	gm.joined_at = TimestampNotNull(&j, "joined_at");
+	gm.premium_since = TimestampNotNull(&j, "premium_since");
+
+	gm.roles.clear();
+	if (j.contains("roles") && !j.at("roles").is_null()) {
+		for (auto& role : j.at("roles")) {
+			gm.roles.push_back(std::stoull(role.get<std::string>()));
+		}
+	}
+
+	gm.flags |= BoolNotNull(&j, "deaf") ? gm_deaf : 0;
+	gm.flags |= BoolNotNull(&j, "mute") ? gm_mute : 0;
+	gm.flags |= BoolNotNull(&j, "pending") ? gm_pending : 0;
 }
 
 std::string guild_member::build_json() const {
@@ -445,4 +454,3 @@ bool guild::ConnectMemberVoice(snowflake user_id) {
 
 
 };
-

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2021 Craig Edwards and D++ contributors 
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ std::map<uint32_t, dpp::user_flags> usermap = {
 	{ 1 << 14,      dpp::u_bughunter_2 },
 	{ 1 << 16,      dpp::u_verified_bot },
 	{ 1 << 17,      dpp::u_verified_bot_dev },
-	{ 1 << 18,	dpp::u_certified_moderator }
+	{ 1 << 18,      dpp::u_certified_moderator }
 };
 
 namespace dpp {
@@ -60,88 +60,88 @@ std::string user::get_avatar_url()  const {
 	/* XXX: Discord were supposed to change their CDN over to discord.com, they havent.
 	 * At some point in the future this URL *will* change!
 	 */
-	return fmt::format("https://cdn.discordapp.com/avatars/{}/{}{}.{}", 
-		this->id, 
-		(has_animated_icon() ? "a_" : ""), 
-		this->avatar.to_string(), 
+	return fmt::format("https://cdn.discordapp.com/avatars/{}/{}{}.{}",
+		this->id,
+		(has_animated_icon() ? "a_" : ""),
+		this->avatar.to_string(),
 		(has_animated_icon() ? "gif" : "png")
-	); 
+	);
 }
 
 bool user::is_bot() const {
-	 return this->flags & u_bot; 
+	 return this->flags & u_bot;
 }
 
 bool user::is_system() const {
-	 return this->flags & u_system; 
+	 return this->flags & u_system;
 }
 
 bool user::is_mfa_enabled() const {
-	 return this->flags & u_mfa_enabled; 
+	 return this->flags & u_mfa_enabled;
 }
 
 bool user::is_verified() const {
-	 return this->flags & u_verified; 
+	 return this->flags & u_verified;
 }
 
 bool user::has_nitro_full() const {
-	 return this->flags & u_nitro_full; 
+	 return this->flags & u_nitro_full;
 }
 
 bool user::has_nitro_classic() const {
-	 return this->flags & u_nitro_classic; 
+	 return this->flags & u_nitro_classic;
 }
 
 bool user::is_discord_employee() const {
-	 return this->flags & u_discord_employee; 
+	 return this->flags & u_discord_employee;
 }
 
 bool user::is_partnered_owner() const {
-	 return this->flags & u_partnered_owner; 
+	 return this->flags & u_partnered_owner;
 }
 
 bool user::has_hypesquad_events() const {
-	 return this->flags & u_hypesquad_events; 
+	 return this->flags & u_hypesquad_events;
 }
 
 bool user::is_bughunter_1() const {
-	 return this->flags & u_bughunter_1; 
+	 return this->flags & u_bughunter_1;
 }
 
 bool user::is_house_bravery() const {
-	 return this->flags & u_house_bravery; 
+	 return this->flags & u_house_bravery;
 }
 
 bool user::is_house_brilliance() const {
-	 return this->flags & u_house_brilliance; 
+	 return this->flags & u_house_brilliance;
 }
 
 bool user::is_house_balanace() const {
-	 return this->flags & u_house_balanace; 
+	 return this->flags & u_house_balanace;
 }
 
 bool user::is_early_supporter() const {
-	 return this->flags & u_early_supporter; 
+	 return this->flags & u_early_supporter;
 }
 
 bool user::is_team_user() const {
-	 return this->flags & u_team_user; 
+	 return this->flags & u_team_user;
 }
 
 bool user::is_bughunter_2() const {
-	 return this->flags & u_bughunter_2; 
+	 return this->flags & u_bughunter_2;
 }
 
 bool user::is_verified_bot() const {
-	 return this->flags & u_verified_bot; 
+	 return this->flags & u_verified_bot;
 }
 
 bool user::is_verified_bot_dev() const {
-	 return this->flags & u_verified_bot_dev; 
+	 return this->flags & u_verified_bot_dev;
 }
 
 bool user::is_certified_moderator() const {
-	 return this->flags & u_certified_moderator; 
+	 return this->flags & u_certified_moderator;
 }
 
 bool user::has_animated_icon() const {
@@ -149,28 +149,35 @@ bool user::has_animated_icon() const {
 }
 
 user& user::fill_from_json(json* j) {
-	this->id = SnowflakeNotNull(j, "id");
-	this->username = StringNotNull(j, "username");
-	std::string av = StringNotNull(j, "avatar");
+	j->get_to(*this);
+	return *this;
+}
+
+void from_json(const nlohmann::json& j, user& u) {
+	u.id = SnowflakeNotNull(&j, "id");
+	u.username = StringNotNull(&j, "username");
+
+	std::string av = StringNotNull(&j, "avatar");
 	if (av.length() > 2 && av.substr(0, 2) == "a_") {
 		av = av.substr(2, av.length());
-		this->flags |= u_animated_icon;
+		u.flags |= u_animated_icon;
 	}
-	this->avatar = av;
-	this->discriminator = SnowflakeNotNull(j, "discriminator");
-	this->flags |= BoolNotNull(j, "bot") ? dpp::u_bot : 0;
-	this->flags |= BoolNotNull(j, "system") ? dpp::u_system : 0;
-	this->flags |= BoolNotNull(j, "mfa_enabled") ? dpp::u_mfa_enabled : 0;
-	this->flags |= BoolNotNull(j, "verified") ? dpp::u_verified : 0;
-	this->flags |= BoolNotNull(j, "premium_type") == 1 ? dpp::u_nitro_classic : 0;
-	this->flags |= BoolNotNull(j, "premium_type") == 2 ? dpp::u_nitro_full : 0;
-	uint32_t flags = Int32NotNull(j, "flags");
+	u.avatar = av;
+
+	u.discriminator = SnowflakeNotNull(&j, "discriminator");
+
+	u.flags |= BoolNotNull(&j, "bot") ? dpp::u_bot : 0;
+	u.flags |= BoolNotNull(&j, "system") ? dpp::u_system : 0;
+	u.flags |= BoolNotNull(&j, "mfa_enabled") ? dpp::u_mfa_enabled : 0;
+	u.flags |= BoolNotNull(&j, "verified") ? dpp::u_verified : 0;
+	u.flags |= BoolNotNull(&j, "premium_type") == 1 ? dpp::u_nitro_classic : 0;
+	u.flags |= BoolNotNull(&j, "premium_type") == 2 ? dpp::u_nitro_full : 0;
+	uint32_t flags = Int32NotNull(&j, "flags");
 	for (auto & flag : usermap) {
 		if (flags & flag.first) {
-			this->flags |= flag.second;
+			u.flags |= flag.second;
 		}
 	}
-	return *this;
 }
 
 };


### PR DESCRIPTION
This fixes a similar issue to #18 #19 but the other way around, received interaction events had their sub-options ignored and not parsed, this used the json's library built-in `from_json` to make this deserialization easier.

The original `::fill_from_json` methods are still there and just call the automatic conversion from the library, for compatibility, also, I onlyu implemented this for the structs involved in the interatcion_create event, the others are still parsed as they used to be.