### PR TITLE
fixed slash command permissions not working

### DIFF
--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -72,8 +72,11 @@ void to_json(json& j, const command_option& opt) {
 	j["name"] = opt.name;
 	j["description"] = opt.description;
 	j["type"] = opt.type;
-	j["autocomplete"] = opt.autocomplete;
 	j["required"] = opt.required;
+
+	if (opt.autocomplete) {
+		j["autocomplete"] = opt.autocomplete;
+	}
 
 	/* Check for minimum and maximum values */
 	if (opt.type == dpp::co_number || opt.type == dpp::co_integer) {


### PR DESCRIPTION
fix #209 

The slash command permissions works now. I changed it so that the `autocomplete` field only get send, when its true.

I've also tested slash command autocompletion with these changes and they still works
(tested with the example https://dpp.dev/application-command-autocomplete.html).
