### PR TITLE
Switch synchronized calls from a condition variable to a promise.

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -341,7 +341,7 @@ struct DPP_EXPORT interaction_response : public json_interface<interaction_respo
 	 *
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Add a command option choice
@@ -445,7 +445,7 @@ public:
 	 *
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Destroy the interaction modal response object
@@ -993,7 +993,7 @@ public:
 	 * @param with_id True if to include the ID in the JSON
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 };
 
 /**

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -224,7 +224,7 @@ public:
 	 * @param with_id include the ID in the json
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Set name of this channel object
@@ -540,7 +540,7 @@ public:
 	 * @param with_id include the ID in the json
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 };
 

--- a/include/dpp/dtemplate.h
+++ b/include/dpp/dtemplate.h
@@ -92,7 +92,7 @@ public:
 	 * @param with_id Add ID to output
 	 * @return std::string JSON content 
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 };
 

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -100,7 +100,7 @@ public:
 	 * @param with_id include the id in the JSON
 	 * @return std::string json data
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Emoji requires colons

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -531,7 +531,7 @@ public:
 	 * @param with_id True if an ID is to be included in the JSON
 	 * @return JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Get the base permissions for a member on this guild,
@@ -829,7 +829,7 @@ public:
 	 * @param with_id Add ID to output
 	 * @return std::string guild widget stringified json
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 };
 
 /**

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -118,7 +118,7 @@ public:
 	 * @param with_id Add ID to output
 	 * @return JSON string of the object
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/** True if emoticons are enabled */
 	bool emoticons_enabled() const;

--- a/include/dpp/invite.h
+++ b/include/dpp/invite.h
@@ -100,7 +100,7 @@ public:
 	 * @param with_id Include ID in JSON
 	 * @return The JSON text of the invite
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 };
 

--- a/include/dpp/json_interface.h
+++ b/include/dpp/json_interface.h
@@ -33,6 +33,11 @@ namespace dpp {
 	 * @tparam T Type of class that implements the interface
 	 */
 	template<typename T> struct DPP_EXPORT json_interface {
+	protected:
+		/* Must not destruct through pointer to json_interface. */
+		~json_interface() = default;
+
+	public:
 		/**
 		 * @brief Convert object from nlohmann::json
 		 * 
@@ -49,7 +54,7 @@ namespace dpp {
 		 * @param with_id Include the ID in the JSON
 		 * @return std::string JSON string version of object
 		 */
-		virtual std::string build_json(bool with_id = false) const {
+		std::string build_json(bool with_id = false) const {
 			throw dpp::logic_exception("JSON interface doesn't implement build_json");
 		}
 	};

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -873,7 +873,7 @@ struct DPP_EXPORT sticker : public managed, public json_interface<sticker> {
 	 * @param with_id True if the ID is to be set in the JSON structure
 	 * @return The JSON text of the invite
 	 */
-	virtual std::string build_json(bool with_id = true) const;
+	std::string build_json(bool with_id = true) const;
 
 	/**
 	 * @brief Get the sticker url
@@ -935,7 +935,7 @@ struct DPP_EXPORT sticker_pack : public managed, public json_interface<sticker_p
 	 * @param with_id True if the ID is to be set in the JSON structure
 	 * @return The JSON text of the invite
 	 */
-	virtual std::string build_json(bool with_id = true) const;
+	std::string build_json(bool with_id = true) const;
 
 };
 

--- a/include/dpp/presence.h
+++ b/include/dpp/presence.h
@@ -355,7 +355,7 @@ public:
 	 * @param with_id Add ID to output
 	 * @return The JSON text of the presence
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/** The users status on desktop
 	 * @return The user's status on desktop

--- a/include/dpp/prune.h
+++ b/include/dpp/prune.h
@@ -51,7 +51,7 @@ struct DPP_EXPORT prune : public json_interface<prune> {
 	 * @param with_prune_count True if the prune count boolean is to be set in the built JSON
 	 * @return The JSON text of the prune object
 	 */
-	virtual std::string build_json(bool with_prune_count = false) const;
+	std::string build_json(bool with_prune_count = false) const;
 
 };
 

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -217,7 +217,7 @@ public:
 	 * @param with_id true if the ID is to be included in the json text
 	 * @return The json of the role
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Get the mention/ping for the role

--- a/include/dpp/scheduled_event.h
+++ b/include/dpp/scheduled_event.h
@@ -207,7 +207,7 @@ struct DPP_EXPORT scheduled_event : public managed, public json_interface<schedu
 	 *
 	 * @return std::string Dumped json of this object
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 };
 
 /**

--- a/include/dpp/stage_instance.h
+++ b/include/dpp/stage_instance.h
@@ -77,7 +77,7 @@ struct DPP_EXPORT stage_instance : public managed, public json_interface<stage_i
 	 * @param with_id include ID
 	 * @return std::string Dumped json of this object
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 };
 
 /** A group of stage instances */

--- a/include/dpp/sync.h
+++ b/include/dpp/sync.h
@@ -21,7 +21,9 @@
 #pragma once
 #include <dpp/export.h>
 #include <dpp/snowflake.h>
