### PR TITLE
add fix to guild_command_create to solve the permissions edit issue

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1461,7 +1461,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::slashcommmand object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_command_create(const slashcommand &s, snowflake guild_id, command_completion_event_t callback = {});
+	void guild_command_create(slashcommand &s, snowflake guild_id, command_completion_event_t callback = {});
 
 
 	/**

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -108,8 +108,13 @@ void cluster::guild_bulk_command_create(const std::vector<slashcommand> &command
 	});
 }
 
-void cluster::guild_command_create(const slashcommand &s, snowflake guild_id, command_completion_event_t callback) {
+void cluster::guild_command_create(slashcommand &s, snowflake guild_id, command_completion_event_t callback) {
 	this->post_rest(API_PATH "/applications", std::to_string(s.application_id ? s.application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_post, s.build_json(false), [s, this, guild_id, callback] (json &j, const http_request_completion_t& http) mutable {
+		/* Setting the id is required to edit the permissions of the command */
+		if (j.contains("id")) {
+			s.id = snowflake_not_null(&j, "id");
+		}
+
 		if (callback) {
 			callback(confirmation_callback_t("slashcommand", slashcommand().fill_from_json(&j), http));
 		}


### PR DESCRIPTION
seems like these lines were there before https://github.com/brainboxdotcc/DPP/blob/f8e48910d0586b028a9495bd28078b1fa911c577/src/dpp/cluster.cpp#L385-L387

The parameter `s` will change to a non-const parameter this could be a breaking change?!

Shouldn't we change that also in `global_command_create` and other methods @braindigitalis ?

#212 