### PR TITLE
remove unused line

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3561,7 +3561,6 @@ public:
 	 * @param event Event to attach to, e.g. cluster::on_message_create
 	 */
 	collector(class cluster* cl, uint64_t duration, event_router_t<T> & event) : owner(cl), triggered(false) {
-		using namespace std::placeholders;
 		std::function<void(const T&)> f = [this](const T& event) {
 			const C* v = filter(event);
 			if (v) {


### PR DESCRIPTION
remove unused `using namespace std::placeholders;`