### PR TITLE
Improve voice receive handling.

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -56,6 +56,9 @@
 #include <thread>
 #include <deque>
 #include <mutex>
+#include <memory>
+#include <future>
+#include <functional>
 #include <chrono>
 
 using json = nlohmann::json;
@@ -152,10 +155,109 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	std::vector<voice_out_packet> outbuf;
 
 	/**
-	 * @brief Input buffer. Each string is a received UDP
-	 * packet. These will usually be RTP.
+	 * @brief Data type of RTP packet sequence number field.
 	 */
-	std::vector<std::string> inbuf;
+	using rtp_seq_t = uint16_t;
+	using rtp_timestamp_t = uint32_t;
+
+	/**
+	 * @brief Keeps track of the voice payload to deliver to voice handlers.
+	 */
+	struct voice_payload {
+		/**
+		 * @brief The sequence number of the RTP packet that generated this
+		 * voice payload.
+		 */
+		rtp_seq_t seq;
+		/**
+		 * @brief The timestamp of the RTP packet that generated this voice
+		 * payload.
+		 *
+		 * The timestamp is used to detect the order around where sequence
+		 * number wraps around.
+		 */
+		rtp_timestamp_t timestamp;
+		/**
+		 * @brief The event payload that voice handlers receive.
+		 */
+		std::unique_ptr<voice_receive_t> vr;
+		
+		/**
+		 * @brief For priority_queue sorting.
+		 * @return true if "this" has lower priority that "other",
+		 *         i.e. appears later in the queue; false otherwise.
+		 */
+		bool operator<(const voice_payload& other) const;
+	};
+
+	struct voice_payload_parking_lot {
+		/**
+		 * @brief The range of RTP packet sequence number and timestamp in the lot.
+		 *
+		 * The minimum is used to drop packets that arrive too late. Packets
+		 * less than the minimum have been delivered to voice handlers and
+		 * there is no going back. Unfortunately we just have to drop them.
+		 *
+		 * The maximum is used, at flush time, to calculate the minimum for
+		 * the next batch. The maximum is also updated every time we receive an
+		 * RTP packet with a larger value.
+		 */
+		struct seq_range_t {
+			rtp_seq_t min_seq, max_seq;
+			rtp_timestamp_t min_timestamp, max_timestamp;
+		} range;
+		/**
+		 * @brief The queue of parked voice payloads.
+		 * 
+		 * We group payloads and deliver them to handlers periodically as the
+		 * handling of out-of-order RTP packets. Payloads in between flushes
+		 * are parked and sorted in this queue.
+		 */
+		std::priority_queue<voice_payload> parked_payloads;
+#ifdef HAVE_VOICE
+		/**
+		 * @brief libopus decoder
+		 *
+		 * Shared with the voice courier thread that does the decoding.
+		 * This is not protected by a mutex because only the courier thread
+		 * uses the decoder.
+		 */
+		std::shared_ptr<OpusDecoder> decoder;
+#endif
+	};
+	/**
+	 * @brief Thread used to deliver incoming voice data to handlers.
+	 */
+	std::thread voice_courier;
+	/**
+	 * @brief Shared state between this voice client and the courier thread.
+	 */
+	struct courier_shared_state_t {
+		/**
+		 * @brief Protects all following members.
+		 */
+		std::mutex mtx;
+		/**
+		 * @brief Signaled when there is a new payload to deliver or terminating state has changed.
+		 */
+		std::condition_variable signal_iteration;
+		/**
+		 * @brief Voice buffers to be reported to handler, grouped by speaker.
+		 *
+		 * Buffers are parked here and flushed every 500ms.
+		 */
+		std::map<snowflake, voice_payload_parking_lot> parked_voice_payloads;
+		/**
+		 * @brief Used to signal termination.
+		 *
+		 * @note Pending payloads are delivered first before termination.
+		 */
+		bool terminating = false;
+	} voice_courier_shared_state;
+	/**
+	 * @brief The run loop of the voice courier thread.
+	 */
+	static void voice_courier_loop(discord_voice_client&, courier_shared_state_t&);
 
 	/**
 	 * @brief If true, audio packet sending is paused
@@ -169,11 +271,6 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	OpusEncoder* encoder;
 
 	/**
-	 * @brief libopus decoder
-	 */
-	OpusDecoder* decoder;
-
-	/**
 	 * @brief libopus repacketizer
 	 * (merges frames into one packet)
 	 */
@@ -183,11 +280,6 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @brief libopus encoder
 	 */
 	void* encoder;
-
-	/**
-	 * @brief libopus decoder
-	 */
-	void* decoder;
 
 	/**
 	 * @brief libopus repacketizer
@@ -381,11 +473,6 @@ public:
 	 * @brief True when the thread is shutting down
 	 */
 	bool terminating;
-
-	/**
-	 * @brief Decode received voice packets to PCM
-	 */
-	bool decode_voice_recv;
 
 	/**
 	 * @brief Heartbeat interval for sending heartbeat keepalive

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -43,6 +43,7 @@
 #include <variant>
 #include <exception>
 #include <algorithm>
+#include <string>
 
 namespace dpp {
 
@@ -1598,18 +1599,24 @@ struct DPP_EXPORT voice_receive_t : public event_dispatch_t {
 	 * @brief Constructor
 	 * @param client The shard the event originated on.
 	 * WILL ALWAYS be NULL.
-	 * @param raw Raw event text as JSON
+	 * @param raw Raw event text as UDP packet.
 	 */
 	voice_receive_t(class discord_client* client, const std::string &raw);
 	class discord_voice_client* voice_client;
 	/**
-	 * @brief Audio data, encoded as 48kHz stereo PCM or Opus
+	 * @brief Audio data, encoded as 48kHz stereo PCM or Opus,
+	 * @deprecated Please switch to using audio_data.
 	 */
-	uint8_t* audio;
+	uint8_t* audio = nullptr;
 	/**
 	 * @brief Size of audio buffer
+	 * @deprecated Please switch to using audio_data.
 	 */
-	size_t audio_size;
+	size_t audio_size = 0;
+	/**
+	 * @brief Audio data, encoded as 48kHz stereo PCM or Opus,
+	 */
+	std::basic_string<uint8_t> audio_data;
 	/**
 	 * @brief User ID of speaker (zero if unknown)
 	 */


### PR DESCRIPTION
## Issue

When there are multiple speakers, the voice data received from `on_voice_receive` callback was wrong. After lots of trial and error, it turns out Opus decoders are stateful, so using the same decoder to decode for all speakers jams the audio data together in a weird way. The main fix is to use a unique decoder for each speaker, but this change also contains a number of refactors and fixes as a result of the trial and error.

## Commit Message

```txt
1. Allocate an Opus decoder for each speaker. Opus decoders are stateful,
   so when there are multiple speakers, using one decoder will mess up the
   voice data of every speaker.

2. Add handling for out-of-order UDP packets. UDP packets can arrive
   out-of-order so it is up to the application to handle such cases. We
   now does reordering for packets and flush them to voice handlers every
   100ms.

3. Add handling for lost UDP packets. Opus decoder allows passing nullptr
   to indicate a packet loss. The decoder can insert some correction, e.g.
   fade out, in place of an abrupt stop that creates popping sounds. When we
   detect a packet loss, we let Opus know and handle that for us.

4. Improve the parsing of RTP packets, especially around the so-called
   "undocumented Discord byte", which is actually misinterpretation of
   the header length property. Other changes in the parsing are mostly
   refactoring.
```