### PR TITLE
Remove extraneous quotes around guild member search query.

### DIFF
--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -112,7 +112,7 @@ void cluster::guild_member_move(const snowflake channel_id, const snowflake guil
 
 
 void cluster::guild_search_members(snowflake guild_id, const std::string& query, uint16_t limit, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/guilds", std::to_string(guild_id), fmt::format("members/search?query=\"{}\"&limit={}", utility::url_encode(query), limit), m_get, "", [this, callback, guild_id] (json &j, const http_request_completion_t& http) {
+	this->post_rest(API_PATH "/guilds", std::to_string(guild_id), fmt::format("members/search?query={}&limit={}", utility::url_encode(query), limit), m_get, "", [this, callback, guild_id] (json &j, const http_request_completion_t& http) {
 		guild_member_map guild_members;
 		confirmation_callback_t e(this, confirmation(), http);
 		if (!e.is_error()) {


### PR DESCRIPTION
## Issue

Was using this API to fetch the guild nickname of the speaking users in a voice channel. Found that this API always returns an empty map. Removing them solved my issue.

## Commit Message

```txt
The quotes in the query becomes literal, which causes Discord to
look for quotes in the username and nickname. Without this change,
the resultant member map is empty unless the nickname really
contains quotes.
```