### PR TITLE
feat: add multiple attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testdata/onandon.pcm
 docs/doxygen_sqlite3.db
 .vs
 .misspell-fixer.ignore
+.idea

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -261,7 +261,7 @@ extern DPP_EXPORT event_handle __next_handle;
  * 
  * // Attach a listener to the event
  * event_handle id = my_event([&](const log_t& cc) {
- *     std::cout << cc.message << "\n";
+ *	 std::cout << cc.message << "\n";
  * });
  * 
  * // Construct a log_t and call the event (listeners will receive the log_t object)
@@ -553,7 +553,7 @@ public:
 	 * Example:
 	 * ```
 	 * bot.set_audit_reason("Too much abusive content")
-	 *    .channel_delete(my_channel_id);
+	 *	.channel_delete(my_channel_id);
 	 * ```
 	 * 
 	 * @param reason The reason to set for the next REST call on this thread
@@ -570,8 +570,8 @@ public:
 	 * Example:
 	 * ```
 	 * bot.set_audit_reason("Won't be sent")
-	 *    .clear_audit_reason()
-	 *    .channel_delete(my_channel_id);
+	 *	.clear_audit_reason()
+	 *	.channel_delete(my_channel_id);
 	 * ```
 	 * 
 	 * @return cluster& Reference to self for chaining.
@@ -1399,9 +1399,9 @@ public:
 	 */
 	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "");
 
-    /**
-     * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
-     *
+	/**
+	 * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
+	 *
 	 * @param endpoint Endpoint to post to, e.g. /api/guilds
 	 * @param major_parameters Major parameters for the endpoint e.g. a guild id
 	 * @param parameters Minor parameters for the API request
@@ -1410,8 +1410,8 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param filename List of filenames to post for POST requests (for uploading files)
 	 * @param filecontent List of file content to post for POST requests (for uploading files)
-     */
-    void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	 */
+	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
 
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asnyncronous access to HTTP APIs outside of Discord.
@@ -1526,7 +1526,7 @@ public:
 
 	/**
 	 * @brief Edit slash command permissions local to a guild,
-	 *        permissions are read from s.permissions
+	 *		permissions are read from s.permissions
 	 *
 	 * @param s Slash command to edit
 	 * @param guild_id Guild ID to edit the slash command in
@@ -2308,12 +2308,12 @@ public:
 	 * integer placeholder, and will be replaced by the API upon consumption. Its purpose is to allow you to overwrite a role's permissions
 	 * in a channel when also passing in channels with the channels array.
 	 * 
-    	 * When using the channels parameter, the position field is ignored, and none of the default channels are created. The id field within
+		 * When using the channels parameter, the position field is ignored, and none of the default channels are created. The id field within
 	 * each channel object may be set to an integer placeholder, and will be replaced by the API upon consumption. Its purpose is to
 	 * allow you to create `GUILD_CATEGORY` channels by setting the `parent_id` field on any children to the category's id field.
 	 * Category channels must be listed before any children.
 	 * 
-    	 * @note The region field is deprecated and is replaced by channel.rtc_region.
+		 * @note The region field is deprecated and is replaced by channel.rtc_region.
 	 * @param g Guild to create
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::guild object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
@@ -3128,10 +3128,10 @@ public:
 	 * There are currently several caveats for this endpoint:
 	 * 
 	 * - `channel_id` must currently point to a stage channel.
-    	 * - current user must already have joined `channel_id`.
-    	 * - You must have the `MUTE_MEMBERS` permission to unsuppress yourself. You can always suppress yourself.
-    	 * - You must have the `REQUEST_TO_SPEAK` permission to request to speak. You can always clear your own request to speak.
-    	 * - You are able to set `request_to_speak_timestamp` to any present or future time.
+		 * - current user must already have joined `channel_id`.
+		 * - You must have the `MUTE_MEMBERS` permission to unsuppress yourself. You can always suppress yourself.
+		 * - You must have the `REQUEST_TO_SPEAK` permission to request to speak. You can always clear your own request to speak.
+		 * - You are able to set `request_to_speak_timestamp` to any present or future time.
 	 * 
 	 * @param guild_id Guild to set voice state on
 	 * @param channel_id Stage channel to set voice state on
@@ -3193,7 +3193,7 @@ private:
 
 	/// Event handle
 	event_handle listener_handle;
-    
+	
 public:
 	/**
 	 * @brief Construct a new timed listener object
@@ -3312,11 +3312,11 @@ public:
 	 * 
 	 * ```cpp
 	 * virtual const dpp::message* filter(const dpp::message_create_t& m) {
-    	 *     if (m.msg.content.find("something i want") != std::string::npos) {
-	 *         return &m.msg;
-	 *     } else {
-	 *         return nullptr;
-	 *     }
+		 *	 if (m.msg.content.find("something i want") != std::string::npos) {
+	 *		 return &m.msg;
+	 *	 } else {
+	 *		 return nullptr;
+	 *	 }
 	 * }
 	 * ```
 	 * 

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1399,6 +1399,20 @@ public:
 	 */
 	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "");
 
