### PR TITLE
removed deprecated exclamation mark from guild_member::get_mention

### DIFF
--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -98,7 +98,7 @@ guild_member::guild_member() :
 }
 
 std::string guild_member::get_mention() const {
-	return "<@!" + std::to_string(user_id) + ">";
+	return "<@" + std::to_string(user_id) + ">";
 }
 
 guild_member& guild_member::set_nickname(const std::string& nick) {


### PR DESCRIPTION
> \* User mentions with an exclamation mark are deprecated and should be handled like any other user mention.

https://discord.com/developers/docs/reference#message-formatting-formats