### PR TITLE
Finished implementing editing of slash command interaction responses

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -767,12 +767,11 @@ public:
 
 	/**
 	 * @brief Respond to a slash command
-	 * 
-	 * @param interaction_id Interaction id to respond to
-	 * @param r Response to send
+	 *
+	 * @param m Message to send
 	 * @param callback Function to call when the API call completes
 	 */
-	void interaction_response_edit(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback = {});
+	void interaction_response_edit(const std::string &token, const message &r, command_completion_event_t callback = {});
 
 	/**
 	 * @brief Create a global slash command (a bot can have a maximum of 100 of these)

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -157,6 +157,20 @@ struct interaction_create_t : public event_dispatch_t {
 	void reply(interaction_response_type t, const std::string & mt) const;
 
 	/**
+	 * @brief Edit the response for this interaction
+	 *
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 */
+	void edit_response(const message & m) const;
+
+	/**
+	 * @brief Edit the response for this interaction
+	 *
+	 * @param mt The string value to send, for simple text only messages
+	 */
+	void edit_response(const std::string & mt) const;
+
+	/**
 	 * @brief Get a command line parameter
 	 * 
 	 * @param name The command line parameter to retrieve

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -239,8 +239,8 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 	});
 }
 
-void cluster::interaction_response_edit(snowflake application_id, const std::string &token, const interaction_response &r, command_completion_event_t callback) {
-	this->post_rest("/api/v8/interactions", std::to_string(application_id), url_encode(token) + "/messages/@original", m_patch, r.build_json(), [callback](json &j, const http_request_completion_t& http) {
+void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
+	this->post_rest("/api/v8/webhooks", std::to_string(me.id), url_encode(token) + "/messages/@original", m_patch, m.build_json(), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("confirmation", confirmation(), http));
 		}

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -65,6 +65,16 @@ void interaction_create_t::reply(interaction_response_type t, const std::string 
 	this->reply(t, dpp::message(this->command.channel_id, mt, mt_application_command));
 }
 
+void interaction_create_t::edit_response(const message & m) const
+{
+	from->creator->interaction_response_edit(this->command.token, m);
+}
+
+void interaction_create_t::edit_response(const std::string & mt) const
+{
+	this->edit_response(dpp::message(this->command.channel_id, mt, mt_application_command));
+}
+
 const command_value& interaction_create_t::get_parameter(const std::string& name) const
 {
 	/* Dummy STATIC return value for unknown options so we arent returning a value off the stack */


### PR DESCRIPTION
This updates `cluster::interaction_response_edit` to use the proper api endpoint (`/api/v8/webhooks`) and format in accordance with https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response. Some unnecessary parameters were removed. Also added `interaction_create_t::edit_response`.