### PR TITLE
Allow an empty vector of commands for bulk command create

### DIFF
--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -24,9 +24,6 @@
 namespace dpp {
 
 void cluster::global_bulk_command_create(const std::vector<slashcommand> &commands, command_completion_event_t callback) {
-	if (commands.empty()) {
-		return;
-	}
 	json j = json::array();
 	for (auto & s : commands) {
 		j.push_back(json::parse(s.build_json(false)));

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -52,9 +52,6 @@ void cluster::global_commands_get(command_completion_event_t callback) {
 }
 
 void cluster::guild_bulk_command_create(const std::vector<slashcommand> &commands, snowflake guild_id, command_completion_event_t callback) {
-	if (commands.empty()) {
-		return;
-	}
 	json j = json::array();
 	for (auto & s : commands) {
 		j.push_back(json::parse(s.build_json(false)));

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -28,7 +28,7 @@ void cluster::global_bulk_command_create(const std::vector<slashcommand> &comman
 	for (auto & s : commands) {
 		j.push_back(json::parse(s.build_json(false)));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(), callback);
 }
 
 void cluster::global_command_create(const slashcommand &s, command_completion_event_t callback) {
@@ -56,7 +56,7 @@ void cluster::guild_bulk_command_create(const std::vector<slashcommand> &command
 	for (auto & s : commands) {
 		j.push_back(json::parse(s.build_json(false)));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(), callback);
 }
 
 void cluster::guild_commands_get_permissions(snowflake guild_id, command_completion_event_t callback) {


### PR DESCRIPTION
This endpoint can be used to delete all global/guild commands by passing an empty array.