### PR TITLE
Explicitly remove the const qualifier from string literal.

### DIFF
--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -79,7 +79,7 @@ std::string StringNotNull(const json* j, const char *keyname) {
 	if (k != j->end()) {
 		return !k->is_null() && k->is_string() ? k->get<std::string>() : "";
 	} else {
-		return "";
+		return const_cast< char* >("");
 	}
 }
 


### PR DESCRIPTION
Mainly gets rid of the compiler ISO warning. The issue still remains but the intention is now obvious.