+    /**
+     * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
+     *
+	 * @param endpoint Endpoint to post to, e.g. /api/guilds
+	 * @param major_parameters Major parameters for the endpoint e.g. a guild id
+	 * @param parameters Minor parameters for the API request
+	 * @param method Method, e.g. GET, POST
+	 * @param postdata Post data (usually JSON encoded)
+	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
+	 * @param filename List of filenames to post for POST requests (for uploading files)
+	 * @param filecontent List of file content to post for POST requests (for uploading files)
+     */
+    void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asnyncronous access to HTTP APIs outside of Discord.
 	 *

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -780,18 +780,18 @@ struct DPP_EXPORT sticker : public managed {
 	/** The name of the sticker */
 	std::string	name;
 	/// description of the sticker (may be empty)
-	std::string     description;    
+	std::string	 description;	
 	/** for guild stickers, the Discord name of a unicode emoji representing the sticker's expression.
 	 * for standard stickers, a comma-separated list of related expressions.
 	 */
-	std::string     tags;
+	std::string	 tags;
 	/**
 	 * @brief Asset ID
 	 * @deprecated now an empty string but still sent by discord.
 	 * While discord still send this empty string value we will still have a field
 	 * here in the library.
 	 */
-	std::string     asset;
+	std::string	 asset;
 	/** The type of sticker */
 	sticker_type	type;
 	/// type of sticker format
@@ -851,15 +851,15 @@ struct DPP_EXPORT sticker_pack : public managed {
 	/// the stickers in the pack
 	std::map<snowflake, sticker> stickers;
 	/// name of the sticker pack
-	std::string     name;
+	std::string	 name;
 	/// id of the pack's SKU
-	snowflake       sku_id;
+	snowflake	   sku_id;
 	/// Optional: id of a sticker in the pack which is shown as the pack's icon
-	snowflake       cover_sticker_id;
+	snowflake	   cover_sticker_id;
 	/// description of the sticker pack
-	std::string     description;
+	std::string	 description;
 	/// id of the sticker pack's banner image
-	snowflake       banner_asset_id;
+	snowflake	   banner_asset_id;
 
 	/**
 	 * @brief Construct a new sticker pack object
@@ -1009,9 +1009,9 @@ struct DPP_EXPORT cache_policy_t {
  */
 struct DPP_EXPORT message : public managed {
 	/** id of the channel the message was sent in */
-	snowflake       channel_id;
+	snowflake	   channel_id;
 	/** Optional: id of the guild the message was sent in */
-	snowflake       guild_id;
+	snowflake	   guild_id;
 	/** the author of this message (not guaranteed to be a valid user) */
 	user		author;
 	/** Optional: member properties for this message's author */
@@ -1056,7 +1056,7 @@ struct DPP_EXPORT message : public managed {
 	std::vector<std::string>	filename;
 
 	/** File content to upload (raw binary) */
-    std::vector<std::string>	filecontent;
+	std::vector<std::string>	filecontent;
 
 	/** Message type */
 	message_type type;
@@ -1310,14 +1310,14 @@ struct DPP_EXPORT message : public managed {
 	 */
 	message& set_file_content(const std::string &fc);
 
-    /**
-     * @brief Add a file to the message
-     *
-     * @param filename filename
-     * @param filecontent raw file content contained in std::string
-     * @return message& reference to self
-     */
-    message& add_file(const std::string &filename, const std::string &filecontent);
+	/**
+	 * @brief Add a file to the message
+	 *
+	 * @param filename filename
+	 * @param filecontent raw file content contained in std::string
+	 * @return message& reference to self
+	 */
+	message& add_file(const std::string &filename, const std::string &filecontent);
 
 	/**
 	 * @brief Set the message content

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1053,10 +1053,10 @@ struct DPP_EXPORT message : public managed {
 	std::vector<sticker> stickers;
 
 	/** Name of file to upload (for use server-side in discord's url) */
-	std::string	filename;
+	std::vector<std::string>	filename;
 
 	/** File content to upload (raw binary) */
-	std::string	filecontent;
+    std::vector<std::string>	filecontent;
 
 	/** Message type */
 	message_type type;
@@ -1295,7 +1295,7 @@ struct DPP_EXPORT message : public managed {
 	message& set_type(message_type t);
 
 	/**
-	 * @brief Set the filename
+	 * @brief Set the filename of the last file in list
 	 * 
 	 * @param fn filename
 	 * @return message& reference to self
@@ -1303,12 +1303,21 @@ struct DPP_EXPORT message : public managed {
 	message& set_filename(const std::string &fn);
 
 	/**
-	 * @brief Set the file content
+	 * @brief Set the file content of the last file in list
 	 * 
 	 * @param fc raw file content contained in std::string
 	 * @return message& reference to self
 	 */
 	message& set_file_content(const std::string &fc);
+
+    /**
+     * @brief Add a file to the message
+     *
+     * @param filename filename
+     * @param filecontent raw file content contained in std::string
+     * @return message& reference to self
+     */
+    message& add_file(const std::string &filename, const std::string &filecontent);
 
 	/**
 	 * @brief Set the message content

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -154,9 +154,9 @@ public:
 	/** Audit log reason for Discord requests, if non-empty */
 	std::string reason;
 	/** Upload file name (server side) */
-	std::string file_name;
+    std::vector<std::string> file_name;
 	/** Upload file contents (binary) */
-	std::string file_content;
+	std::vector<std::string> file_content;
 	/** Request mime type */
 	std::string mimetype;
 	/** Request headers (non-discord requests only) */
@@ -174,7 +174,19 @@ public:
 	 */
 	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "");
 
-	/** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
+    /** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
+	 * @param _endpoint The API endpoint, e.g. /api/guilds
+	 * @param _parameters Major and minor parameters for the endpoint e.g. a user id or guild id
+	 * @param completion completion event to call when done
+	 * @param _postdata Data to send in POST and PUT requests
+	 * @param method The HTTP method to use from dpp::http_method
+	 * @param audit_reason Audit log reason to send, empty to send none
+	 * @param filename The filename (server side) of any uploaded file
+	 * @param filecontent The binary content of any uploaded file for the request
+	 */
+    http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+
+    /** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
 	 * @param _url Raw HTTP url
 	 * @param completion completion event to call when done
 	 * @param method The HTTP method to use from dpp::http_method

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -154,7 +154,7 @@ public:
 	/** Audit log reason for Discord requests, if non-empty */
 	std::string reason;
 	/** Upload file name (server side) */
-    std::vector<std::string> file_name;
+	std::vector<std::string> file_name;
 	/** Upload file contents (binary) */
 	std::vector<std::string> file_content;
 	/** Request mime type */
@@ -174,7 +174,7 @@ public:
 	 */
 	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "");
 
-    /** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
+	/** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
 	 * @param _endpoint The API endpoint, e.g. /api/guilds
 	 * @param _parameters Major and minor parameters for the endpoint e.g. a user id or guild id
 	 * @param completion completion event to call when done
@@ -184,9 +184,9 @@ public:
 	 * @param filename The filename (server side) of any uploaded file
 	 * @param filecontent The binary content of any uploaded file for the request
 	 */
-    http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
 
-    /** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
+	/** Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
 	 * @param _url Raw HTTP url
 	 * @param completion completion event to call when done
 	 * @param method The HTTP method to use from dpp::http_method

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -207,23 +207,23 @@ void cluster::post_rest(const std::string &endpoint, const std::string &major_pa
 }
 
 void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent) {
-    /* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
-    rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback, this](const http_request_completion_t& rv) {
-        json j;
-        if (rv.error == h_success && !rv.body.empty()) {
-            try {
-                j = json::parse(rv.body);
-            }
-            catch (const std::exception &e) {
-                /* TODO: Do something clever to handle malformed JSON */
-                log(ll_error, fmt::format("post_rest_multipart() to {}: {}", endpoint, e.what()));
-                return;
-            }
-        }
-        if (callback) {
-            callback(j, rv);
-        }
-    }, postdata, method, get_audit_reason(), filename, filecontent));
+	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
+	rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback, this](const http_request_completion_t& rv) {
+		json j;
+		if (rv.error == h_success && !rv.body.empty()) {
+			try {
+				j = json::parse(rv.body);
+			}
+			catch (const std::exception &e) {
+				/* TODO: Do something clever to handle malformed JSON */
+				log(ll_error, fmt::format("post_rest_multipart() to {}: {}", endpoint, e.what()));
+				return;
+			}
+		}
+		if (callback) {
+			callback(j, rv);
+		}
+	}, postdata, method, get_audit_reason(), filename, filecontent));
 }
 
 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -206,6 +206,27 @@ void cluster::post_rest(const std::string &endpoint, const std::string &major_pa
 	}, postdata, method, get_audit_reason(), filename, filecontent));
 }
 
