### PR TITLE
feat: calculate opus packet duration internally

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -474,6 +474,29 @@ public:
 	void send_audio_opus(uint8_t* opus_packet, const size_t length, uint64_t duration);
 
 	/**
+	 * @brief Send opus packets to the voice channel
+	 * 
+	 * Some containers such as .ogg may contain OPUS
+	 * encoded data already. In this case, we don't need to encode the
+	 * frames using opus here. We can bypass the codec, only applying 
+	 * libsodium to the stream.
+	 * 
+	 * Duration is calculated internally
+	 * 
+	 * @param opus_packet Opus packets. Discord expects opus frames 
+	 * to be encoded at 48000Hz
+	 * 
+	 * @param length The length of the audio data. 
+	 * 
+	 * @note It is your responsibility to ensure that packets of data 
+	 * sent to send_audio are correctly repacketized for streaming, 
+	 * e.g. that audio frames are not too large or contain
+	 * an incorrect format. Discord will still expect the same frequency
+	 * and bit width of audio and the same signedness.
+	 */
+	void send_audio_opus(uint8_t* opus_packet, const size_t length);
+
+	/**
 	 * @brief Set the timescale in nanoseconds.
 	 * 
 	 * @param new_timescale Timescale to set. This defaults to 1000000,

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -796,6 +796,14 @@ void discord_voice_client::send_audio_raw(uint16_t* audio_data, const size_t len
 #endif
 }
 
+void discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length) {
+#if HAVE_VOICE
+	int samples = opus_packet_get_nb_samples(opus_packet, length, 48000);
+	uint64_t duration = (samples / 48) / (timescale / 1000000);
+	send_audio_opus(opus_packet, length, duration);
+#endif
+}
+
 void discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length, uint64_t duration) {
 #if HAVE_VOICE
 	int frameSize = 48 * duration * (timescale / 1000000);


### PR DESCRIPTION
- Add send_audio_opus method overload that calculates duration of packet internally