### PR TITLE
Added ability to pass reaction emoji to all reaction methods without url encoding it

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1788,10 +1788,11 @@ public:
 	 * @see https://discord.com/developers/docs/resources/channel#create-reaction
 	 * @param m Message to add a reaction to
 	 * @param reaction Reaction to add. Emojis should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_add_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_add_reaction(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete own reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1799,10 +1800,11 @@ public:
 	 * @see https://discord.com/developers/docs/resources/channel#delete-own-reaction
 	 * @param m Message to delete own reaction from
 	 * @param reaction Reaction to delete. The reaction should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_own_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_own_reaction(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a user's reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1811,10 +1813,11 @@ public:
 	 * @param m Message to delete a user's reaction from
 	 * @param user_id User ID who's reaction you want to remove
 	 * @param reaction Reaction to remove. Reactions should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get reactions on a message for a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1825,10 +1828,11 @@ public:
 	 * @param before Reactions before this ID should be retrieved if this is set to non-zero
 	 * @param after Reactions before this ID should be retrieved if this is set to non-zero
 	 * @param limit This number of reactions maximum should be returned
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
+	void message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, bool url_encode, command_completion_event_t callback);
 
 	/**
 	 * @brief Delete all reactions on a message
@@ -1846,10 +1850,11 @@ public:
 	 * @see https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
 	 * @param m Message to delete reactions from
 	 * @param reaction Reaction to delete, in the form emojiname:id or a unicode character
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction_emoji(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_reaction_emoji(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Add a reaction to a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1858,10 +1863,11 @@ public:
 	 * @param message_id Message to add reactions to
 	 * @param channel_id Channel to add reactions to
 	 * @param reaction Reaction to add. Emojis should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete own reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1870,10 +1876,11 @@ public:
 	 * @param message_id Message to delete reactions from
 	 * @param channel_id Channel to delete reactions from
 	 * @param reaction Reaction to delete. The reaction should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a user's reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1883,10 +1890,11 @@ public:
 	 * @param channel_id Channel to delete reactions from
 	 * @param user_id User ID who's reaction you want to remove
 	 * @param reaction Reaction to remove. Reactions should be in the form emojiname:id
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get reactions on a message for a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1898,10 +1906,11 @@ public:
 	 * @param before Reactions before this ID should be retrieved if this is set to non-zero
 	 * @param after Reactions before this ID should be retrieved if this is set to non-zero
 	 * @param limit This number of reactions maximum should be returned
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
+	void message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, bool url_encode, command_completion_event_t callback);
 
 	/**
 	 * @brief Delete all reactions on a message by id
@@ -1921,10 +1930,11 @@ public:
 	 * @param message_id Message to delete reactions from
 	 * @param channel_id Channel to delete reactions from
 	 * @param reaction Reaction to delete, in the form emojiname:id or a unicode character
+	 * @param url_encode Should the reaction be url-encoded. Useful for when unicode emoji cannot be used
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+	void message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a message from a channel. The callback function is called when the message has been edited

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -23,16 +23,17 @@
 
 namespace dpp {
 
-void cluster::message_add_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/@me", m_put, "", callback);
+void cluster::message_add_reaction(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
+	std::string _reaction = url_encode ? utility::url_encode(reaction) : reaction;
+
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + _reaction + "/@me", m_put, "", callback);
 }
 
-void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
-	message_add_reaction(m, reaction, callback);
+	message_add_reaction(m, reaction, url_encode, callback);
 }
-
 
 
 void cluster::message_create(const message &m, command_completion_event_t callback) {
@@ -75,39 +76,44 @@ void cluster::message_delete(snowflake message_id, snowflake channel_id, command
 }
 
 
-void cluster::message_delete_own_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/@me", m_delete, "", callback);
+void cluster::message_delete_own_reaction(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
+	std::string _reaction = url_encode ? utility::url_encode(reaction) : reaction;
+
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + _reaction + "/@me", m_delete, "", callback);
 }
 
-void cluster::message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
-	message_delete_own_reaction(m, reaction, callback);
+	message_delete_own_reaction(m, reaction, url_encode, callback);
 }
 
+void cluster::message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
+	std::string _reaction = url_encode ? utility::url_encode(reaction) : reaction;
 
-void cluster::message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/" + std::to_string(user_id), m_delete, "", callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + _reaction + "/" + std::to_string(user_id), m_delete, "", callback);
 }
 
-void cluster::message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
-	message_delete_reaction(m, user_id, reaction, callback);
+	message_delete_reaction(m, user_id, reaction, url_encode, callback);
 }
 
 
-void cluster::message_delete_reaction_emoji(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction), m_delete, "", callback);
+void cluster::message_delete_reaction_emoji(const struct message &m, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
+	std::string _reaction = url_encode ? utility::url_encode(reaction) : reaction;
+
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + _reaction, m_delete, "", callback);
 }
 
-void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, bool url_encode, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
-	message_delete_reaction_emoji(m, reaction, callback);
+	message_delete_reaction_emoji(m, reaction, url_encode, callback);
 }
 
 
@@ -125,20 +131,23 @@ void cluster::message_get(snowflake message_id, snowflake channel_id, command_co
 }
 
 
-void cluster::message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
+void cluster::message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, bool url_encode, command_completion_event_t callback) {
 	std::string parameters = utility::make_url_parameters({
 		{"before", before},
 		{"after", after},
 		{"limit", limit},
 	});
-	rest_request_list<user>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + parameters, m_get, "", callback);
+
+	std::string _reaction = url_encode ? utility::url_encode(reaction) : reaction;
+
+	rest_request_list<user>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + _reaction + parameters, m_get, "", callback);
 }
 
-void cluster::message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
+void cluster::message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, bool url_encode, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
-	message_get_reactions(m, reaction, before, after, limit, callback);
+	message_get_reactions(m, reaction, before, after, limit, url_encode, callback);
 }
 
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -235,7 +235,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 										set_test("MESSAGEDELETE", false);
 										dpp::message m = std::get<dpp::message>(callback.value);
 										set_test("REACTEVENT", false);
-										bot.message_add_reaction(m.id, TEST_TEXT_CHANNEL_ID, "😄", [](const dpp::confirmation_callback_t &callback) {
+										bot.message_add_reaction(m.id, TEST_TEXT_CHANNEL_ID, "😄", true, [](const dpp::confirmation_callback_t &callback) {
 											if (!callback.is_error()) {
 												set_test("REACT", true);
 											} else {


### PR DESCRIPTION
I had problems with passing emoji as unicode character to reaction methods (either discord API or D++ didn't like it), so I added the ability to disable url encoding to be able to pass raw value (for example the already url-encoded value for given emoji).

This is done via additional parameter before callback which is `bool url_encode`
I wanted to make it with default value `true` so you can omit it, but some reaction methods dont have default callback handler in order to force users to provide one, thus `url_encoded` needs to be provided in each call to these methods with either `true` or `false`