### PR TITLE
Fix potential hang in discord_voice_client destructor.

### DIFF
--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -283,6 +283,7 @@ discord_voice_client::~discord_voice_client()
 			std::lock_guard lk(voice_courier_shared_state.mtx);
 			voice_courier_shared_state.terminating = true;
 		}
+		voice_courier_shared_state.signal_iteration.notify_one();
 		voice_courier.join();
 	}
 #endif


### PR DESCRIPTION
Sorry for not noticing until after the release 👀.

## Commit Message

```txt
If the voice courier thread waits because of no voice data, it can
hang forever in the destructor because the thread is never signaled
to unblock (unless woken up by a spurious wake). This change adds
the signaling in the destructor to unblock a waiting courier thread.
```