### PR TITLE
Depend `discord_voice_client::voice_payload` priority only on timestamps.

### DIFF
--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -68,7 +68,7 @@ struct rtp_header {
 bool discord_voice_client::sodium_initialised = false;
 
 bool discord_voice_client::voice_payload::operator<(const voice_payload& other) const {
-	return seq > other.seq || timestamp > other.timestamp;
+	return timestamp > other.timestamp;
 }
 
 #ifdef HAVE_VOICE


### PR DESCRIPTION
```txt
Previously, the condition depended also on the sequence number.
This was supposed to handle the wrap around case. In reality,
it depends on what LHS and RHS are, and flipping the LHS and RHS
breaks the ordering.

Recall that LHS has lower priority, i.e. should appear behind, RHS if

     LHS.seq > RHS.seq || LHS.timestamp > RHS.timestamp

The timestamp is only taken into account if LHS.seq <= RHS.seq.

For example, in case of LHS.seq = 1 < 65530 = RHS.seq, the
timestamp will be taken into account, which could place
LHS (1) after RHS (65530). However, if we flip the sides, so that
LHS.seq = 65530 and RHS.seq = 1, then LHS (65530) is immediately
placed after RHS (1), without considering the timestamp, which is
incorrect behavior.

The consequence is that the ordering in the payload queue is
incorrect. For instance, seq=65530 can appear after seq=65531,
and the loop has to run through all sequence numbers from 65531,
to 65535, to 1, back to 65530. As we approach the wrap-around
case, we tend to hang long in the voice courier thread.
```