### PR TITLE
permissions rework

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -468,7 +468,7 @@ struct DPP_EXPORT command_resolved {
 	/**
 	 * @brief Resolved total guild member permissions in the channel, including overwrites
 	 */
-	std::map<dpp::snowflake, uint64_t> member_permissions;
+	std::map<dpp::snowflake, permission> member_permissions;
 	/**
 	 * @brief Resolved roles
 	 */
@@ -866,7 +866,7 @@ public:
 	 * D++ defaults this to p_use_application_commands.
 	 * @note You can set it to 0 to disable the command for everyone except admins by default
 	 */
-	uint64_t default_member_permissions;
+	permission default_member_permissions;
 
 	/**
 	 * @brief True if this command should be allowed in a DM
@@ -918,6 +918,13 @@ public:
 	 * 
 	 * @param defaults default permissions to set
 	 * @note You can set it to 0 to disable the command for everyone except admins by default
+	 *
+	 * **Example:**
+	 *
+	 * ```cpp
+	 * command.set_default_permissions(dpp::p_manage_roles | dpp::p_manage_nicknames | dpp::p_manage_guild);
+	 * ```
+	 *
 	 * @return slashcommand& reference to self
 	 */
 	slashcommand& set_default_permissions(uint64_t defaults);

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -25,6 +25,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/user.h>
+#include <dpp/permissions.h>
 #include <dpp/nlohmann/json_fwd.hpp>
 #include <dpp/json_interface.h>
 
@@ -66,7 +67,7 @@ enum application_flags : uint32_t {
  * @brief Represents the settings for the bot/application's in-app authorization link
  */
 struct DPP_EXPORT application_install_params {
-	uint64_t permissions;	//!< A bitmask of dpp::permissions to request for the bot role
+	permission permissions;	//!< A bitmask of dpp::permissions to request for the bot role
 	std::vector<std::string> scopes;	//!< The [scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes) as strings to add the application to the server with
 };
 

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -66,7 +66,7 @@ enum application_flags : uint32_t {
  * @brief Represents the settings for the bot/application's in-app authorization link
  */
 struct DPP_EXPORT application_install_params {
-	uint64_t permissions;	//!< The dpp::permissions to request for the bot role
+	uint64_t permissions;	//!< A bitmask of dpp::permissions to request for the bot role
 	std::vector<std::string> scopes;	//!< The [scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes) as strings to add the application to the server with
 };
 

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -66,7 +66,7 @@ enum application_flags : uint32_t {
  * @brief Represents the settings for the bot/application's in-app authorization link
  */
 struct DPP_EXPORT application_install_params {
-	uint64_t permissions;	//!< The dpp::role_permissions to request for the bot role
+	uint64_t permissions;	//!< The dpp::permissions to request for the bot role
 	std::vector<std::string> scopes;	//!< The [scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes) as strings to add the application to the server with
 };
 

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -343,8 +343,8 @@ public:
 	 * 
 	 * @param id ID of the role or the member you want to add overwrite for
 	 * @param type type of overwrite (0 for role, 1 for member)
-	 * @param allowed_permissions bitmask of allowed permissions (refer to enum role_permissions) for this user/role in this channel
-	 * @param denied_permissions bitmask of denied permissions (refer to enum role_permissions) for this user/role in this channel
+	 * @param allowed_permissions bitmask of allowed permissions (refer to enum dpp::permissions) for this user/role in this channel
+	 * @param denied_permissions bitmask of denied permissions (refer to enum dpp::permissions) for this user/role in this channel
 	 *
 	 * @return Reference to self, so these method calls may be chained 
 	 */

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -26,6 +26,7 @@
 #include <dpp/utility.h>
 #include <dpp/voicestate.h>
 #include <dpp/nlohmann/json_fwd.hpp>
+#include <dpp/permissions.h>
 #include <dpp/json_interface.h>
 #include <unordered_map>
 
@@ -81,17 +82,31 @@ enum overwrite_type : uint8_t {
 };
 
 /**
- * @brief channel permission overwrites
+ * @brief Channel permission overwrites
  */
 struct DPP_EXPORT permission_overwrite {
-	/// Overwrite id
+	/// ID of the role or the member
 	snowflake id;
-	/// Allow mask
-	uint64_t allow;
-	/// Deny mask
-	uint64_t deny;
-	/// Overwrite type
+	/// Bitmask of allowed permissions
+	permission allow;
+	/// Bitmask of denied permissions
+	permission deny;
+	/// Type of overwrite. See dpp::overwrite_type
 	uint8_t type;
+
+	/**
+	 * @brief Construct a new permission_overwrite object
+	 */
+	permission_overwrite();
+
+	/**
+	 * @brief Construct a new permission_overwrite object
+	 * @param id ID of the role or the member to create the overwrite for
+	 * @param allow Bitmask of allowed permissions (refer to enum dpp::permissions) for this user/role in this channel
+	 * @param deny Bitmask of denied permissions (refer to enum dpp::permissions) for this user/role in this channel
+	 * @param type Type of overwrite
+	 */
+	permission_overwrite(snowflake id, uint64_t allow, uint64_t deny, overwrite_type type);
 };
 
 
@@ -191,7 +206,7 @@ public:
 	 * it contains the calculated permission bitmask of the user issuing the command
 	 * within this channel.
 	 */
-	uint64_t permissions;
+	permission permissions;
 
 	/** Sorting position, lower number means higher up the list */
 	uint16_t position;
@@ -342,13 +357,13 @@ public:
 	 * @brief Add a permission_overwrite to this channel object
 	 * 
 	 * @param id ID of the role or the member you want to add overwrite for
-	 * @param type type of overwrite (0 for role, 1 for member)
+	 * @param type type of overwrite
 	 * @param allowed_permissions bitmask of allowed permissions (refer to enum dpp::permissions) for this user/role in this channel
 	 * @param denied_permissions bitmask of denied permissions (refer to enum dpp::permissions) for this user/role in this channel
 	 *
 	 * @return Reference to self, so these method calls may be chained 
 	 */
-	channel& add_permission_overwrite(const snowflake id, const uint8_t type, const uint64_t allowed_permissions, const uint64_t denied_permissions);
+	channel& add_permission_overwrite(const snowflake id, const overwrite_type type, const uint64_t allowed_permissions, const uint64_t denied_permissions);
 
 	/**
 	 * @brief Get the mention ping for the channel
@@ -361,11 +376,11 @@ public:
 	 * @brief Get the user permissions for a user on this channel
 	 * 
 	 * @param member The user to return permissions for
-	 * @return uint64_t Permissions bitmask made of bits in role_permissions.
+	 * @return permission Permissions bitmask made of bits in dpp::permissions.
 	 * Note that if the user is not on the channel or the guild is
 	 * not in the cache, the function will always return 0.
 	 */
-	uint64_t get_user_permissions(const class user* member) const;
+	permission get_user_permissions(const class user* member) const;
 
 	/**
 	 * @brief Return a map of members on the channel, built from the guild's

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2106,7 +2106,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void channel_edit_permissions(const class channel &c, const snowflake overwrite_id, const uint32_t allow, const uint32_t deny, const bool member, command_completion_event_t callback = utility::log_error());
+	void channel_edit_permissions(const class channel &c, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit a channel's permissions
@@ -2121,7 +2121,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint32_t allow, const uint32_t deny, const bool member, command_completion_event_t callback = utility::log_error());
+	void channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a channel

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2100,8 +2100,8 @@ public:
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @param c Channel to set permissions for
 	 * @param overwrite_id Overwrite to change (a user or role ID)
-	 * @param allow allow permissions
-	 * @param deny deny permissions
+	 * @param allow allow permissions bitmask
+	 * @param deny deny permissions bitmask
 	 * @param member true if the overwrite_id is a user id, false if it is a channel id
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
@@ -2115,8 +2115,8 @@ public:
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @param channel_id ID of the channel to set permissions for
 	 * @param overwrite_id Overwrite to change (a user or role ID)
-	 * @param allow allow permissions
-	 * @param deny deny permissions
+	 * @param allow allow permissions bitmask
+	 * @param deny deny permissions bitmask
 	 * @param member true if the overwrite_id is a user id, false if it is a channel id
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -33,7 +33,7 @@
  * @see dpp::cluster::global_bulk_command_create
  * @see https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands
  * @param commands Vector of slash commands to create/update.
- * overwriting existing commands that are registered globally for this application.
+ * overwriting existing commands that are registered globally for this application. Updates will be available in all guilds after 1 hour.
  * Commands that do not already exist will count toward daily application command create limits.
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
@@ -154,6 +154,7 @@ guild_command_permissions_map guild_commands_get_permissions_sync(snowflake guil
  * @param commands A vector of slash commands to edit/overwrite the permissions for
  * @param guild_id Guild ID to edit permissions of the slash commands in
  * @return guild_command_permissions_map returned object on completion
+ * @deprecated This has been disabled with updates to Permissions v2. You can use guild_command_edit_permissions instead
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.

--- a/include/dpp/dpp.h
+++ b/include/dpp/dpp.h
@@ -38,6 +38,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/voicestate.h>
+#include <dpp/permissions.h>
 #include <dpp/role.h>
 #include <dpp/user.h>
 #include <dpp/channel.h>

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -24,6 +24,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/voicestate.h>
+#include <dpp/permissions.h>
 #include <string>
 #include <unordered_map>
 #include <dpp/json_interface.h>
@@ -540,9 +541,9 @@ public:
 	 * before permission overwrites are applied.
 	 *
 	 * @param member member to get permissions for
-	 * @return uint64_t permissions bitmask
+	 * @return permission permissions bitmask
 	 */
-	uint64_t base_permissions(const class user* member) const;
+	permission base_permissions(const class user* member) const;
 
 	/**
 	 * @brief Get the permission overwrites for a member
@@ -552,9 +553,9 @@ public:
 	 * from channel::base_permissions
 	 * @param member Member to fetch permissions for
 	 * @param channel Channel to fetch permissions against
-	 * @return uint64_t Merged permissions bitmask of overwrites.
+	 * @return permission Merged permissions bitmask of overwrites.
 	 */
-	uint64_t permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const;
+	permission permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const;
 
 	/**
 	 * @brief Rehash members map

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -71,7 +71,7 @@ enum permissions : uint64_t {
 };
 
 /**
- * @brief Permission type which holds the permission bitmask in an uint64_t
+ * @brief Represents a permission bitmask which are hold in an uint64_t
  */
 class permission {
 private:
@@ -80,6 +80,10 @@ private:
 	 */
 	uint64_t value;
 public:
+	/**
+	 * @brief Construct a permission object
+	 * @param value A permission bitmask
+	 */
 	permission(const uint64_t& value);
 
 	/**

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -80,7 +80,7 @@ using role_permissions = permissions;
  * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are hold in an uint64_t
  */
 class permission {
-private:
+protected:
 	/**
 	 * @brief The permission bitmask value
 	 */
@@ -111,12 +111,12 @@ public:
 
 	/**
 	 * @brief For building json
-	 * @return The permission bitmask value
+	 * @return The permission bitmask value as a string
 	 */
 	operator nlohmann::json() const;
 
 	/**
-	 * @brief Check if it has a permission flag set
+	 * @brief Check if it has a permission flag set. It uses the Bitwise AND operator
 	 * @param p The permission flag from dpp::permissions
 	 * @return True if it has the permission
 	 */
@@ -130,7 +130,7 @@ public:
 	const permission& add(uint64_t p);
 
 	/**
-	 * @brief Set a permission with the Bitwise AND operation
+	 * @brief Assign a permission. This will reset the bitmask to the new value.
 	 * @param p The permissions (from dpp::permissions) to set
 	 * @return permission& reference to self for chaining
 	 */

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -1,0 +1,120 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#pragma once
+#include <dpp/export.h>
+
+namespace dpp {
+
+/**
+ * @brief Represents the various discord permissions
+ */
+enum permissions : uint64_t {
+	p_create_instant_invite = 0x00000000001,    //!< allows creation of instant invites
+	p_kick_members = 0x00000000002,    //!< allows kicking members
+	p_ban_members = 0x00000000004,    //!< allows banning members
+	p_administrator = 0x00000000008,    //!< allows all permissions and bypasses channel permission overwrites
+	p_manage_channels = 0x00000000010,    //!< allows management and editing of channels
+	p_manage_guild = 0x00000000020,    //!< allows management and editing of the guild
+	p_add_reactions = 0x00000000040,    //!< allows for the addition of reactions to messages
+	p_view_audit_log = 0x00000000080,    //!< allows for viewing of audit logs
+	p_priority_speaker = 0x00000000100,    //!< allows for using priority speaker in a voice channel
+	p_stream = 0x00000000200,    //!< allows the user to go live
+	p_view_channel = 0x00000000400,    //!< allows guild members to view a channel, which includes reading messages in text channels and joining voice channels
+	p_send_messages = 0x00000000800,    //!< allows for sending messages in a channel
+	p_send_tts_messages = 0x00000001000,    //!< allows for sending of /tts messages
+	p_manage_messages = 0x00000002000,    //!< allows for deletion of other users messages
+	p_embed_links = 0x00000004000,    //!< links sent by users with this permission will be auto-embedded
+	p_attach_files = 0x00000008000,    //!< allows for uploading images and files
+	p_read_message_history = 0x00000010000,    //!< allows for reading of message history
+	p_mention_everyone = 0x00000020000,    //!< allows for using the everyone and the here tag to notify users in a channel
+	p_use_external_emojis = 0x00000040000,    //!< allows the usage of custom emojis from other servers
+	p_view_guild_insights = 0x00000080000,    //!< allows for viewing guild insights
+	p_connect = 0x00000100000,    //!< allows for joining of a voice channel
+	p_speak = 0x00000200000,    //!< allows for speaking in a voice channel
+	p_mute_members = 0x00000400000,    //!< allows for muting members in a voice channel
+	p_deafen_members = 0x00000800000,    //!< allows for deafening of members in a voice channel
+	p_move_members = 0x00001000000,    //!< allows for moving of members between voice channels
+	p_use_vad = 0x00002000000,    //!< allows for using voice-activity-detection in a voice channel
+	p_change_nickname = 0x00004000000,    //!< allows for modification of own nickname
+	p_manage_nicknames = 0x00008000000,    //!< allows for modification of other users nicknames
+	p_manage_roles = 0x00010000000,    //!< allows management and editing of roles
+	p_manage_webhooks = 0x00020000000,    //!< allows management and editing of webhooks
+	p_manage_emojis_and_stickers = 0x00040000000,    //!< allows management and editing of emojis and stickers
+	p_use_application_commands = 0x00080000000,    //!< allows members to use application commands, including slash commands and context menus
+	p_request_to_speak = 0x00100000000,    //!< allows for requesting to speak in stage channels. (Discord: This permission is under active development and may be changed or removed.)
+	p_manage_events = 0x00200000000,    //!< allows for management (creation, updating, deleting, starting) of scheduled events
+	p_manage_threads = 0x00400000000,    //!< allows for deleting and archiving threads, and viewing all private threads
+	p_create_public_threads = 0x00800000000,    //!< allows for creating public and announcement threads
+	p_create_private_threads = 0x01000000000,    //!< allows for creating private threads
+	p_use_external_stickers = 0x02000000000,    //!< allows the usage of custom stickers from other servers
+	p_send_messages_in_threads = 0x04000000000,    //!< allows for sending messages in threads
+	p_use_embedded_activities = 0x08000000000,    //!< allows for using activities (applications with the EMBEDDED flag) in a voice channel
+	p_moderate_members = 0x10000000000,    //!< allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels
+};
+
+/**
+ * @brief Permission type which holds the permission bitmask in an uint64_t
+ */
+class permission {
+private:
+	/**
+	 * @brief The permission bitmask value
+	 */
+	uint64_t value;
+public:
+	template<typename T> permission(T v);
+
+	/**
+ 	 * @brief Construct a permission object
+ 	 */
+	permission();
+
+	operator uint64_t() const;
+
+	operator uint64_t &();
+
+	/**
+	 * @brief Check if it has a permission flag set
+	 * @param p The permission flag from dpp::permissions
+	 * @return True if it has the permission
+	 */
+	bool has(uint64_t p) const;
+
+	/**
+	 * @brief Add a permission with the Bitwise OR operation
+	 * @param p The permission from dpp::permissions to add
+	 */
+	void add(uint64_t p);
+
+	/**
+	 * @brief Set a permission with the Bitwise AND operation
+	 * @param p The permission from dpp::permissions to set
+	 */
+	void set(uint64_t p);
+
+	/**
+	 * @brief Remove a permission with the Bitwise NOT operation
+	 * @param p The permission from dpp::permissions to remove
+	 */
+	void remove(uint64_t p);
+};
+
+}

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -80,7 +80,7 @@ private:
 	 */
 	uint64_t value;
 public:
-	template<typename T> permission(T v);
+	permission(const uint64_t& value);
 
 	/**
  	 * @brief Construct a permission object
@@ -90,6 +90,8 @@ public:
 	operator uint64_t() const;
 
 	operator uint64_t &();
+
+	operator nlohmann::json() const;
 
 	/**
 	 * @brief Check if it has a permission flag set

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -71,7 +71,13 @@ enum permissions : uint64_t {
 };
 
 /**
- * @brief Represents a permission bitmask which are hold in an uint64_t
+ * @brief Represents the various discord permissions
+ * @deprecated Use dpp::permissions instead.
+ */
+using role_permissions = permissions;
+
+/**
+ * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are hold in an uint64_t
  */
 class permission {
 private:
@@ -106,19 +112,19 @@ public:
 
 	/**
 	 * @brief Add a permission with the Bitwise OR operation
-	 * @param p The permission from dpp::permissions to add
+	 * @param p The permissions (from dpp::permissions) to add
 	 */
 	void add(uint64_t p);
 
 	/**
 	 * @brief Set a permission with the Bitwise AND operation
-	 * @param p The permission from dpp::permissions to set
+	 * @param p The permissions (from dpp::permissions) to set
 	 */
 	void set(uint64_t p);
 
 	/**
 	 * @brief Remove a permission with the Bitwise NOT operation
-	 * @param p The permission from dpp::permissions to remove
+	 * @param p The permissions (from dpp::permissions) to remove
 	 */
 	void remove(uint64_t p);
 };

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -97,10 +97,22 @@ public:
  	 */
 	permission();
 
+	/**
+	 * @brief For acting like an integer
+	 * @return The permission bitmask value
+	 */
 	operator uint64_t() const;
 
+	/**
+	 * @brief For acting like an integer
+	 * @return A reference to the permission bitmask value
+	 */
 	operator uint64_t &();
 
+	/**
+	 * @brief For building json
+	 * @return The permission bitmask value
+	 */
 	operator nlohmann::json() const;
 
 	/**
@@ -113,20 +125,23 @@ public:
 	/**
 	 * @brief Add a permission with the Bitwise OR operation
 	 * @param p The permissions (from dpp::permissions) to add
+	 * @return permission& reference to self for chaining
 	 */
-	void add(uint64_t p);
+	const permission& add(uint64_t p);
 
 	/**
 	 * @brief Set a permission with the Bitwise AND operation
 	 * @param p The permissions (from dpp::permissions) to set
+	 * @return permission& reference to self for chaining
 	 */
-	void set(uint64_t p);
+	const permission& set(uint64_t p);
 
 	/**
 	 * @brief Remove a permission with the Bitwise NOT operation
 	 * @param p The permissions (from dpp::permissions) to remove
+	 * @return permission& reference to self for chaining
 	 */
-	void remove(uint64_t p);
+	const permission& remove(uint64_t p);
 };
 
 }

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -37,12 +37,6 @@ enum role_flags : uint8_t {
 };
 
 /**
- * @brief Represents the various discord permissions
- * @deprecated Use dpp::permissions instead.
- */
-using role_permissions = permissions;
-
-/**
  * @brief Represents a role within a dpp::guild.
  * Roles are combined via logical OR of the permission bitmasks, then channel-specific overrides
  * can be applied on top, deny types apply a logic NOT to the bit mask, and allows apply a logical OR.

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -22,6 +22,7 @@
 #include <dpp/export.h>
 #include <dpp/managed.h>
 #include <dpp/nlohmann/json_fwd.hpp>
+#include <dpp/permissions.h>
 #include <dpp/guild.h>
 #include <dpp/json_interface.h>
 
@@ -33,53 +34,6 @@ enum role_flags : uint8_t {
 	r_managed =		0b00000010, //!< Managed role (introduced by a bot or application)
 	r_mentionable =		0b00000100, //!< Mentionable with a ping
 	r_premium_subscriber =	0b00001000, //!< This is set for the role given to nitro 
-};
-
-/**
- * @brief Represents the various discord permissions
- */
-enum permissions : uint64_t {
-	p_create_instant_invite		=	0x00000000001,	//!< allows creation of instant invites
-	p_kick_members			=	0x00000000002,	//!< allows kicking members
-	p_ban_members			=	0x00000000004,	//!< allows banning members
-	p_administrator			=	0x00000000008,	//!< allows all permissions and bypasses channel permission overwrites
-	p_manage_channels		=	0x00000000010,	//!< allows management and editing of channels
-	p_manage_guild			=	0x00000000020,	//!< allows management and editing of the guild
-	p_add_reactions			=	0x00000000040,	//!< allows for the addition of reactions to messages
-	p_view_audit_log		=	0x00000000080,	//!< allows for viewing of audit logs
-	p_priority_speaker		=	0x00000000100,	//!< allows for using priority speaker in a voice channel
-	p_stream			=	0x00000000200,	//!< allows the user to go live
-	p_view_channel			=	0x00000000400,	//!< allows guild members to view a channel, which includes reading messages in text channels and joining voice channels
-	p_send_messages			=	0x00000000800,	//!< allows for sending messages in a channel
-	p_send_tts_messages		=	0x00000001000,	//!< allows for sending of /tts messages
-	p_manage_messages		=	0x00000002000,	//!< allows for deletion of other users messages
-	p_embed_links			=	0x00000004000,	//!< links sent by users with this permission will be auto-embedded
-	p_attach_files			=	0x00000008000,	//!< allows for uploading images and files
-	p_read_message_history		=	0x00000010000,	//!< allows for reading of message history
-	p_mention_everyone		=	0x00000020000,	//!< allows for using the everyone and the here tag to notify users in a channel
-	p_use_external_emojis		=	0x00000040000,	//!< allows the usage of custom emojis from other servers
-	p_view_guild_insights		=	0x00000080000,	//!< allows for viewing guild insights
-	p_connect			=	0x00000100000,	//!< allows for joining of a voice channel
-	p_speak				=	0x00000200000,	//!< allows for speaking in a voice channel
-	p_mute_members			=	0x00000400000,	//!< allows for muting members in a voice channel
-	p_deafen_members		=	0x00000800000,	//!< allows for deafening of members in a voice channel
-	p_move_members			=	0x00001000000,	//!< allows for moving of members between voice channels
-	p_use_vad			=	0x00002000000,	//!< allows for using voice-activity-detection in a voice channel
-	p_change_nickname		=	0x00004000000,	//!< allows for modification of own nickname 
-	p_manage_nicknames		=	0x00008000000,	//!< allows for modification of other users nicknames 
-	p_manage_roles			=	0x00010000000,	//!< allows management and editing of roles 
-	p_manage_webhooks		=	0x00020000000,	//!< allows management and editing of webhooks
-	p_manage_emojis_and_stickers	=	0x00040000000,	//!< allows management and editing of emojis and stickers
-	p_use_application_commands	=	0x00080000000,	//!< allows members to use application commands, including slash commands and context menus 
-	p_request_to_speak		=	0x00100000000,	//!< allows for requesting to speak in stage channels. (Discord: This permission is under active development and may be changed or removed.)
-	p_manage_events			=	0x00200000000,	//!< allows for management (creation, updating, deleting, starting) of scheduled events
-	p_manage_threads		=	0x00400000000,	//!< allows for deleting and archiving threads, and viewing all private threads
-	p_create_public_threads		=	0x00800000000,	//!< allows for creating public and announcement threads
-	p_create_private_threads	=	0x01000000000,	//!< allows for creating private threads
-	p_use_external_stickers		=	0x02000000000,	//!< allows the usage of custom stickers from other servers
-	p_send_messages_in_threads	=	0x04000000000,	//!< allows for sending messages in threads
-	p_use_embedded_activities	=	0x08000000000,	//!< allows for using activities (applications with the EMBEDDED flag) in a voice channel
-	p_moderate_members		=	0x10000000000,	//!< allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels
 };
 
 /**

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -64,7 +64,7 @@ public:
 	/** Role position */
 	uint8_t position;
 	/** Role permissions bitmask values from dpp::permissions */
-	uint64_t permissions;
+	permission permissions;
 	/** Role flags from dpp::role_flags */
 	uint8_t flags;
 	/** Integration id if any (e.g. role is a bot's role created when it was invited) */

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -38,7 +38,7 @@ enum role_flags : uint8_t {
 /**
  * @brief Represents the various discord permissions
  */
-enum role_permissions : uint64_t {
+enum permissions : uint64_t {
 	p_create_instant_invite		=	0x00000000001,	//!< allows creation of instant invites
 	p_kick_members			=	0x00000000002,	//!< allows kicking members
 	p_ban_members			=	0x00000000004,	//!< allows banning members
@@ -83,6 +83,12 @@ enum role_permissions : uint64_t {
 };
 
 /**
+ * @brief Represents the various discord permissions
+ * @deprecated Use dpp::permissions instead.
+ */
+using role_permissions = permissions;
+
+/**
  * @brief Represents a role within a dpp::guild.
  * Roles are combined via logical OR of the permission bitmasks, then channel-specific overrides
  * can be applied on top, deny types apply a logic NOT to the bit mask, and allows apply a logical OR.
@@ -109,7 +115,7 @@ public:
 	uint32_t colour;
 	/** Role position */
 	uint8_t position;
-	/** Role permissions bitmask values from dpp::role_permissions */
+	/** Role permissions bitmask values from dpp::permissions */
 	uint64_t permissions;
 	/** Role flags from dpp::role_flags */
 	uint8_t flags;

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -355,7 +355,7 @@ namespace dpp {
 		 * @brief Create a bot invite
 		 * 
 		 * @param bot_id Bot ID
-		 * @param permissions Permissions of the bot to invite
+		 * @param permissions Permission bitmask of the bot to invite
 		 * @param scopes Scopes to use
 		 * @return Invite URL
 		 */

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -32,6 +32,10 @@ using json = nlohmann::json;
 
 namespace dpp {
 
+permission_overwrite::permission_overwrite() : id(0), allow(0), deny(0), type(0) {}
+
+permission_overwrite::permission_overwrite(snowflake id, uint64_t allow, uint64_t deny, overwrite_type type) : id(id), allow(allow), deny(deny), type(type) {}
+
 const uint8_t CHANNEL_TYPE_MASK = 0b00001111;
 
 thread_member& thread_member::fill_from_json(nlohmann::json* j) {
@@ -145,7 +149,7 @@ channel& channel::set_user_limit(const uint8_t user_limit) {
 	return *this;
 }
 
-channel& channel::add_permission_overwrite(const snowflake id, const uint8_t type, const uint64_t allowed_permissions, const uint64_t denied_permissions) {
+channel& channel::add_permission_overwrite(const snowflake id, const overwrite_type type, const uint64_t allowed_permissions, const uint64_t denied_permissions) {
 	permission_overwrite po {id, allowed_permissions, denied_permissions, type};
 	this->permission_overwrites.push_back(po);
 	return *this;
@@ -365,7 +369,7 @@ std::string channel::build_json(bool with_id) const {
 	return j.dump();
 }
 
-uint64_t channel::get_user_permissions(const user* member) const
+permission channel::get_user_permissions(const user* member) const
 {
 	if (member == nullptr)
 		return 0;

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -35,11 +35,11 @@ void cluster::channel_delete(snowflake channel_id, command_completion_event_t ca
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "", m_delete, "", callback);
 }
 
-void cluster::channel_edit_permissions(const class channel &c, const snowflake overwrite_id, const uint32_t allow, const uint32_t deny, const bool member, command_completion_event_t callback) {
+void cluster::channel_edit_permissions(const class channel &c, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback) {
 	channel_edit_permissions(c.id, overwrite_id, allow, deny, member, callback);
 }
 
-void cluster::channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint32_t allow, const uint32_t deny, const bool member, command_completion_event_t callback) {
+void cluster::channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback) {
 	json j({ {"allow", std::to_string(allow)}, {"deny", std::to_string(deny)}, {"type", member ? 1 : 0}  });
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "permissions/" + std::to_string(overwrite_id), m_put, j.dump(), callback);
 }

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -532,7 +532,7 @@ std::string guild_widget::build_json(bool with_id) const {
 }
 
 
-uint64_t guild::base_permissions(const user* member) const
+permission guild::base_permissions(const user* member) const
 {
 	if (owner_id == member->id)
 		return ~0;
@@ -543,7 +543,7 @@ uint64_t guild::base_permissions(const user* member) const
 		return 0;
 	guild_member gm = mi->second;
 
-	uint64_t permissions = everyone->permissions;
+	permission permissions = everyone->permissions;
 
 	for (auto& rid : gm.roles) {
 		role* r = dpp::find_role(rid);
@@ -558,12 +558,12 @@ uint64_t guild::base_permissions(const user* member) const
 	return permissions;
 }
 
-uint64_t guild::permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const
+permission guild::permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const
 {
 	if (base_permissions & p_administrator)
 		return ~0;
 
-	int64_t permissions = base_permissions;
+	permission permissions = base_permissions;
 	for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
 		if (it->id == id && it->type == ot_role) {
 			permissions &= ~it->deny;

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -36,7 +36,7 @@ permission::operator uint64_t &() {
 }
 
 permission::operator nlohmann::json() const {
-	return value;
+	return std::to_string(value);
 }
 
 bool permission::has(uint64_t p) const {

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -43,16 +43,19 @@ bool permission::has(uint64_t p) const {
 	return (value & p);
 }
 
-void permission::add(uint64_t p) {
+const permission& permission::add(uint64_t p) {
 	value |= p;
+	return *this;
 }
 
-void permission::set(uint64_t p) {
+const permission& permission::set(uint64_t p) {
 	value = p;
+	return *this;
 }
 
-void permission::remove(uint64_t p) {
+const permission& permission::remove(uint64_t p) {
 	value &= ~p;
+	return *this;
 }
 
 }

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -40,7 +40,7 @@ permission::operator nlohmann::json() const {
 }
 
 bool permission::has(uint64_t p) const {
-	return (value & p);
+	return (value & p) == p;
 }
 
 const permission& permission::add(uint64_t p) {

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -18,12 +18,12 @@
  * limitations under the License.
  *
  ************************************************************************************/
-#pragma once
 #include <dpp/permissions.h>
+#include <dpp/nlohmann/json.hpp>
 
 namespace dpp {
 
-template<typename T> permission::permission(T v) : value(v) {};
+permission::permission(const uint64_t &value) : value(value) {}
 
 permission::permission() : permission(0) {}
 
@@ -32,6 +32,10 @@ permission::operator uint64_t() const {
 }
 
 permission::operator uint64_t &() {
+	return value;
+}
+
+permission::operator nlohmann::json() const {
 	return value;
 }
 

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -1,0 +1,54 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#pragma once
+#include <dpp/permissions.h>
+
+namespace dpp {
+
+template<typename T> permission::permission(T v) : value(v) {};
+
+permission::permission() : permission(0) {}
+
+permission::operator uint64_t() const {
+	return value;
+}
+
+permission::operator uint64_t &() {
+	return value;
+}
+
+bool permission::has(uint64_t p) const {
+	return (value & p);
+}
+
+void permission::add(uint64_t p) {
+	value |= p;
+}
+
+void permission::set(uint64_t p) {
+	value = p;
+}
+
+void permission::remove(uint64_t p) {
+	value &= ~p;
+}
+
+}

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -22,6 +22,7 @@
 #include <dpp/role.h>
 #include <dpp/cache.h>
 #include <dpp/discordevents.h>
+#include <dpp/permissions.h>
 #include <dpp/stringops.h>
 #include <dpp/nlohmann/json.hpp>
 #include <dpp/fmt-minimal.h>
@@ -143,167 +144,167 @@ bool role::is_managed() const {
 }
 
 bool role::has_create_instant_invite() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_create_instant_invite));
+	return has_administrator() || permissions.has(p_create_instant_invite);
 }
 
 bool role::has_kick_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_kick_members));
+	return has_administrator() || permissions.has(p_kick_members);
 }
 
 bool role::has_ban_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_ban_members));
+	return has_administrator() || permissions.has(p_ban_members);
 }
 
 bool role::has_administrator() const {
-	return (this->permissions & p_administrator);
+	return permissions.has(p_administrator);
 }
 
 bool role::has_manage_channels() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_channels));
+	return has_administrator() || permissions.has(p_manage_channels);
 }
 
 bool role::has_manage_guild() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_guild));
+	return has_administrator() || permissions.has(p_manage_guild);
 }
 
 bool role::has_add_reactions() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_add_reactions));
+	return has_administrator() || permissions.has(p_add_reactions);
 }
 
 bool role::has_view_audit_log() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_view_audit_log));
