### PR TITLE
Webhook Adjustments

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -1656,7 +1656,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 	if (thread_id) {
 		parameters.append("&thread_id=" + std::to_string(thread_id));
 	}
-	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(token), m_post, m.build_json(false), [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(!wh.token.empty() ? wh.token: token), m_post, m.build_json(false), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("message", message().fill_from_json(&j), http));
 		}
@@ -1665,7 +1665,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 
 void cluster::get_webhook_message(const class webhook &wh, command_completion_event_t callback)
 {
-	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(token) + "/messages/@original", m_get, "", [callback](json &j, const http_request_completion_t &http){
+	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/@original", m_get, "", [callback](json &j, const http_request_completion_t &http){
 		if (callback){
 			callback(confirmation_callback_t("message", message().fill_from_json(&j), http));
 		}
@@ -1673,7 +1673,7 @@ void cluster::get_webhook_message(const class webhook &wh, command_completion_ev
 }
 
 void cluster::edit_webhook_message(const class webhook &wh, const struct message& m, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(token) + "/messages/" + std::to_string(m.id), m_patch, m.build_json(false), [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(m.id), m_patch, m.build_json(false), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("message", message().fill_from_json(&j), http));
 		}
@@ -1681,7 +1681,7 @@ void cluster::edit_webhook_message(const class webhook &wh, const struct message
 }
 
 void cluster::delete_webhook_message(const class webhook &wh, snowflake message_id, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(token) + "/messages/" + std::to_string(message_id), m_delete, "", [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest(API_PATH "/webhooks", std::to_string(wh.id), dpp::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(message_id), m_delete, "", [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("confirmation", confirmation(), http));
 		}

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -553,6 +553,11 @@ std::string message::build_json(bool with_id, bool is_interaction_response) cons
 		j["content"] = content;
 	}
 
+    if(author != nullptr) {
+        /* Used for webhooks */
+        j["username"] = author->username;
+    }
+
 	/* Populate message reference */
 	if (message_reference.channel_id || message_reference.guild_id || message_reference.message_id) {
 		j["message_reference"] = json::object();


### PR DESCRIPTION
I was having a hard time using a webhook to both post messages and use a user provided username.  These changes worked for me.

* Use the webhook token, if provided otherwise fall back to previous behavior (bot token).  According to the API documentation this should be a webhook token, not the bot token
![image](https://user-images.githubusercontent.com/1894689/132973874-22ca4fd5-eedf-4fea-9e42-49c25a3e0c36.png)

* Add "username" to messages if there is an author, currently only used for execute_webhook
![image](https://user-images.githubusercontent.com/1894689/132973884-f4e23106-44ee-45ba-ad50-506aa9beabef.png)