+void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent) {
+    /* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
+    rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback, this](const http_request_completion_t& rv) {
+        json j;
+        if (rv.error == h_success && !rv.body.empty()) {
+            try {
+                j = json::parse(rv.body);
+            }
+            catch (const std::exception &e) {
+                /* TODO: Do something clever to handle malformed JSON */
+                log(ll_error, fmt::format("post_rest_multipart() to {}: {}", endpoint, e.what()));
+                return;
+            }
+        }
+        if (callback) {
+            callback(j, rv);
+        }
+    }, postdata, method, get_audit_reason(), filename, filecontent));
+}
+
+
 void cluster::request(const std::string &url, http_method method, http_completion_event callback, const std::string &postdata, const std::string &mimetype, const std::multimap<std::string, std::string> &headers) {
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	raw_rest->post_request(new http_request(url, callback, method, postdata, mimetype, headers));

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -174,7 +174,7 @@ void cluster::guild_commands_get(snowflake guild_id, command_completion_event_t 
 }
 
 void cluster::interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/interactions", std::to_string(interaction_id), url_encode(token) + "/callback", m_post, r.build_json(), [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/interactions", std::to_string(interaction_id), url_encode(token) + "/callback", m_post, r.build_json(), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("confirmation", confirmation(), http));
 		}