+	return has_administrator() || permissions.has(p_view_audit_log);
 }
 
 bool role::has_priority_speaker() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_priority_speaker));
+	return has_administrator() || permissions.has(p_priority_speaker);
 }
 
 bool role::has_stream() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_stream));
+	return has_administrator() || permissions.has(p_stream);
 }
 
 bool role::has_view_channel() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_view_channel));
+	return has_administrator() || permissions.has(p_view_channel);
 }
 
 bool role::has_send_messages() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_send_messages));
+	return has_administrator() || permissions.has(p_send_messages);
 }
 
 bool role::has_send_tts_messages() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_send_tts_messages));
+	return has_administrator() || permissions.has(p_send_tts_messages);
 }
 
 bool role::has_manage_messages() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_messages));
+	return has_administrator() || permissions.has(p_manage_messages);
 }
 
 bool role::has_embed_links() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_embed_links));
+	return has_administrator() || permissions.has(p_embed_links);
 }
 
 bool role::has_attach_files() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_attach_files));
+	return has_administrator() || permissions.has(p_attach_files);
 }
 
 bool role::has_read_message_history() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_read_message_history));
+	return has_administrator() || permissions.has(p_read_message_history);
 }
 
 bool role::has_mention_everyone() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_mention_everyone));
+	return has_administrator() || permissions.has(p_mention_everyone);
 }
 
 bool role::has_use_external_emojis() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_use_external_emojis));
