### PR TITLE
add set_guild_id to channel

### DIFF
--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -300,6 +300,14 @@ public:
 	channel& set_position(const uint16_t position);
 
 	/**
+	 * @brief Set guild_id of this channel object
+	 *
+	 * @param guild_id Guild ID to set
+	 * @return Reference to self, so these method calls may be chained 
+	 */
+	channel& set_guild_id(const snowflake guild_id);
+
+	/**
 	 * @brief Set parent_id of this channel object
 	 *
 	 * @param parent_id Parent ID to set

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -87,6 +87,11 @@ channel& channel::set_topic(const std::string& topic) {
 	return *this;
 }
 
+channel& channel::set_guild_id(const snowflake guild_id) {
+	this->guild_id = guild_id;
+	return *this;
+}
+
 channel& channel::set_parent_id(const snowflake parent_id) {
 	this->parent_id = parent_id;
 	return *this;


### PR DESCRIPTION
You can't set the guild_id using functions, so this PR adds it.