### PR TITLE
interaction_create_t::get_parameter returns reference to value on the stack

### DIFF
--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -69,7 +69,7 @@ const command_value& interaction_create_t::get_parameter(const std::string& name
 {
 	/* Dummy STATIC return value for unknown options so we arent returning a value off the stack */
 	static command_value dummy_value = {};
-	command_interaction ci = std::get<command_interaction>(command.data);
+	const command_interaction& ci = std::get<command_interaction>(command.data);
 	for (auto i = ci.options.begin(); i != ci.options.end(); ++i) {
 		if (i->name == name) {
 			return i->value;


### PR DESCRIPTION
While working with long (>16 chars) slash command parameters, I ran into some issues with parts of the data getting corrupted, and after some examination the problem seems to be the following:

`std::get` in `command_interaction ci = std::get(...` returns a `const command_interaction&`, but the assignment to a non-reference type creates a local copy on the stack. The `const command_value&` returned by the function is therefore a reference to a local object. Changing the type of `ci` from `command_interaction` to `const command_interaction&` seems and ought to have fixed the problem, as it preserves the reference returned by `std::get` instead of creating a local copy.