+	return has_administrator() || permissions.has(p_use_external_emojis);
 }
 
 bool role::has_view_guild_insights() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_view_guild_insights));
+	return has_administrator() || permissions.has(p_view_guild_insights);
 }
 
 bool role::has_connect() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_connect));
+	return has_administrator() || permissions.has(p_connect);
 }
 
 bool role::has_speak() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_speak));
+	return has_administrator() || permissions.has(p_speak);
 }
 
 bool role::has_mute_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_mute_members));
+	return has_administrator() || permissions.has(p_mute_members);
 }
 
 bool role::has_deafen_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_deafen_members));
+	return has_administrator() || permissions.has(p_deafen_members);
 }
 
 bool role::has_move_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_move_members));
+	return has_administrator() || permissions.has(p_move_members);
 }
 
 bool role::has_use_vad() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_use_vad));
+	return has_administrator() || permissions.has(p_use_vad);
 }
 
 bool role::has_change_nickname() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_change_nickname));
+	return has_administrator() || permissions.has(p_change_nickname);
 }
 
 bool role::has_manage_nicknames() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_nicknames));
+	return has_administrator() || permissions.has(p_manage_nicknames);
 }
 
 bool role::has_manage_roles() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_roles));
+	return has_administrator() || permissions.has(p_manage_roles);
 }
 
 bool role::has_manage_webhooks() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_webhooks));
