### PR TITLE
add set_channel_id and set_guild_id to message

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1385,6 +1385,22 @@ struct DPP_EXPORT message : public managed {
 	 * @return message& reference to self
 	 */
 	message& set_content(const std::string &c);
+	
+	/**
+	 * @brief Set the channel id
+	 * 
+	 * @param _channel_id channel id
+	 * @return message& reference to self
+	 */
+	message& set_channel_id(snowflake _channel_id);
+
+	/**
+	 * @brief Set the channel id
+	 * 
+	 * @param _guild_id channel id
+	 * @return message& reference to self
+	 */
+	message& set_guild_id(snowflake _guild_id);
 };
 
 /** A group of messages */

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -496,6 +496,16 @@ message& message::set_content(const std::string &c)
 	return *this;
 }
 
+message& message::set_channel_id(snowflake _channel_id) {
+	channel_id = _channel_id;
+	return *this;
+}
+
+message& message::set_guild_id(snowflake _guild_id) {
+	guild_id = _guild_id;
+	return *this;
+}
+
 message::message(const std::string &_content, message_type t) : message() {
 	content = utility::utf8substr(_content, 0, 2000);
 	type = t;


### PR DESCRIPTION
`set_channel_id` and `set_guild_id` were missing in `dpp::message`