### PR TITLE
Add get, edit, and delete original response functions

### DIFF
--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -363,7 +363,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void edit_original_response(const message & m, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
-	 * @brief Delete original response message for this interaction
+	 * @brief Delete original response message for this interaction. This cannot be used on an ephemeral interaction response.
 	 *
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -351,7 +351,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void get_original_response(command_completion_event_t callback = utility::log_error()) const;
+	void get_original_response(command_completion_event_t callback) const;
 
 	/**
 	 * @brief Edit original response message for this interaction

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -346,31 +346,6 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void dialog(const interaction_modal_response& mr, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
-	 * @brief Get original response message for this interaction
-	 *
-	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	void get_original_response(command_completion_event_t callback) const;
-
-	/**
-	 * @brief Edit original response message for this interaction
-	 *
-	 * @param m Message object to send. Not all fields are supported by Discord.
-	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	void edit_original_response(const message & m, command_completion_event_t callback = utility::log_error()) const;
-
-	/**
-	 * @brief Delete original response message for this interaction. This cannot be used on an ephemeral interaction response.
-	 *
-	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	void delete_original_response(command_completion_event_t callback = utility::log_error()) const;
-
-	/**
 	 * @brief Edit the response for this interaction
 	 *
 	 * @param m Message object to send. Not all fields are supported by Discord.
@@ -396,6 +371,31 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void thinking(bool ephemeral = false, command_completion_event_t callback = utility::log_error()) const;
+
+	/**
+	 * @brief Get original response message for this interaction
+	 *
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void get_original_response(command_completion_event_t callback) const;
+
+	/**
+	 * @brief Edit original response message for this interaction
+	 *
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void edit_original_response(const message & m, command_completion_event_t callback = utility::log_error()) const;
+
+	/**
+	 * @brief Delete original response message for this interaction. This cannot be used on an ephemeral interaction response.
+	 *
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void delete_original_response(command_completion_event_t callback = utility::log_error()) const;
 
 	/**
 	 * @brief Get a command line parameter

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -351,7 +351,24 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void get_original_response(command_completion_event_t callback) const;
+	void get_original_response(command_completion_event_t callback = utility::log_error()) const;
+
+	/**
+	 * @brief Edit original response message for this interaction
+	 *
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void edit_original_response(const message & m, command_completion_event_t callback = utility::log_error()) const;
+
+	/**
+	 * @brief Delete original response message for this interaction
+	 *
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void delete_original_response(command_completion_event_t callback = utility::log_error()) const;
 
 	/**
 	 * @brief Edit the response for this interaction
@@ -370,14 +387,6 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void edit_response(const std::string & mt, command_completion_event_t callback = utility::log_error()) const;
-
-	/**
-	 * @brief Delete the original response for this interaction
-	 *
-	 * @param callback User function to execute when the api call completes.
-	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	void delete_original_response(command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Set the bot to 'thinking' state

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -138,6 +138,16 @@ void interaction_create_t::reply(const std::string & mt, command_completion_even
 	this->reply(ir_channel_message_with_source, dpp::message(this->command.channel_id, mt, mt_application_command), callback);
 }
 
+void interaction_create_t::edit_response(const message & m, command_completion_event_t callback) const
+{
+	from->creator->interaction_response_edit(this->command.token, m, callback);
+}
+
+void interaction_create_t::edit_response(const std::string & mt, command_completion_event_t callback) const
+{
+	this->edit_response(dpp::message(this->command.channel_id, mt, mt_application_command), callback);
+}
+
 void interaction_create_t::get_original_response(command_completion_event_t callback) const
 {
 	from->creator->post_rest(API_PATH "/webhooks", std::to_string(command.application_id), command.token + "/messages/@original", m_get, "", [this, callback](json &j, const http_request_completion_t& http) {
@@ -163,16 +173,6 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 			callback(confirmation_callback_t(from->creator, message().fill_from_json(&j), http));
 		}
 	});
-}
-
-void interaction_create_t::edit_response(const message & m, command_completion_event_t callback) const
-{
-	from->creator->interaction_response_edit(this->command.token, m, callback);
-}
-
-void interaction_create_t::edit_response(const std::string & mt, command_completion_event_t callback) const
-{
-	this->edit_response(dpp::message(this->command.channel_id, mt, mt_application_command), callback);
 }
 
 const command_value& interaction_create_t::get_parameter(const std::string& name) const

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -170,7 +170,7 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 {
 	from->creator->post_rest(API_PATH "/webhooks", std::to_string(command.application_id), command.token + "/messages/@original", m_delete, "", [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
-			callback(confirmation_callback_t(from->creator, message().fill_from_json(&j), http));
+			callback(confirmation_callback_t(from->creator, confirmation(), http));
 		}
 	});
 }

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -147,6 +147,24 @@ void interaction_create_t::get_original_response(command_completion_event_t call
 	});
 }
 
+void interaction_create_t::edit_original_response(const message & m, command_completion_event_t callback) const
+{
+	from->creator->post_rest_multipart(API_PATH "/webhooks", std::to_string(command.application_id), command.token + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
+		if (callback) {
+			callback(confirmation_callback_t(from->creator, message().fill_from_json(&j), http));
+		}
+	}, m.filename, m.filecontent);
+}
+
+void interaction_create_t::delete_original_response(command_completion_event_t callback) const
+{
+	from->creator->post_rest(API_PATH "/webhooks", std::to_string(command.application_id), command.token + "/messages/@original", m_delete, "", [this, callback](json &j, const http_request_completion_t& http) {
+		if (callback) {
+			callback(confirmation_callback_t(from->creator, message().fill_from_json(&j), http));
+		}
+	});
+}
+
 void interaction_create_t::edit_response(const message & m, command_completion_event_t callback) const
 {
 	from->creator->interaction_response_edit(this->command.token, m, callback);


### PR DESCRIPTION
Adds `get_original_response`, `edit_original_response`, and `delete_original_response`. These functions are documented [here](https://discord.com/developers/docs/interactions/receiving-and-responding#get-original-interaction-response).