### PR TITLE
A few small fixes to documentation of various files that were throwing warnings

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -853,7 +853,7 @@ public:
 	 * which is specified in dpp::discord_voice_client::insert_marker and returned to this
 	 * event.
 	 *
-	 * @param _voice_receive User function to attach to event
+	 * @param _voice_track_marker User function to attach to event
 	 */
 	void on_voice_track_marker (std::function<void(const voice_track_marker_t& _event)> _voice_track_marker);
 
@@ -898,7 +898,7 @@ public:
 	/**
 	 * @brief Respond to a slash command
 	 *
-	 * @param m Message to send
+	 * @param r Message to send
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
@@ -936,7 +936,7 @@ public:
 	/**
 	 * @brief Create/overwrite guild slash commands
 	 *
-	 * @param s Vector of slash commands to create/update.
+	 * @param commands Vector of slash commands to create/update.
 	 * New guild commands will be available in the guild immediately. If the command did not already exist, it will count toward daily application command create limits.
 	 * @param guild_id Guild ID to create/update the slash commands in
 	 * @param callback Function to call when the API call completes.
@@ -947,7 +947,7 @@ public:
 	/**
 	 * @brief Create/overwrite global slash commands
 	 *
-	 * @param s Vector of slash commands to create/update.
+	 * @param commands Vector of slash commands to create/update.
 	 * overwriting existing commands that are registered globally for this application. Updates will be available in all guilds after 1 hour.
 	 * Commands that do not already exist will count toward daily application command create limits.
 	 * @param callback Function to call when the API call completes.
@@ -1840,7 +1840,7 @@ public:
 	/**
 	 * @brief Get webhook message
 	 *
-	 * @param Webhook to get the original message for
+	 * @param wh Webhook to get the original message for
 	 * @param callback Function to call when the API call completes.
 	 */
 	void get_webhook_message(const class webhook &wh, command_completion_event_t callback = {});

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -875,6 +875,8 @@ struct CoreExport voice_receive_t : public event_dispatch_t {
  */
 class CoreExport dispatcher {
 public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdocumentation"
 	/** @brief Event handler function pointer for log event
 	 * @param event Event parameters
 	 */
@@ -1119,6 +1121,7 @@ public:
 	 * @param event Event parameters
 	 */
 	std::function<void(const guild_stickers_update_t& event)> stickers_update;
+#pragma GCC diagnostic pop
 };
 
 /**

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -71,11 +71,11 @@ public:
 	/**
 	 * @brief Construct a new emoji object with name, ID and flags
 	 * 
-	 * @param name The emoji's name
-	 * @param id ID, if it has one (unicode does not)
-	 * @param flags Emoji flags (emoji_flags)
+	 * @param n The emoji's name
+	 * @param i ID, if it has one (unicode does not)
+	 * @param f Emoji flags (emoji_flags)
 	 */
-	emoji(const std::string, const snowflake = 0, const uint8_t = 0);
+	emoji(const std::string n, const snowflake i = 0, const uint8_t f = 0);
 
 	/**
 	 * @brief Destroy the emoji object

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -629,6 +629,7 @@ struct CoreExport sticker {
 	 * While discord still send this empty string value we will still have a field
 	 * here in the library.
 	 */
+	[[deprecated("Will always be an empty string")]]
 	std::string     asset;
 	/** The type of sticker */
 	sticker_type	type;

--- a/include/dpp/presence.h
+++ b/include/dpp/presence.h
@@ -166,10 +166,10 @@ public:
 	/**
 	 * @brief Construct a new activity
 	 * 
-	 * @param typ 
-	 * @param nam 
-	 * @param stat
-	 * @param url_
+	 * @param typ activity type
+	 * @param nam Name of the activity
+	 * @param stat State of the activity
+	 * @param url_ url of the activity, only works for certain sites, such as YouTube
 	 */
 	activity(const activity_type typ, const std::string& nam, const std::string& stat, const std::string& url_);
 };
@@ -197,16 +197,16 @@ public:
 	/**
 	 * @brief Construct a new presence object with some parameters for sending to a websocket
 	 * 
-	 * @param status 
-	 * @param type 
-	 * @param activity_description 
+	 * @param status Status of the activity
+	 * @param type Type of activity
+	 * @param activity_description Description of the activity
 	 */
 	presence(presence_status status, activity_type type, const std::string& activity_description);
 
 	/**
 	 * @brief Construct a new presence object with some parameters for sending to a websocket
 	 * 
-	 * @param status 
+	 * @param status Status of the activity
 	 * @param a Activity itself 
 	 */
 	presence(presence_status status, activity a);

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -83,7 +83,7 @@ class CoreExport websocket_client : public ssl_client
 	/** Fill a header for outbound messages
 	 * @param outbuf The raw frame to fill
 	 * @param sendlength The size of the data to encapsulate
-	 * @param ws_opcode the opcode to send in the header
+	 * @param opcode the ws_opcode to send in the header
 	 */
 	size_t FillHeader(unsigned char* outbuf, size_t sendlength, ws_opcode opcode);
 


### PR DESCRIPTION
cluster.h:856,901,939,950,1843 fixed a couple typos in documentation that were causing warnings.

dispatcher.h:880-1123 Added a pragma to silence documentation warnings for this block because there doesn't appear a way to properly document std::function variables (least not I could find).

emoji.h:74-78 Fixed some documentation warnings in  due to just problems with names of certain parameters.

message.h:634 Added deprecation marker to a var that was marked as deprecated in a comment, but not in actual code which was causing a warning

presence.h:169-172,200-202,209 Added rudimentary descriptions to silence warning about missing description for parameters

wsclient.h:86 Fixed typo in documentation that was causing a warning