### PR TITLE
spdlog example now includes dpp after spdlog

### DIFF
--- a/docpages/02_building_a_bot.md
+++ b/docpages/02_building_a_bot.md
@@ -44,6 +44,8 @@ project(discord-bot VERSION 1.0 DESCRIPTION "A discord bot")
 
 # Add DPP as dependency
 add_subdirectory(libs/DPP)
+add_subdirectory(libs/spdlog) # if you need a logger. Don't forget to clone sources
+                              # in the `libs/` directory
 
 # Create an executable
 add_executable(${PROJECT_NAME}
@@ -54,8 +56,7 @@ add_executable(${PROJECT_NAME}
 # Linking libraries
 target_link_libraries(${PROJECT_NAME}
     dpp
-    spdlog # if you need a logger. Don't forget to clone sources
-           # in the `libs/` directory
+    spdlog # Like before, if you need spdlog
 )
 
 # Specify includes

--- a/docpages/03_example_programs.md
+++ b/docpages/03_example_programs.md
@@ -559,13 +559,13 @@ int main()
 If you want to make your bot use spdlog, like aegis does, you can attach it to the on_log event. You can do this as follows:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-#include <dpp/dpp.h>
-#include <dpp/fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <iomanip>
+#include <dpp/dpp.h>
+#include <dpp/fmt/format.h>
 
 int main(int argc, char const *argv[])
 {


### PR DESCRIPTION
**changes:**
- spdlog example now includes dpp after spdlog
- i also added add_subdirectory() for the spdlog in the example of 'Building with CMake'

fixes #123 