### PR TITLE
fixed css name

### DIFF
--- a/docpages/footer.template.html
+++ b/docpages/footer.template.html
@@ -19,7 +19,7 @@
 
         gtag('config', 'G-QTH6YHBNG5');
 </script>
-<div style="font-size: 0.001rem;font-color:transparent">
+<div style="font-size: 0.001rem;color:transparent">
 	<!-- For crawlability of past versions -->
 	###PREV###
 </div>


### PR DESCRIPTION
in the footer template of the docs i found an invalid css property.
`font-color` doesn't exist. i replaced it to `color`