### PR TITLE
[🚧 WIP 🚧] 🎉 DPP Threads Support

### DIFF
--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -33,28 +33,37 @@ namespace dpp {
 #define GUILD_CATEGORY	4	//!< an organizational category that contains up to 50 channels
 #define GUILD_NEWS	5	//!< a channel that users can follow and crosspost into their own server
 #define GUILD_STORE	6	//!< a channel in which game developers can sell their game on Discord
+#define GUILD_NEWS_THREAD 10 //!< a temporary sub-channel within a GUILD_NEWS channel
+#define GUILD_PUBLIC_THREAD 11 //!< a temporary sub-channel within a GUILD_TEXT channel
+#define GUILD_PRIVATE_THREAD 12 //!< a temporary sub-channel within a GUILD_TEXT channel that is only viewable by those invited and those with the MANAGE_THREADS permission
 #define GUILD_STAGE	13	//!< a "stage" channel, like a voice channel with one authorised speaker
 
 /** @brief Our flags as stored in the object */
 enum channel_flags {
 	/// NSFW Gated Channel
-	c_nsfw =		0b00000001,
+	c_nsfw =			0b00000001,
 	/// Text channel
-	c_text =		0b00000010,
+	c_text =			0b00000010,
 	/// Direct Message
-	c_dm =			0b00000100,
+	c_dm =				0b00000100,
 	/// Voice channel
-	c_voice =		0b00001000,
+	c_voice =			0b00001000,
 	/// Group
-	c_group =		0b00010000,
+	c_group =			0b00010000,
 	/// Category
 	c_category =		0b00100000,
 	/// News channel
-	c_news =		0b01000000,
+	c_news =			0b01000000,
 	/// Store page
-	c_store =		0b10000000,
+	c_store =			0b10000000,
 	/// Stage channel
-	c_stage =		0b11000000
+	c_stage =			0b11000000,
+	/// News thread
+	c_news_thread =		0b11100000,
+	/// Public thread
+	c_public_thread = 	0b11110000,
+	/// Private thread
+	c_private_thread =	0b11111000
 };
 
 /**
@@ -79,6 +88,21 @@ struct permission_overwrite {
 	uint64_t allow;
 	/// Deny mask
 	uint64_t deny;
+};
+
+
+/**
+ * @brief metadata for threads
+ */
+struct thread_metadata {
+	/// Whether a thread is archived
+	bool archived;
+	/// When the thread was archived
+	time_t archive_timestamp;
+	/// The duration after a thread will archive
+	uint16_t auto_archive_duration;
+	/// Whether a thread is locked
+	bool locked;
 };
 
 /** @brief A definition of a discord channel */
@@ -122,6 +146,15 @@ public:
 
 	/** Permission overwrites to apply to base permissions */
 	std::vector<permission_overwrite> permission_overwrites;
+
+	/** Approximate count of messages in a thread (threads) */
+	uint8_t message_count;
+
+	/** Approximate count of members in a thread (threads) */
+	uint8_t member_count;
+
+	/** Thread metadata (threads) */
+	thread_metadata metadata;
 
 	/** Constructor */
 	channel();

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -242,6 +242,9 @@ public:
 	/** List of channels on this server */
 	std::vector<snowflake> channels;
 
+	/** List of threads on this server */
+	std::vector<snowflake> threads;
+
 	/** List of guild members. Note that when you first receive the
 	 * guild create event, this may be empty or near empty.
 	 * This depends upon your dpp::intents and the size of your bot.

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -108,6 +108,9 @@ channel& channel::fill_from_json(json* j) {
 	this->flags |= (type == GUILD_NEWS) ? dpp::c_news : 0;
 	this->flags |= (type == GUILD_STORE) ? dpp::c_store : 0;
 	this->flags |= (type == GUILD_STAGE) ? dpp::c_stage : 0;
+	this->flags |= (type == GUILD_NEWS_THREAD) ? dpp::c_news_thread : 0;
+	this->flags |= (type == GUILD_PUBLIC_THREAD) ? dpp::c_public_thread : 0;
+	this->flags |= (type == GUILD_PRIVATE_THREAD) ? dpp::c_private_thread : 0;
 
 	if (j->find("recipients") != j->end()) {
 		recipients = {};
@@ -126,6 +129,18 @@ channel& channel::fill_from_json(json* j) {
 			po.type = Int8NotNull(&overwrite, "type");
 			permission_overwrites.push_back(po);
 		}
+	}
+	
+	if (type == GUILD_NEWS_THREAD || type == GUILD_PUBLIC_THREAD || type == GUILD_PRIVATE_THREAD) {
+		SetInt8NotNull(j, "message_count", this->message_count);
+		SetInt8NotNull(j, "memeber_count", this->member_count);
+		dpp::thread_metadata metadata;
+		auto json_metadata = (*j)["thread_metadata"];
+		metadata.archived = BoolNotNull(&json_metadata, "archived");
+		metadata.archive_timestamp = TimestampNotNull(&json_metadata, "archive_timestamp");
+		metadata.auto_archive_duration = Int16NotNull(&json_metadata, "auto_archive_duration");
+		metadata.locked = BoolNotNull(&json_metadata, "locked");
+
 	}
 
 	return *this;

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -40,7 +40,9 @@ channel::channel() :
 	rate_limit_per_user(0),
 	owner_id(0),
 	parent_id(0),
-	last_pin_timestamp(0)
+	last_pin_timestamp(0),
+	message_count(0),
+	member_count(0)
 {
 }
 

--- a/src/dpp/events/guild_create.cpp
+++ b/src/dpp/events/guild_create.cpp
@@ -83,6 +83,20 @@ void guild_create::handle(discord_client* client, json &j, const std::string &ra
 			g->channels.push_back(c->id);
 		}
 
+		/* Store guild threads */
+		g->threads.clear();
+		g->threads.reserve(d["threads"].size());
+		for (auto & channel : d["threads"]) {
+			dpp::channel* c = dpp::find_channel(SnowflakeNotNull(&channel, "id"));
+			if (!c) {
+				c = new dpp::channel();
+			}
+			c->fill_from_json(&channel);
+			c->guild_id = g->id;
+			dpp::get_channel_cache()->store(c);
+			g->threads.push_back(c->id);
+		}
+
 		/* Store guild members */
 		if (client->creator->cache_policy == cp_aggressive) {
 			g->members.reserve(d["members"].size());

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -23,24 +23,19 @@ int main()
 
 		command_handler.add_command(
 			/* Command name */
-			"ping",
+			"channelid",
 
 			/* Parameters */
-			{
-				{"testparameter", dpp::param_info(dpp::pt_string, true, "Optional test parameter") }
-			},
+			{},
 
 			/* Command handler */
 			[&command_handler, d](const std::string& command, const dpp::parameter_list_t& parameters, dpp::command_source src) {
-
-				command_handler.reply(dpp::message(fmt::format("Pong! {0:.3f}", d->websocket_ping)), src);
+				std::cout << src.channel_id << std::endl;
+				command_handler.reply(dpp::message(fmt::format("Channel ID is `{0}`", src.channel_id)), src);
 			},
 
 			/* Command description */
-			"A test ping command",
-
-			/* Guild id (omit for a global command) */
-			819556414099554344
+			"Checks what the channel ID is"
 		);
 
 	});


### PR DESCRIPTION
Threads are now partially added to DPP. They are basically channels, but with these new keys: 
![image](https://user-images.githubusercontent.com/72332327/123526487-179f9800-d68d-11eb-9d47-ca46bb07dbbd.png)

Todo list:
[ ] Add thread specific gw events (currently threads are only imported through `guild_create`)
[ ] Add thread creation utils
[ ] Add thread REST utils