### PR TITLE
Fixed slash command permissions not being included in json

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -357,7 +357,15 @@ void cluster::guild_command_edit(const slashcommand &s, snowflake guild_id, comm
 
 void cluster::guild_command_edit_permissions(const slashcommand &s, snowflake guild_id, command_completion_event_t callback) {
 	json j;
-	j["permissions"] = s.permissions;
+
+	if(s.permissions.size())  {
+		j["permissions"] = json();
+
+		for(const auto& perm : s.permissions) {
+			json jperm = perm;
+			j["permissions"].push_back(jperm);
+		}
+	}
 
 	this->post_rest(API_PATH "/applications", std::to_string(me.id), "guilds/" + std::to_string(guild_id) + "/commands/" + std::to_string(s.id) + "/permissions", m_put, j.dump(), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -103,6 +103,15 @@ void to_json(json& j, const slashcommand& p) {
 		}
 	}
 
+	if(p.permissions.size())  {
+		j["permissions"] = json();
+
+		for(const auto& perm : p.permissions) {
+			json jperm = perm;
+			j["permissions"].push_back(jperm);
+		}
+	}
+
 	j["default_permission"] = p.default_permission;
 }
 


### PR DESCRIPTION
Currently, the `permissions` vector is not being included in the json from what I can tell. This updates the appropriate `to_json` function to now also include the permissions, basically using the same code that is used to convert the other vectors to json. The `cluster::guild_command_edit_permissions` function also needs that vector, so I added the same code there as well. I tested it and for me, it's working now.

It might also be worth considering refactoring this into a template of some sort, since there are multiple instances throughout the code where that logic is used in exactly the same way.