### PR TITLE
Change command_value to accept signed integers

### DIFF
--- a/include/dpp/slashcommand.h
+++ b/include/dpp/slashcommand.h
@@ -54,7 +54,7 @@ enum command_option_type : uint8_t {
  * native data types represented by the enum above.
  * It is used in interactions.
  */
-typedef std::variant<std::string, uint32_t, bool, snowflake> command_value;
+typedef std::variant<std::string, int32_t, bool, snowflake> command_value;
 
 /**
  * @brief This struct represents choices in a multiple choice option

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -42,8 +42,8 @@ slashcommand& slashcommand::fill_from_json(nlohmann::json* j) {
 
 void to_json(json& j, const command_option_choice& choice) {
 	j["name"] = choice.name;
-	if (std::holds_alternative<uint32_t>(choice.value)) {
-		j["value"] = std::get<uint32_t>(choice.value);
+	if (std::holds_alternative<int32_t>(choice.value)) {
+		j["value"] = std::get<int32_t>(choice.value);
 	} else if (std::holds_alternative<bool>(choice.value)) {
 		j["value"] = std::get<bool>(choice.value);
 	} else if (std::holds_alternative<snowflake>(choice.value)) {
@@ -172,7 +172,7 @@ void from_json(const nlohmann::json& j, command_data_option& cdo) {
 			cdo.value = SnowflakeNotNull(&j, "value");
 			break;
 		case co_integer:
-			cdo.value = j.at("value").get<uint32_t>();
+			cdo.value = j.at("value").get<int32_t>();
 			break;
 		case co_string:
 			cdo.value = j.at("value").get<std::string>();


### PR DESCRIPTION
Command interaction options with integer type (`dpp::co_integer`) can have signed values, this is taken directly form the discord json:

![image](https://user-images.githubusercontent.com/12468184/119233282-af461f80-bafe-11eb-8323-d75507f5e667.png)

This PR changes unsigned to signed