### PR TITLE
implemented channel::get_icon_url & small doc improvements of slashcommand.h and some intent fixes

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -814,8 +814,7 @@ public:
 	snowflake application_id;
 
 	/**
-	 * @brief Context menu type, defaults to none
-	 * 
+	 * @brief Context menu type, defaults to dpp::ctxm_chat_input
 	 */
 	slashcommand_contextmenu_type type;
 
@@ -843,6 +842,7 @@ public:
 
 	/**
 	 * @brief command permissions
+	 * @deprecated Discord discourage use of this value and instead you should use default_member_permissions.
 	 */
 	std::vector<command_permission> permissions;
 
@@ -864,6 +864,7 @@ public:
 	/**
 	 * @brief The default permissions of this command on a guild.
 	 * D++ defaults this to p_use_application_commands.
+	 * @note You can set it to 0 to disable the command for everyone except admins by default
 	 */
 	uint64_t default_member_permissions;
 
@@ -916,6 +917,7 @@ public:
 	 * this is a permission bitmask.
 	 * 
 	 * @param defaults default permissions to set
+	 * @note You can set it to 0 to disable the command for everyone except admins by default
 	 * @return slashcommand& reference to self
 	 */
 	slashcommand& set_default_permissions(uint64_t defaults);
@@ -932,7 +934,7 @@ public:
 	 * @brief Set the type of the slash command (only for context menu entries)
 	 * 
 	 * @param _type Type of context menu entry this command represents
-	 * @note If the type is dpp::slashcommand_contextmenu_type::ctxm_chat_input, the command name will be set to lowercase.
+	 * @note If the type is dpp::ctxm_chat_input, the command name will be set to lowercase.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
 	slashcommand& set_type(slashcommand_contextmenu_type _type);
@@ -943,7 +945,7 @@ public:
 	 * @param n name of command
 	 * @note The maximum length of a command name is 32 UTF-8 codepoints.
 	 * If your command name is longer than this, it will be truncated.
-	 * The command name will be set to lowercase on the default dpp::slashcommand_contextmenu_type::ctxm_chat_input type.
+	 * The command name will be set to lowercase when the type is the default dpp::ctxm_chat_input.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
 	slashcommand& set_name(const std::string &n);
@@ -971,6 +973,7 @@ public:
 	 *
 	 * @param p permission to add
 	 * @return slashcommand& reference to self for chaining of calls
+	 * @deprecated Discord discourage use of this value and instead you should use default_member_permissions.
 	 */
 	slashcommand& add_permission(const command_permission& p);
 
@@ -980,6 +983,7 @@ public:
 	 *        dpp::guild_command_edit_permissions
 	 *
 	 * @return slashcommand& reference to self for chaining of calls
+	 * @deprecated Discord discourage use of this value and instead you should use default_member_permissions.
 	 */
 	slashcommand& disable_default_permissions();
 

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -26,6 +26,7 @@
 #include <dpp/discordevents.h>
 #include <dpp/stringops.h>
 #include <dpp/nlohmann/json.hpp>
+#include <dpp/fmt-minimal.h>
 
 using json = nlohmann::json;
 
@@ -422,8 +423,12 @@ std::string channel::get_icon_url(uint16_t size) const {
 	 * At some point in the future this URL *will* change!
 	 */
 	if (!this->icon.to_string().empty()) {
-		// TODO implement this, endpoint for that isn't finished yet https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints
-		return std::string();
+		return fmt::format("{}/channel-icons/{}/{}.png{}",
+						   utility::cdn_host,
+						   this->id,
+						   this->icon.to_string(),
+						   utility::avatar_size(size)
+		);
 	} else {
 		return std::string();
 	}

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -357,16 +357,16 @@ command_option &command_option::fill_from_json(nlohmann::json *j) {
             }
         }
 
-	if (j->contains("name_localizations")) {
-		for(auto loc = (*j)["name_localizations"].begin(); loc != (*j)["name_localizations"].end(); ++loc) {
-			o.name_localizations[loc.key()] = loc.value();
+		if (j->contains("name_localizations")) {
+			for(auto loc = (*j)["name_localizations"].begin(); loc != (*j)["name_localizations"].end(); ++loc) {
+				o.name_localizations[loc.key()] = loc.value();
+			}
 		}
-	}
-	if (j->contains("description_localizations")) {
-		for(auto loc = (*j)["description_localizations"].begin(); loc != (*j)["description_localizations"].end(); ++loc) {
-			o.description_localizations[loc.key()] = loc.value();
+		if (j->contains("description_localizations")) {
+			for(auto loc = (*j)["description_localizations"].begin(); loc != (*j)["description_localizations"].end(); ++loc) {
+				o.description_localizations[loc.key()] = loc.value();
+			}
 		}
-	}
 
         if (j->contains("options") && i > 0) {
             i--; // prevent infinite recursion call with a counter


### PR DESCRIPTION
> You can set it to 0 to disable the command for everyone except admins by default

source https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure

<hr>

* implemented channel::get_icon_url although the endpoint is not documented in the docs. but i found the url with the browser debugger :D
![2022-05-25_23-49](https://user-images.githubusercontent.com/44061123/170374229-d2ee8b54-7a6e-4640-8daf-e4edf296d115.png)

