### PR TITLE
Fix double-free of SSL client through dpp::voiceconn when disconnecting from a voice channel.

### DIFF
--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -657,8 +657,6 @@ bool voiceconn::is_active() {
 
 voiceconn& voiceconn::disconnect() {
 	if (this->is_active()) {
-		voiceclient->terminating = true;
-		voiceclient->close();
 		delete voiceclient;
 		voiceclient = nullptr;
 	}


### PR DESCRIPTION
## Issue

I created a slash command that lets the user tell the bot to join a specified voice channel. As shown in [this example](https://dpp.dev/joinvc.html), the bot needs to disconnect from its current voice channel before joining another voice channel in the same guild. The app always crashes on my M1 Mac (though in theory it should not be limited to Macs) at disconnection time, using `dpp::discord_client::disconnect_voice` from within the `on_interaction_create` handler.

With the help of ASAN I was able to identify the crash as a double-free.

## Commit Message

```txt
At connection time, voiceconn creates a voice client, which handles
the closing of its underlying SSL client in the destructor. However,
at disconnection time, dpp::voiceconn also attempts to close the voice
client before deleting it. This ultimately leads to a double-free
as voice client's own destruction logic closes the SSL client again.

Since the destructor of voice client already handles the closing,
there is no need to manually close from voiceconn, thus fixes the
double-free and crash.
```

## Remarks

It is probably more correct to make `dpp::discord_client::terminating` an `std::atomic<bool>` since it is being read from the thread loop and written from other client threads, even though practically the readwrite of a `bool` field is very likely atomic. 

Meanwhile, I also found this API, `dpp::voiceconn::disconnect`, that crashes as well before this change, and doesn't crash after. However, that API doesn't seem to correctly disconnect the bot from the voice channel, whereas `dpp::discord_client::disconnect_voice` does. Not sure if it is expected, but I can unblock myself with the latter API now.