### PR TITLE
std::exception does not have a constructor that takes in a string.

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -44,7 +44,7 @@ cluster::cluster(const std::string &_token, uint32_t _intents, uint32_t _shards,
 	// Set up winsock.
 	WSADATA wsadata;
 	if (WSAStartup(MAKEWORD(2, 2), &wsadata)) {
-		throw std::exception("WSAStartup failure");
+		throw std::runtime_error("WSAStartup failure");
 	}
 #endif
 }


### PR DESCRIPTION
Maybe create a custom exception class in the `dpp` namespace so exceptions from DPP can be filtered?

Ex:
```cpp
#include <utility> // std::in_place_t
#include <exception> // std::exception

namespace dpp {

class exception : public std::exception
{
	std::string msg;

public:

	using std::exception::exception;

	exception() = default;

	explicit exception(const char* what) : msg(what) { }
	exception(const char* what, size_t len) : msg(what, len) { }

	explicit exception(const std::string& what) : msg(what) { }
	explicit exception(std::string&& what) : msg(std::move(what)) { }

	template < class... Args > explicit exception(std::in_place_t, Args&&... args)
		: msg(fmt::format(std::forward< Args >(args)...)) { }

	exception(const exception&) = default;
	exception(exception&&) = default;

	~exception() override = default;

	exception & operator = (const exception &) = default;
	exception & operator = (exception&&) = default;

	[[nodiscard]] const char* what() const noexcept override { return msg.c_str(); }
};

}
```