@@ -182,7 +182,7 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/webhooks", std::to_string(me.id), url_encode(token) + "/messages/@original", m_patch, m.build_json(), [callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), url_encode(token) + "/messages/@original", m_patch, m.build_json(), [callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("confirmation", confirmation(), http));
 		}

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -41,7 +41,7 @@ void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, c
 
 
 void cluster::message_create(const message &m, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/channels", std::to_string(m.channel_id), "messages", m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages", m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("message", message(this).fill_from_json(&j), http));
 		}
@@ -145,7 +145,7 @@ void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake chan
 
 
 void cluster::message_edit(const message &m, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, m.build_json(true), [this, callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, m.build_json(true), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t("message", message(this).fill_from_json(&j), http));
 		}

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -574,16 +574,16 @@ embed& embed::set_url(const std::string &u) {
 
 embed_footer& embed_footer::set_text(const std::string& t){
 	text = t; 
-	return *this;     
+	return *this;
 }
 
-embed_footer& embed_footer::set_icon(const std::string& i){     
+embed_footer& embed_footer::set_icon(const std::string& i){	 
 	icon_url = i;
-	return *this;           
-}                                                                                  
+	return *this;
+}																				  
 
-embed_footer& embed_footer::set_proxy(const std::string& p){     
-	proxy_url = p;          
+embed_footer& embed_footer::set_proxy(const std::string& p){	 
+	proxy_url = p;		  
 	return *this;
 }
 

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -384,13 +384,27 @@ message& message::set_type(message_type t)
 
 message& message::set_filename(const std::string &fn)
 {
-	filename = fn;
+	if (filename.empty()) {
+		filename.push_back(fn);
+	} else {
+		filename[filename.size() - 1] = fn;
+	}
 	return *this;
 }
 
 message& message::set_file_content(const std::string &fc)
 {
-	filecontent = fc;
+	if (filecontent.empty()) {
+		filecontent.push_back(fc);
+	} else {
+		filecontent[filecontent.size() - 1] = fc;
+	}
+	return *this;
+}
+
+message& message::add_file(const std::string &fn, const std::string &fc) {
+	filecontent.push_back(fc);
+	filename.push_back(fn);
 	return *this;
 }
 

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -175,18 +175,18 @@ http_request_completion_t http_request::run(cluster* owner) {
 				} else {
 					/* Special multipart mime body for Discord */
 					httplib::MultipartFormDataItems items  = {
-                        { "payload_json", postdata, "", mimetype }
-                    };
+						{ "payload_json", postdata, "", mimetype }
+					};
 
-                    if (file_content.size() == 1) {
-                        struct httplib::MultipartFormData file = { "file", file_content[0], file_name[0], "application/octet-stream" };
-                        items.push_back(file);
-                    } else {
-                        for (size_t i = 0; i < file_content.size(); i++) {
-                            struct httplib::MultipartFormData file = { fmt::format("files[{}]", i), file_content[i], file_name[i], "application/octet-stream" };
-                            items.push_back(file);
-                        }
-                    }
+					if (file_content.size() == 1) {
+						struct httplib::MultipartFormData file = { "file", file_content[0], file_name[0], "application/octet-stream" };
+						items.push_back(file);
+					} else {
+						for (size_t i = 0; i < file_content.size(); i++) {
+							struct httplib::MultipartFormData file = { fmt::format("files[{}]", i), file_content[i], file_name[i], "application/octet-stream" };
+							items.push_back(file);
+						}
+					}
 
 					if (auto res = cli.Post(_url.c_str(), items)) {
 						rv.latency = dpp::utility::time_f() - start;
@@ -429,4 +429,3 @@ std::string url_encode(const std::string &value) {
 
 
 };
-

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -37,9 +37,15 @@ static std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/
 static const char* DISCORD_HOST = "https://discord.com";
 
 http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method _method, const std::string &audit_reason, const std::string &filename, const std::string &filecontent)
- : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(_method), reason(audit_reason), file_name(filename), file_content(filecontent), mimetype("application/json")
+ : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(_method), reason(audit_reason), file_name({filename}), file_content({filecontent}), mimetype("application/json")
 {
 }
+
+http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method method, const std::string &audit_reason, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent)
+ : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(method), reason(audit_reason), file_name(filename), file_content(filecontent), mimetype("application/json")
+{
+}
+
 
 http_request::http_request(const std::string &_url, http_completion_event completion, http_method _method, const std::string &_postdata, const std::string &_mimetype, const std::multimap<std::string, std::string> &_headers)
  : complete_handler(completion), completed(false), non_discord(true), endpoint(_url), postdata(_postdata), method(_method), mimetype(_mimetype), req_headers(_headers)
@@ -168,10 +174,20 @@ http_request_completion_t http_request::run(cluster* owner) {
 					}
 				} else {
 					/* Special multipart mime body for Discord */
-					httplib::MultipartFormDataItems items = {
-						{ "payload_json", postdata, "", mimetype.c_str() },
-						{ "file", file_content, file_name, "application/octet-stream" }
-					};
+					httplib::MultipartFormDataItems items  = {
+                        { "payload_json", postdata, "", mimetype }
+                    };
+
+                    if (file_content.size() == 1) {
+                        struct httplib::MultipartFormData file = { "file", file_content[0], file_name[0], "application/octet-stream" };
+                        items.push_back(file);
+                    } else {
+                        for (size_t i = 0; i < file_content.size(); i++) {
+                            struct httplib::MultipartFormData file = { fmt::format("files[{}]", i), file_content[i], file_name[i], "application/octet-stream" };
+                            items.push_back(file);
+                        }
+                    }
+
 					if (auto res = cli.Post(_url.c_str(), items)) {
 						rv.latency = dpp::utility::time_f() - start;
 						populate_result(_url, owner, rv, res);


### PR DESCRIPTION
- Add the ability to add multiple attachment to messages as suggested in issue #181 
- Add .idea to gitignore for CLion

This does not break any of the existing methods (`set_filename`, `set_file_content`) but instead adds another method called `add_file` to the message class