### PR TITLE
quickfix guild_edit_member

### DIFF
--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -180,7 +180,11 @@ bool guild_member::has_animated_guild_avatar() const {
 
 std::string guild_member::build_json() const {
 	json j;
-	j["communication_disabled_until"] = ts_to_string(this->communication_disabled_until);
+	if (this->communication_disabled_until == 0) {
+		j["communication_disabled_until"] = NULL;
+	} else {
+		j["communication_disabled_until"] = ts_to_string(this->communication_disabled_until);
+	}
 	if (!this->nickname.empty())
 		j["nick"] = this->nickname;
 	if (this->roles.size()) {


### PR DESCRIPTION
This is not a bulletproof fix (just a workaround i think) because when you edit a guild_member who has administrator permissions or is admin, it will fail.
See documentation here https://discord.com/developers/docs/resources/guild#modify-guild-member.

#251 