### PR TITLE
Add ephemeral boolean to attachment.

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -569,6 +569,8 @@ struct CoreExport attachment {
 	uint32_t height;
 	/** MIME type of the attachment, if applicable */
 	std::string content_type;
+	//** Whether this attachment is ephemeral, if applicable */
+	bool ephemeral;
 
 	/**
 	 * @brief Constructs a new attachment object.

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -569,7 +569,7 @@ struct CoreExport attachment {
 	uint32_t height;
 	/** MIME type of the attachment, if applicable */
 	std::string content_type;
-	//** Whether this attachment is ephemeral, if applicable */
+	/** Whether this attachment is ephemeral, if applicable */
 	bool ephemeral;
 
 	/**

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -533,6 +533,7 @@ attachment::attachment(json *j) : attachment() {
 	this->width = Int32NotNull(j, "width");
 	this->height = Int32NotNull(j, "height");
 	this->content_type = StringNotNull(j, "content_type");
+	this->ephemeral = BoolNotNull(j, "ephemeral");
 }
 
 std::string message::build_json(bool with_id, bool is_interaction_response) const {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -517,11 +517,13 @@ reaction::reaction(json* j) {
 	emoji_name = StringNotNull(&emoji, "name");
 }
 
-attachment::attachment() {
-	id = 0;
-	size = 0;
-	width = 0;
-	height = 0;
+attachment::attachment() 
+	: id(0)
+	, size(0)
+	, width(0)
+	, height(0)
+	, ephemeral(false)
+{
 }
 
 attachment::attachment(json *j) : attachment() {


### PR DESCRIPTION
As added to the discord api docs, the attachment now has a ephemeral boolean. Added the json support for this new boolean.

docs commit:
https://github.com/discord/discord-api-docs/commit/670f33f6b3c5dff2993c497be9e5a8ea35e2cb57#diff-160acb4654c611c67c4ee46b2ce5dda2be82212af8d1d00cd0256ef6edda1e95