### PR TITLE
updated docs of avatar size

### DIFF
--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -214,10 +214,10 @@ public:
 	/**
 	 * @brief Returns the members's per guild avatar if they have one, otherwise returns an empty string
 	 * 
-	 * @param size The size of the avatar in pixels. If not specified, the default sized avatar is returned.
+	 * @param size The size of the avatar in pixels. It can be any power of two between 16 and 4096. If not specified, the default sized avatar is returned.
 	 * @return std::string avatar or empty string
 	 */
-	std::string get_avatar_url(uint32_t size = 0) const;
+	std::string get_avatar_url(uint16_t size = 0) const;
 
 	/**
 	 * @brief Set the nickname 

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -107,7 +107,7 @@ public:
 	/**
 	 * @brief Get the avatar url of the user object
 	 *
-	 * @param size The size of the avatar in pixels. Image size can be any power of two between 16 and 4096. if not specified, the default size is returned.
+	 * @param size The size of the avatar in pixels. It can be any power of two between 16 and 4096. if not specified, the default size is returned.
 	 * @return std::string avatar url
 	 */
 	std::string get_avatar_url(uint16_t size = 0) const;

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -107,10 +107,10 @@ public:
 	/**
 	 * @brief Get the avatar url of the user object
 	 *
-	 * @param size The size of the avatar in pixels, if not specified, the default size is returned.
+	 * @param size The size of the avatar in pixels. Image size can be any power of two between 16 and 4096. if not specified, the default size is returned.
 	 * @return std::string avatar url
 	 */
-	std::string get_avatar_url(uint32_t size = 0) const;
+	std::string get_avatar_url(uint16_t size = 0) const;
 
 	/**
 	 * @brief Return a ping/mention for the user

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -150,7 +150,7 @@ void from_json(const nlohmann::json& j, guild_member& gm) {
 	gm.flags |= bool_not_null(&j, "pending") ? gm_pending : 0;
 }
 
-std::string guild_member::get_avatar_url(uint32_t size)  const {
+std::string guild_member::get_avatar_url(uint16_t size)  const {
 	/* XXX: Discord were supposed to change their CDN over to discord.com, they haven't.
 	 * At some point in the future this URL *will* change!
 	 */

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -64,7 +64,7 @@ user_identified::user_identified() : user(), accent_color(0), verified(false) {
 user_identified::~user_identified() {
 }
 
-std::string user::get_avatar_url(uint32_t size)  const {
+std::string user::get_avatar_url(uint16_t size)  const {
 	/* XXX: Discord were supposed to change their CDN over to discord.com, they haven't.
 	 * At some point in the future this URL *will* change!
 	 */


### PR DESCRIPTION
- updated docs of avatar size: https://discord.com/developers/docs/reference#image-formatting-image-base-url
- so `uint16_t` should be enough ig