+	return has_administrator() || permissions.has(p_manage_webhooks);
 }
 
 bool role::has_manage_emojis_and_stickers() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_emojis_and_stickers));
+	return has_administrator() || permissions.has(p_manage_emojis_and_stickers);
 }
 
 bool role::has_use_application_commands() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_use_application_commands));
+	return has_administrator() || permissions.has(p_use_application_commands);
 }
 
 bool role::has_request_to_speak() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_request_to_speak));
+	return has_administrator() || permissions.has(p_request_to_speak);
 }
 
 bool role::has_manage_threads() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_threads));
+	return has_administrator() || permissions.has(p_manage_threads);
 }
 
 bool role::has_create_public_threads() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_create_public_threads));
+	return has_administrator() || permissions.has(p_create_public_threads);
 }
 
 bool role::has_create_private_threads() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_create_private_threads));
+	return has_administrator() || permissions.has(p_create_private_threads);
 }
 
 bool role::has_use_external_stickers() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_use_external_stickers));
+	return has_administrator() || permissions.has(p_use_external_stickers);
 }
 
 bool role::has_send_messages_in_threads() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_send_messages_in_threads));
+	return has_administrator() || permissions.has(p_send_messages_in_threads);
 }
 
 bool role::has_use_embedded_activities() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_use_embedded_activities));
