### PR TITLE
refactor: move constant maps to global scope

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -30,13 +30,13 @@
 #include <dpp/nlohmann/json.hpp>
 #include <dpp/fmt/format.h>
 
+namespace dpp {
+
 static const std::map<image_type, std::string> mimetypes = {
 	{ i_gif, "image/gif" },
 	{ i_jpg, "image/jpeg" },
 	{ i_png, "image/png" }
 };
-
-namespace dpp {
 
 cluster::cluster(const std::string &_token, uint32_t _intents, uint32_t _shards, uint32_t _cluster_id, uint32_t _maxclusters, bool comp, cache_policy_t policy)
 	: token(_token), intents(_intents), numshards(_shards), cluster_id(_cluster_id),

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -30,6 +30,12 @@
 #include <dpp/nlohmann/json.hpp>
 #include <dpp/fmt/format.h>
 
+static const std::map<image_type, std::string> mimetypes = {
+	{ i_gif, "image/gif" },
+	{ i_jpg, "image/jpeg" },
+	{ i_png, "image/png" }
+};
+
 namespace dpp {
 
 cluster::cluster(const std::string &_token, uint32_t _intents, uint32_t _shards, uint32_t _cluster_id, uint32_t _maxclusters, bool comp, cache_policy_t policy)
@@ -1376,11 +1382,6 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 		j["nickname"] = nickname;
 	}
 	if (!image_blob.empty()) {
-		static std::map<image_type, std::string> mimetypes = {
-			{ i_gif, "image/gif" },
-			{ i_jpg, "image/jpeg" },
-			{ i_png, "image/png" }
-		};
 		if (image_blob.size() > MAX_EMOJI_SIZE) {
 			throw dpp::exception("User icon file exceeds discord limit of 256 kilobytes");
 		}

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -36,6 +36,43 @@
 #define PATH_COMPRESSED		"/?v=" DISCORD_API_VERSION "&encoding=json&compress=zlib-stream"
 #define DECOMP_BUFFER_SIZE	512 * 1024
 
+static const std::map<uint32_t, std::string> errortext = {
+	{ 1000, "Socket shutdown" },
+	{ 1001, "Client is leaving" },
+	{ 1002, "Endpoint received a malformed frame" },
+	{ 1003, "Endpoint received an unsupported frame" },
+	{ 1004, "Reserved code" },
+	{ 1005, "Expected close status, received none" },
+	{ 1006, "No close code frame has been received" },
+	{ 1007, "Endpoint received inconsistent message (e.g. malformed UTF-8)" },
+	{ 1008, "Generic error" },
+	{ 1009, "Endpoint won't process large frame" },
+	{ 1010, "Client wanted an extension which server did not negotiate" },
+	{ 1011, "Internal server error while operating" },
+	{ 1012, "Server/service is restarting" },
+	{ 1013, "Temporary server condition forced blocking client's request" },
+	{ 1014, "Server acting as gateway received an invalid response" },
+	{ 1015, "Transport Layer Security handshake failure" },
+	{ 4000, "Unknown error" },
+	{ 4001, "Unknown opcode" },
+	{ 4002, "Decode error" },
+	{ 4003, "Not authenticated" },
+	{ 4004, "Authentication failed" },
+	{ 4005, "Already authenticated" },
+	{ 4007, "Invalid seq" },
+	{ 4008, "Rate limited" },
+	{ 4009, "Session timed out" },
+	{ 4010, "Invalid shard" },
+	{ 4011, "Sharding required" },
+	{ 4012, "Invalid API version" },
+	{ 4013, "Invalid intent(s)" },
+	{ 4014, "Disallowed intent(s)" },
+	{ 6000, "ZLib Stream Error" },
+	{ 6001, "ZLib Data Error" },
+	{ 6002, "ZLib Memory Error" },
+	{ 6666, "Hell freezing over" }
+};
+
 namespace dpp {
 
 /* This is an internal class, defined externally as just a forward declaration for an opaque pointer.
@@ -322,42 +359,6 @@ bool discord_client::is_connected()
 
 void discord_client::Error(uint32_t errorcode)
 {
-	std::map<uint32_t, std::string> errortext = {
-		{ 1000, "Socket shutdown" },
-		{ 1001, "Client is leaving" },
-		{ 1002, "Endpoint received a malformed frame" },
-		{ 1003, "Endpoint received an unsupported frame" },
-		{ 1004, "Reserved code" },
-		{ 1005, "Expected close status, received none" },
-		{ 1006, "No close code frame has been received" },
-		{ 1007, "Endpoint received inconsistent message (e.g. malformed UTF-8)" },
-		{ 1008, "Generic error" },
-		{ 1009, "Endpoint won't process large frame" },
-		{ 1010, "Client wanted an extension which server did not negotiate" },
-		{ 1011, "Internal server error while operating" },
-		{ 1012, "Server/service is restarting" },
-		{ 1013, "Temporary server condition forced blocking client's request" },
-		{ 1014, "Server acting as gateway received an invalid response" },
-		{ 1015, "Transport Layer Security handshake failure" },
-		{ 4000, "Unknown error" },
-		{ 4001, "Unknown opcode" },
-		{ 4002, "Decode error" },
-		{ 4003, "Not authenticated" },
-		{ 4004, "Authentication failed" },
-		{ 4005, "Already authenticated" },
-		{ 4007, "Invalid seq" },
-		{ 4008, "Rate limited" },
-		{ 4009, "Session timed out" },
-		{ 4010, "Invalid shard" },
-		{ 4011, "Sharding required" },
-		{ 4012, "Invalid API version" },
-		{ 4013, "Invalid intent(s)" },
-		{ 4014, "Disallowed intent(s)" },
-		{ 6000, "ZLib Stream Error" },
-		{ 6001, "ZLib Data Error" },
-		{ 6002, "ZLib Memory Error" },
-		{ 6666, "Hell freezing over" }
-	};
 	std::string error = "Unknown error";
 	auto i = errortext.find(errorcode);
 	if (i != errortext.end()) {

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -247,7 +247,7 @@ void SetTimestampNotNull(const json* j, const char* keyname, time_t &v)
 	}
 }
 
-static const std::map<std::string, dpp::events::event*> eventmap = {
+const std::map<std::string, dpp::events::event*> eventmap = {
 	{ "__LOG__", new dpp::events::logger() },
 	{ "GUILD_CREATE", new dpp::events::guild_create() },
 	{ "GUILD_UPDATE", new dpp::events::guild_update() },

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -247,7 +247,7 @@ void SetTimestampNotNull(const json* j, const char* keyname, time_t &v)
 	}
 }
 
-std::map<std::string, dpp::events::event*> eventmap = {
+static const std::map<std::string, dpp::events::event*> eventmap = {
 	{ "__LOG__", new dpp::events::logger() },
 	{ "GUILD_CREATE", new dpp::events::guild_create() },
 	{ "GUILD_UPDATE", new dpp::events::guild_update() },

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -28,7 +28,7 @@
 
 using json = nlohmann::json;
 
-static const std::map<std::string, dpp::guild_flags> featuremap = {
+const std::map<std::string, dpp::guild_flags> featuremap = {
 	{"INVITE_SPLASH", dpp::g_invite_splash },
 	{"VIP_REGIONS", dpp::g_vip_regions },
 	{"VANITY_URL", dpp::g_vanity_url },
@@ -46,7 +46,7 @@ static const std::map<std::string, dpp::guild_flags> featuremap = {
 	{"PREVIEW_ENABLED", dpp::g_preview_enabled }
 };
 
-std::map<std::string, dpp::region> regionmap = {
+const std::map<std::string, dpp::region> regionmap = {
 	{ "brazil", dpp::r_brazil },
 	{ "central-europe", dpp::r_central_europe },
 	{ "hong-kong", dpp::r_hong_kong },

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -28,7 +28,7 @@
 
 using json = nlohmann::json;
 
-const std::map<std::string, dpp::guild_flags> featuremap = {
+static const std::map<std::string, dpp::guild_flags> featuremap = {
 	{"INVITE_SPLASH", dpp::g_invite_splash },
 	{"VIP_REGIONS", dpp::g_vip_regions },
 	{"VANITY_URL", dpp::g_vanity_url },
@@ -46,7 +46,7 @@ const std::map<std::string, dpp::guild_flags> featuremap = {
 	{"PREVIEW_ENABLED", dpp::g_preview_enabled }
 };
 
-const std::map<std::string, dpp::region> regionmap = {
+static const std::map<std::string, dpp::region> regionmap = {
 	{ "brazil", dpp::r_brazil },
 	{ "central-europe", dpp::r_central_europe },
 	{ "hong-kong", dpp::r_hong_kong },

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -28,7 +28,7 @@
 
 using json = nlohmann::json;
 
-std::map<std::string, dpp::guild_flags> featuremap = {
+static const std::map<std::string, dpp::guild_flags> featuremap = {
 	{"INVITE_SPLASH", dpp::g_invite_splash },
 	{"VIP_REGIONS", dpp::g_vip_regions },
 	{"VANITY_URL", dpp::g_vanity_url },

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -34,6 +34,13 @@ static const std::map<presence_status, std::string> status_name_mapping = {
 	{ps_dnd, "dnd"}
 };
 
+static const std::map<std::string, integration_type> type_map = {
+	{ "", i_discord },
+	{ "youtube", i_youtube },
+	{ "twitch", i_twitch },
+	{ "discord", i_discord }
+};
+
 namespace dpp {
 
 integration::integration() :
@@ -56,12 +63,6 @@ integration::~integration()
 
 integration& integration::fill_from_json(nlohmann::json* j)
 {
-	std::map<std::string, integration_type> type_map = {
-		{ "", i_discord },
-		{ "youtube", i_youtube },
-		{ "twitch", i_twitch },
-		{ "discord", i_discord }
-	};
 	this->id = SnowflakeNotNull(j, "id");
 	this->name = StringNotNull(j, "name");
 	this->type = type_map[StringNotNull(j, "type")];

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -27,6 +27,13 @@
 
 using json = nlohmann::json;
 
+static const std::map<presence_status, std::string> status_name_mapping = {
+	{ps_online, "online"},
+	{ps_offline, "offline"},
+	{ps_idle, "idle"},
+	{ps_dnd, "dnd"}
+};
+
 namespace dpp {
 
 integration::integration() :

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -155,12 +155,6 @@ presence& presence::fill_from_json(nlohmann::json* j) {
 }
 
 std::string presence::build_json() const {
-	std::map<presence_status, std::string> status_name_mapping = {
-		{ps_online, "online"},
-		{ps_offline, "offline"},
-		{ps_idle, "idle"},
-		{ps_dnd, "dnd"}
-	};
 	json j({
 
 		{"op", 3},

--- a/src/dpp/webhook.cpp
+++ b/src/dpp/webhook.cpp
@@ -24,6 +24,12 @@
 #include <dpp/nlohmann/json.hpp>
 #include <dpp/dispatcher.h>
 
+static const std::map<image_type, std::string> mimetypes = {
+	{ i_gif, "image/gif" },
+	{ i_jpg, "image/jpeg" },
+	{ i_png, "image/png" }
+};
+
 namespace dpp {
 
 using json = nlohmann::json;
@@ -76,11 +82,6 @@ std::string webhook::build_json(bool with_id) const {
 }
 
 webhook& webhook::load_image(const std::string &image_blob, image_type type) {
-	static std::map<image_type, std::string> mimetypes = {
-		{ i_gif, "image/gif" },
-		{ i_jpg, "image/jpeg" },
-		{ i_png, "image/png" }
-	};
 	if (image_blob.size() > MAX_EMOJI_SIZE) {
 		throw dpp::exception("Webhook icon file exceeds discord limit of 256 kilobytes");
 	}


### PR DESCRIPTION
I think it would be better if some of the constant maps are moved to a global scope, so they won't be created in every function call. Similar to what you all did to [`dpp::eventmap`](https://github.com/brainboxdotcc/DPP/blob/40e55d7e0a7a44dd84805cb6fa88d12a08ad6e66/src/dpp/discordevents.cpp#L250)