### PR TITLE
fix wrong http method

### DIFF
--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -121,7 +121,7 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 
 
 void cluster::message_get(snowflake message_id, snowflake channel_id, command_completion_event_t callback) {
-	rest_request<message>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id), m_put, "", callback);
+	rest_request<message>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id), m_get, "", callback);
 }
 
 


### PR DESCRIPTION
commit 5a83595da5ac753127b25917469f72cef46db071 broke this.

Only this one http method was broken. All the others should be correct. I manually looked through all of them.