### PR TITLE
Generate pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,9 @@ if(NOT WIN32)
 	install(TARGETS dpp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DLDCONFIG_EXECUTABLE=${LDCONFIG_EXECUTABLE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PostInstall.cmake)")
+
+	configure_file("${CMAKE_CURRENT_SOURCE_DIR}/dpp.pc.in" "${CMAKE_BINARY_DIR}/dpp.pc" @ONLY)
+	install(FILES "${CMAKE_BINARY_DIR}/dpp.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
 include("cmake/CPackSetup.cmake")						# Setup information for packaging and distribution

--- a/dpp.pc.in
+++ b/dpp.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libdpp
+Description: An incredibly lightweight C++ Discord library
+Version: @PROJECT_VERSION@
+URL: https://dpp.brainbox.cc/
+Libs: -L${libdir} -ldpp
+Cflags: -I${includedir}


### PR DESCRIPTION
Makes it easier to integrate DPP into builds using systems other than CMake. Not entirely sure if anything else needs to be added to the `Libs:` line, but it has been working for me as-is.