### PR TITLE
fix wrong make install dir

### DIFF
--- a/docpages/02_build.md
+++ b/docpages/02_build.md
@@ -108,7 +108,7 @@ Replace the number after -j with a number suitable for your setup, usually the s
 
 ## 4. Install globally
 
-    sudo make install
+    cd build; sudo make install
 
 ## 5. Installation to a different directory
 

--- a/docpages/02_build.md
+++ b/docpages/02_build.md
@@ -22,7 +22,7 @@ Replace the number after -j with a number suitable for your setup, usually the s
 
 ## 2. Install to /usr/local/include and /usr/local/lib
 
-    sudo make install
+    cd build; sudo make install
 
 ## 3. Installation to a different directory
 
@@ -160,7 +160,7 @@ Replace the number after -j with a number suitable for your setup, usually the s
 
 ## 4. Install globally
 
-    make install
+    cd build; make install
 
 ## 5. Installation to a different directory
 


### PR DESCRIPTION
right now, the docs show that you should run `make install` from the root dir, while you should do so from the `./build` dir. This PR fixes it.