### PR TITLE
added dpp::cluster::guild_member_remove_role and deprecated dpp::cluster::guild_member_delete_role

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -913,17 +913,10 @@ public:
 	slashcommand& set_dm_permission(bool dm);
 
 	/**
-	 * @brief Set the default permissions of the slash command,
-	 * this is a permission bitmask.
+	 * @brief Set the default permissions of the slash command
 	 * 
-	 * @param defaults default permissions to set
+	 * @param defaults default permissions to set. This is a permission bitmask
 	 * @note You can set it to 0 to disable the command for everyone except admins by default
-	 *
-	 * **Example:**
-	 *
-	 * ```cpp
-	 * command.set_default_permissions(dpp::p_manage_roles | dpp::p_manage_nicknames | dpp::p_manage_guild);
-	 * ```
 	 *
 	 * @return slashcommand& reference to self
 	 */

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2419,8 +2419,24 @@ public:
 	 * @param role_id Role to remove
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * @deprecated Use dpp::cluster::guild_member_remove_role instead
 	 */
 	void guild_member_delete_role(snowflake guild_id, snowflake user_id, snowflake role_id, command_completion_event_t callback = utility::log_error());
+
+	/**
+	 * @brief Remove role from guild member
+	 *
+	 * Removes a role from a guild member. Requires the `MANAGE_ROLES` permission.
+	 * Fires a `Guild Member Update` Gateway event.
+	 * @see https://discord.com/developers/docs/resources/guild#remove-guild-member-role
+	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
+	 * @param guild_id Guild ID to remove role from user on
+	 * @param user_id User ID to remove role from
+	 * @param role_id Role to remove
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void guild_member_remove_role(snowflake guild_id, snowflake user_id, snowflake role_id, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Remove (kick) a guild member

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -1191,12 +1191,32 @@ confirmation guild_member_timeout_sync(snowflake guild_id, snowflake user_id, ti
  * @param user_id User ID to remove role from
  * @param role_id Role to remove
  * @return confirmation returned object on completion
+ * @deprecated Use dpp::cluster::guild_member_remove_role instead
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
 confirmation guild_member_delete_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
+
+/**
+ * @brief Remove role from guild member
+ *
+ * Removes a role from a guild member. Requires the `MANAGE_ROLES` permission.
+ * Fires a `Guild Member Update` Gateway event.
+ * @see dpp::cluster::guild_member_remove_role
+ * @see https://discord.com/developers/docs/resources/guild#remove-guild-member-role
+ * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
+ * @param guild_id Guild ID to remove role from user on
+ * @param user_id User ID to remove role from
+ * @param role_id Role to remove
+ * @return confirmation returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+confirmation guild_member_remove_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
 
 /**
  * @brief Moves the guild member to a other voice channel, if member is connected to one

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -95,7 +95,7 @@ void cluster::guild_member_timeout(snowflake guild_id, snowflake user_id, time_t
 
 
 void cluster::guild_member_delete_role(snowflake guild_id, snowflake user_id, snowflake role_id, command_completion_event_t callback) {
-	guild_member_remove_role(guild_id, user_id, role_id, callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id) + "/roles/" + std::to_string(role_id), m_delete, "", callback);
 }
 
 

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -95,6 +95,11 @@ void cluster::guild_member_timeout(snowflake guild_id, snowflake user_id, time_t
 
 
 void cluster::guild_member_delete_role(snowflake guild_id, snowflake user_id, snowflake role_id, command_completion_event_t callback) {
+	guild_member_remove_role(guild_id, user_id, role_id, callback);
+}
+
+
+void cluster::guild_member_remove_role(snowflake guild_id, snowflake user_id, snowflake role_id, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id) + "/roles/" + std::to_string(role_id), m_delete, "", callback);
 }
 

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -328,6 +328,10 @@ confirmation cluster::guild_member_delete_role_sync(snowflake guild_id, snowflak
 	return dpp::sync<confirmation>(this, &cluster::guild_member_delete_role, guild_id, user_id, role_id);
 }
 
+confirmation cluster::guild_member_remove_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id) {
+	return dpp::sync<confirmation>(this, &cluster::guild_member_remove_role, guild_id, user_id, role_id);
+}
+
 guild_member cluster::guild_member_move_sync(const snowflake channel_id, const snowflake guild_id, const snowflake user_id) {
 	return dpp::sync<guild_member>(this, &cluster::guild_member_move, channel_id, guild_id, user_id);
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -179,16 +179,16 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		bool success = false;
 		auto p = dpp::permission();
 		p = 16;
-		success = p == 16 && success;
+		success = p == 16;
 		p |= 4;
 		success = p == 20 && success;
-		p <<= 8;
-		success = p == 4096 && success;
+		p <<= 8; // left shift
+		success = p == 5120 && success;
 		auto s = std::to_string(p);
-		success = s == "4096" && success;
+		success = s == "5120" && success;
 		json j;
 		j["value"] = p;
-		success = dpp::snowflake_not_null(&j, "value") == 4096 && success;
+		success = dpp::snowflake_not_null(&j, "value") == 5120 && success;
 		p.set(8);
 		success = p.has(8) && success;
 		set_test("PERMISSION_CLASS", success);


### PR DESCRIPTION
the name guild_member_delete_role is just confusing because it doesnt delete anything, its just removing the role...