+	return has_administrator() || permissions.has(p_use_embedded_activities);
 }
 
 bool role::has_manage_events() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_manage_events));
+	return has_administrator() || permissions.has(p_manage_events);
 }
 
 bool role::has_moderate_members() const {
-	return ((this->permissions & p_administrator) | (this->permissions & p_moderate_members));
+	return has_administrator() || permissions.has(p_moderate_members);
 }
 
 role& role::set_name(const std::string& n) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -174,6 +174,26 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		set_test("COMMANDOPTIONCHOICEFILLFROMJSON", (success_double && success_int && success_int2 && success_bool && success_snowflake && success_string));
 	}
 
+	{
+		set_test("PERMISSION_CLASS", false);
+		bool success = false;
+		auto p = dpp::permission();
+		p = 16;
+		success = p == 16 && success;
+		p |= 4;
+		success = p == 20 && success;
+		p <<= 8;
+		success = p == 4096 && success;
+		auto s = std::to_string(p);
+		success = s == "4096" && success;
+		json j;
+		j["value"] = p;
+		success = dpp::snowflake_not_null(&j, "value") == 4096 && success;
+		p.set(8);
+		success = p.has(8) && success;
+		set_test("PERMISSION_CLASS", success);
+	}
+
 	set_test("TIMESTRINGTOTIMESTAMP", false);
 	json tj;
 	tj["t1"] = "2022-01-19T17:18:14.506000+00:00";

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -179,16 +179,16 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		bool success = false;
 		auto p = dpp::permission();
 		p = 16;
