### PR TITLE
Add interaction feature to dpp::message

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -901,6 +901,17 @@ struct CoreExport message {
 		bool fail_if_not_exists;
 	} message_reference;
 
+	struct message_interaction_struct{
+		// id of the interaction
+		snowflake id;
+		// type of interaction
+		uint8_t type;
+		// name of the application command
+		std::string name;
+		// the user who invoked the interaction
+		user usr;
+	} interaction;
+
 	struct allowed_ref {
 		bool parse_users;
 		bool parse_everyone;

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -257,6 +257,9 @@ message::message() : id(0), channel_id(0), guild_id(0), author(nullptr), sent(0)
 	message_reference.guild_id = 0;
 	message_reference.message_id = 0;
 	message_reference.fail_if_not_exists = false;
+	interaction.id = 0;
+	interaction.type = interaction_type::it_ping;
+	interaction.usr.id = 0;
 	allowed_mentions.parse_users = false;
 	allowed_mentions.parse_everyone = false;
 	allowed_mentions.parse_roles = false;
@@ -795,6 +798,13 @@ message& message::fill_from_json(json* d, cache_policy_t cp) {
 			}
 			this->author = authoruser;
 		}
+	}
+	if (d->find("interaction") != d->end()) {
+		json& inter = (*d)["interaction"];
+		interaction.id = SnowflakeNotNull(&inter, "id");
+		interaction.name = StringNotNull(&inter, "name");
+		interaction.type = Int8NotNull(&inter, "type");
+		if (inter.contains("user") && !inter["user"].is_null()) from_json(inter["user"], interaction.usr);
 	}
 	if (d->find("sticker_items") != d->end()) {
 		json &sub = (*d)["sticker_items"];


### PR DESCRIPTION
Interaction is a good way to get who triggered the bot's message if that was from a slash command.

Sources:
- Message Interaction structure: https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object-message-interaction-structure
- Message object: https://discord.com/developers/docs/resources/channel#message-object
