### PR TITLE
break: Add parameter dpp::timer to timer_callback_t

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3421,7 +3421,7 @@ public:
 		/* Attach event */
 		listener_handle = ev(listener);
 		/* Create timer */
-		th = cl->start_timer([this]() {
+		th = cl->start_timer([this](dpp::timer timer_handle) {
 			/* Timer has finished, detach it from event.
 			 * Only allowed to tick once.
 			 */
@@ -3492,7 +3492,7 @@ public:
 				stored.push_back(*v);
 			}
 		};
-		tl = new dpp::timed_listener<event_router_t<T>, std::function<void(const T&)>>(cl, duration, event, f, [this]() {
+		tl = new dpp::timed_listener<event_router_t<T>, std::function<void(const T&)>>(cl, duration, event, f, [this](dpp::timer timer_handle) {
 			if (!triggered) {
 				triggered = true;
 				completed(stored);

--- a/include/dpp/timer.h
+++ b/include/dpp/timer.h
@@ -39,7 +39,7 @@ typedef size_t timer;
 /**
  * @brief The type for a timer callback
  */
-typedef std::function<void()> timer_callback_t;
+typedef std::function<void(timer)> timer_callback_t;
 
 /**
  * @brief Used internally to store state of active timers

--- a/src/dpp/cluster/timer.cpp
+++ b/src/dpp/cluster/timer.cpp
@@ -50,7 +50,7 @@ bool cluster::stop_timer(timer t) {
 		timer_t* tptr = i->second;
 		if (tptr->on_stop) {
 			/* If there is an on_stop event, call it */
-			tptr->on_stop();
+			tptr->on_stop(t);
 		}
 		timer_list.erase(i);
 		auto j = next_timer.find(tptr->next_tick);
@@ -98,7 +98,7 @@ void cluster::tick_timers() {
 	}
 	for (auto & t : scheduled) {
 		/* Call handler */
-		t->on_tick();
+		t->on_tick(t->handle);
 		/* Reschedule for next tick */
 		timer_reschedule(t);
 	}
@@ -106,8 +106,8 @@ void cluster::tick_timers() {
 
 oneshot_timer::oneshot_timer(class cluster* cl, uint64_t duration, timer_callback_t callback) : owner(cl) {
 	/* Create timer */
-	th = cl->start_timer([callback, this]() {
-		callback();
+	th = cl->start_timer([callback, this](dpp::timer timer_handle) {
+		callback(this->get_handle());
 		this->owner->stop_timer(this->th);
 	}, duration);
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -402,7 +402,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 
 		set_test("TIMERSTART", false);
 		uint32_t ticks = 0;
-		dpp::timer th = bot.start_timer([&]() {
+		dpp::timer th = bot.start_timer([&](dpp::timer timer_handle) {
 			if (ticks == 5) {
 				/* The simple test timer ticks every second.
 				 * If we get to 5 seconds, we know the timer is working.
@@ -419,7 +419,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 
 		set_test("ONESHOT", false);
 		bool once = false;
-		dpp::oneshot_timer ost(&bot, 5, [&]() {
+		dpp::oneshot_timer ost(&bot, 5, [&](dpp::timer timer_handle) {
 			if (!once) {
 				set_test("ONESHOT", true);
 			} else {


### PR DESCRIPTION
For when you don't want to manage a lifetime of object which holds `dpp::timer` handle such as `dpp::oneshot_timer` and still be able to stop the timer without convoluted pointers to it's ID. 