-		success = p == 16 && success;
+		success = p == 16;
 		p |= 4;
 		success = p == 20 && success;
-		p <<= 8;
-		success = p == 4096 && success;
+		p <<= 8; // left shift
+		success = p == 5120 && success;
 		auto s = std::to_string(p);
-		success = s == "4096" && success;
+		success = s == "5120" && success;
 		json j;
 		j["value"] = p;
-		success = dpp::snowflake_not_null(&j, "value") == 4096 && success;
+		success = dpp::snowflake_not_null(&j, "value") == 5120 && success;
 		p.set(8);
 		success = p.has(8) && success;
 		set_test("PERMISSION_CLASS", success);

--- a/src/unittest.cpp
+++ b/src/unittest.cpp
@@ -78,6 +78,7 @@ std::map<std::string, test_t> tests = {
 	{"COMPARISON", {"dpp::manged object comparison", false, false}},
 	{"CHANNELCACHE", {"dpp::find_channel()", false, false}},
 	{"CHANNELTYPES", {"dpp::channel type flags", false, false}},
+	{"PERMISSION_CLASS", {"testing dpp::permission functionality", false, false}},
 };
 
 double start = dpp::utility::time_f();


### PR DESCRIPTION
- **renamed `dpp::role_permissions` to `dpp::permissions`**, but added `using role_permissions = permissions;` so it shouldn't be too much breaking. I also moved it to a new file `permissions.cpp`.

- **Added constructor for `dpp::permission_overwrite`**

- **The has_-getters in `dpp::role` are now using the utility methods of `dpp::permission`**

### Added new `dpp::permission` class
The class holds an `uint64_t` and has some utility methods to check, remove and add flags.
This new class is now used for permission bitmasks and i replaced the old uint64_t with it on various places.