-#include <chrono>
+#include <future>
+#include <utility>
+#include <exception>
 
 namespace dpp {
 
@@ -50,50 +52,29 @@ namespace dpp {
      * @throw dpp::rest_exception On failure of the method call, an exception is thrown
      */
     template<typename T, class F, class... Ts> T sync(class cluster* c, F func, Ts&&... args) {
-        bool except = false;
-        std::string message;
-
-        std::mutex sync_mutex;
-        std::unique_lock<std::mutex> sync_guard(sync_mutex);
-        std::condition_variable sync;
-
-        /* Passing _t into the lambda is SAFE here, as this function is
-         * guaranteed to stick around until execution of the REST call is finished.
-         */
-        T _t = {};
+        std::promise<T> _p;
+        std::future<T> _f = _p.get_future();
         /* (obj ->* func) is the obscure syntax for calling a method pointer on an object instance */
-        (c ->* func)(std::forward<Ts>(args)..., [&sync, &except, &message, &_t](const auto& cc) {
-            if (cc.is_error()) {
-                message = cc.get_error().message;
-                except = true;
-            } else {
-                try {
-                    _t = std::get<T>(cc.value);
+        (c ->* func)(std::forward<Ts>(args)..., [&_p](const auto& cc) {
+            try {
+                if (cc.is_error()) {
+                    throw dpp::rest_exception(cc.get_error().message);
+                } else {
+                    try {
+                        _p.set_value(std::get<T>(cc.value));
+                    } catch (const std::exception& e) {
+                        throw dpp::rest_exception(e.what());
+                    }
                 }
-                catch (const std::exception& e) {
-                    /* As we are inside a separate thread here, we can't just
-                     * let this exception loose into the stack. It'll be thrown
-                     * in a place where the user has no means to catch it. Instead
-                     * record the failure, and re-throw later from the calling
-                     * thread.
-                     */
-                    message = e.what();
-                    except = true;
-                }
+            } catch (const dpp::rest_exception&) {
+                _p.set_exception(std::current_exception());
             }
-
-            // Resume calling thread.
-            sync.notify_all();
         });
 
-        // Blocking calling thread until rest request is completed.
-        sync.wait(sync_guard);
-
-        if (except) {
-            /* Re-throw any exceptions encountered on the other thread */
-            throw dpp::rest_exception(message);
-        }
-        return _t;
+        /* Blocking calling thread until rest request is completed. 
+         * Exceptions encountered on the other thread are re-thrown.
+         */
+        return _f.get();
     }
 
 };

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -117,7 +117,7 @@ public:
 	 * @param with_id include ID in output
 	 * @return std::string JSON output
 	 */
-	virtual std::string build_json(bool with_id = true) const;
+	std::string build_json(bool with_id = true) const;
 
 	/**
 	 * @brief Get the avatar url of the user object
@@ -299,7 +299,7 @@ public:
 	 * @param with_id include ID in output
 	 * @return std::string JSON output
 	 */
-	virtual std::string build_json(bool with_id = true) const;
+	std::string build_json(bool with_id = true) const;
 
 	/**
 	 * @brief Construct a new user identified object

--- a/include/dpp/voicestate.h
+++ b/include/dpp/voicestate.h
@@ -79,7 +79,7 @@ public:
 	 * @param with_id Add ID to output
 	 * @return std::string JSON string
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/// Return true if user is deafened
 	bool is_deaf() const;

--- a/include/dpp/webhook.h
+++ b/include/dpp/webhook.h
@@ -91,7 +91,7 @@ public:
 	 * @param with_id Include the ID of the webhook in the json
 	 * @return std::string JSON encoded object
 	 */
-	virtual std::string build_json(bool with_id = false) const;
+	std::string build_json(bool with_id = false) const;
 
 	/**
 	 * @brief Base64 encode image data and allocate it to image_data


### PR DESCRIPTION
## Issue

The synced functions sometimes indefinitely block. All other threads are waiting for work to do, so it appears the condition variable is waited after the rest request is completed. The lambda probably needed to lock the mutex before signaling to ensure the calling thread started the wait.

Anyway, thought that promises and futures are cleaner so switched to using those. Calling thread is no longer indefinitely blocked.

Also refactored `json_interface` since I encountered some warnings and thought those are valid things to fix.

## Commit Messages

```txt
Switch synchronized calls from a condition variable to a promise.

Occasionally the synchronized call blocks indefinitely: the request
has been fulfilled before the calling thread starts waiting. This
can in theory happen in certain thread scheduling order. Switched to
using promises and delegated all the management of locking to the
implementation of std::promise.
```

```txt
Fix compiler warnings about virtual destructors.

This change fixes the valid warning -Wdelete-non-abstract-non-virtual-dtor
from clang.

json_interface<T> contains a virtual method yet has no virtual destructors.
Some of its subclasses do not inherit from other classes, so these
subclasses have no virtual destructors, which can in theory lead to
undefined behavior when those objects are destructed through the pointer
to their base class (json_interface<T>).

In practice, json_interface is a CRTP. The subclasses are never referenced
through the base class, so virtual methods aren't necessary; only method
overloading is needed. This change switches json_interface<T>::build_json
from virtual to nonvirtual. The subclass declares an overload under the
same name.

The destructor of json_interface is also explicitly marked protected now,
since subclasses should never be destructed through a pointer to
json_interface.
```

## Remarks

`dpp::guild_widget` in `guild.h` does not inherit from `json_interface<guild_widget>` yet has implemented the `build_json` method. Suggest taking a look at whether this is expected.