### PR TITLE
Export include directory to external CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,8 +138,6 @@ endif()
 
 include_directories(${OPENSSL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
 
-include_directories("include")
-
 find_package(Git QUIET)
 
 if(NOT GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
@@ -194,6 +192,9 @@ foreach (fullmodname ${subdirlist})
 	else()
 		add_library(${modname} STATIC ${modsrc})
 	endif()
+    target_include_directories(${modname} PUBLIC 
+       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+    )
 
 	if (WIN32 AND NOT MINGW)
 		if (NOT WINDOWS_32_BIT)


### PR DESCRIPTION
This PR exports the `include/` directory to any other CMake project who may want to include `dpp` as a source-dependency instead of building it system-wide. This makes the project more compatible with modern CMake practices and also makes it possible to install out-of-the-box using package managers like [CPM](https://github.com/cpm-cmake/CPM.cmake).