### PR TITLE
Properly set deaf and mute properties on member

### DIFF
--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -199,7 +199,7 @@ std::string guild_member::build_json(bool with_id) const {
 			j["roles"].push_back(std::to_string(role));
 		}
 	}
-	j["mute"] = is_mute();
+	j["mute"] = is_muted();
 	j["deaf"] = is_deaf();
 	return j.dump();
 }

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -199,12 +199,8 @@ std::string guild_member::build_json(bool with_id) const {
 			j["roles"].push_back(std::to_string(role));
 		}
 	}
-	if (is_muted()) {
-		j["mute"] = true;
-	}
-	if (is_deaf()) {
-		j["deaf"] = true;
-	}
+	j["mute"] = is_mute();
+	j["deaf"] = is_deaf();
 	return j.dump();
 }
 


### PR DESCRIPTION
Before, it wouldn't get unset bc it wouldn’t be put into the JSON. This PR fixes it.