### PR TITLE
Text inputs have max 100 char placeholders, not 150 chars

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -237,7 +237,7 @@ public:
 	 */
 	std::string url;
 
-	/** Placeholder text for select menus and text inputs (max 150 characters)
+	/** Placeholder text for select menus and text inputs (max 150 characters for select menus, 100 characters for text inputs)
 	 */
 	std::string placeholder;
 

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -317,9 +317,8 @@ select_option& select_option::set_animated(bool anim) {
 	return *this;
 }
 
-
 component& component::set_placeholder(const std::string &_placeholder) {
-	placeholder = dpp::utility::utf8substr(_placeholder, 0, 150);
+	placeholder = dpp::utility::utf8substr(_placeholder, 0, (this->type == cot_text) ? 100 : 150);
 	return *this;
 }
 


### PR DESCRIPTION
According to the Discord API, text inputs have [100](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure) characters as the palceholder limit, while select menus have [150](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure) characters as the placeholder limit.

This PR sets the limit for text inputs to 100 chars instead of 150.