### PR TITLE
Fix OpenSSL for Windows

### DIFF
--- a/include/dpp/httplib.h
+++ b/include/dpp/httplib.h
@@ -206,6 +206,15 @@ using socket_t = int;
 #include <sys/stat.h>
 #include <thread>
 
+#ifdef OPENSSL_SYS_WIN32
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef X509_CERT_PAIR
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif
+
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 #include <openssl/err.h>
 #include <openssl/md5.h>

--- a/include/dpp/sslclient.h
+++ b/include/dpp/sslclient.h
@@ -21,8 +21,19 @@
 #pragma once
 #include <string>
 #include <functional>
+
+#ifdef OPENSSL_SYS_WIN32
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef X509_CERT_PAIR
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif
+
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+
 #include <dpp/discord.h>
 
 namespace dpp {


### PR DESCRIPTION
This commit fixes errors about random missing symbols (or redefined) on OpenSSL headers. This has been tested and works on my machine.