### PR TITLE
improved context menu example & updated set_name

### DIFF
--- a/docpages/03_example_programs.md
+++ b/docpages/03_example_programs.md
@@ -1650,8 +1650,8 @@ int main()
             /* Register the command */
             bot.guild_command_create(
 		dpp::slashcommand()
+					.set_type(dpp::ctxm_user)
                     .set_name("High Five")
-                    .set_type(dpp::ctxm_user)
                     .set_application_id(bot.me.id),
                 857692897221033129 // you need to put your guild-id in here
             );

--- a/docpages/03_example_programs.md
+++ b/docpages/03_example_programs.md
@@ -1660,9 +1660,8 @@ int main()
 
     /* Use the on_interaction_create event to look for application commands */
     bot.on_user_context_menu([&](const dpp::user_context_menu_t &event) {
-         dpp::command_interaction cmd_data = event.command.get_command_interaction();
          /* check if the context menu name is High Five */
-         if (cmd_data.name == "High Five") {
+         if (event.command.get_command_name() == "High Five") {
              dpp::user user = event.get_user(); // the user who the command has been issued on
              dpp::user author = event.command.usr; // the user who clicked on the context menu
              event.reply(author.get_mention() + " slapped " + user.get_mention());

--- a/docpages/03_example_programs.md
+++ b/docpages/03_example_programs.md
@@ -1658,7 +1658,7 @@ int main()
         }
     });
 
-    /* Use the on_interaction_create event to look for application commands */
+    /* Use the on_user_context_menu event to look for user context menu actions */
     bot.on_user_context_menu([&](const dpp::user_context_menu_t &event) {
          /* check if the context menu name is High Five */
          if (event.command.get_command_name() == "High Five") {

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -930,6 +930,7 @@ public:
 	 * @brief Set the type of the slash command (only for context menu entries)
 	 * 
 	 * @param _type Type of context menu entry this command represents
+	 * @note If the type is dpp::slashcommand_contextmenu_type::ctxm_chat_input, the command name will be set to lowercase.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
 	slashcommand& set_type(slashcommand_contextmenu_type _type);
@@ -940,6 +941,7 @@ public:
 	 * @param n name of command
 	 * @note The maximum length of a command name is 32 UTF-8 codepoints.
 	 * If your command name is longer than this, it will be truncated.
+	 * The command name will be set to lowercase on the default dpp::slashcommand_contextmenu_type::ctxm_chat_input type.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
 	slashcommand& set_name(const std::string &n);

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -249,7 +249,7 @@ slashcommand& slashcommand::set_type(slashcommand_contextmenu_type t) {
 }
 
 slashcommand& slashcommand::set_name(const std::string &n) {
-	name = lowercase(utility::utf8substr(n, 0, 32));
+	name = utility::utf8substr(n, 0, 32);
 	return *this;
 }
 

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -245,11 +245,18 @@ std::string slashcommand::build_json(bool with_id) const {
 
 slashcommand& slashcommand::set_type(slashcommand_contextmenu_type t) {
 	type = t;
+	if (type == ctxm_chat_input) {
+		name = lowercase(name);
+	}
 	return *this;
 }
 
 slashcommand& slashcommand::set_name(const std::string &n) {
-	name = utility::utf8substr(n, 0, 32);
+	if (type == ctxm_chat_input) {
+		name = lowercase(utility::utf8substr(n, 0, 32));
+	} else {
+		name = utility::utf8substr(n, 0, 32);
+	}
 	return *this;
 }
 


### PR DESCRIPTION
- `set_name` sets the command name to lowercase only when the type is ctxm_chat_input

fix #373 