### PR TITLE
fix for apple silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,11 @@ if(MINGW OR NOT WIN32)
 endif(MINGW OR NOT WIN32)
 
 if(APPLE)
-	set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
-
+	if(CMAKE_APPLE_SILICON_PROCESSOR)
+		set(OPENSSL_ROOT_DIR "/opt/homebrew/opt/openssl")
+	else()
+		set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+	endif()
 	find_package(OpenSSL REQUIRED)
 else()
 	if(MINGW OR NOT WIN32)

--- a/cmake/libdpp-config.cmake
+++ b/cmake/libdpp-config.cmake
@@ -8,7 +8,12 @@ include(${SELF_DIR}/libdpp.cmake)
 
 ## Set OpenSSl directory for macos. It is also in our main CMakeLists.txt, but this file is independent from that.
 if(APPLE)
-    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
+	if(CMAKE_APPLE_SILICON_PROCESSOR)
+		set(OPENSSL_ROOT_DIR "/opt/homebrew/opt/openssl")
+	else()
+		set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+	endif()
+	find_package(OpenSSL REQUIRED)
 endif()
 
 # Search for libdpp dependencies


### PR DESCRIPTION
On Apple Silicon macbooks, brew's root directory is `/opt/homebrew/` instead of `/usr/local/`, so the the code needs to be updated to fix that.