### PR TITLE
fix: add dummy ptrs into structure so that it doesn't break if the us…

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -138,6 +138,19 @@ class CoreExport discord_voice_client : public websocket_client
 	 * (merges frames into one packet)
 	 */
 	OpusRepacketizer* repacketizer;
+#else
+	/** libopus encoder
+	 */
+	void* encoder;
+
+	/** libopus decoder
+	 */
+	void* decoder;
+
+	/** libopus repacketizer
+	 * (merges frames into one packet)
+	 */
+	void* repacketizer;
 #endif
 
 	/** File descriptor for UDP connection


### PR DESCRIPTION
…er builds their bot without HAVE_VOICE defined, but built the lib with it

rhese pointers are opaque anyhow and should not be messed with by the user