### PR TITLE
add template to only enable for int convertible types

### DIFF
--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -145,7 +145,7 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T>
+	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
 	permission& add(T... values) {
 		(value |= (0 | ... | values));
 		return *this;
@@ -164,7 +164,7 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T>
+	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
 	permission& set(T... values) {
 		(value = (0 | ... | values));
 		return *this;
@@ -184,7 +184,7 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T>
+	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
 	permission& remove(T... values) {
 		(value &= ~(0 | ... | values));
 		return *this;

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -145,9 +145,10 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
-	permission& add(T... values) {
-		(value |= (0 | ... | values));
+	template <typename... T>
+	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
+	add(T... values) {
+		value |= (0 | ... | values);
 		return *this;
 	}
 
@@ -164,9 +165,10 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
-	permission& set(T... values) {
-		(value = (0 | ... | values));
+	template <typename... T>
+	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
+	set(T... values) {
+		value = (0 | ... | values);
 		return *this;
 	}
 
@@ -184,9 +186,10 @@ public:
 	 *
 	 * @return permission& reference to self for chaining
 	 */
-	template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
-	permission& remove(T... values) {
-		(value &= ~(0 | ... | values));
+	template <typename... T>
+	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
+	remove(T... values) {
+		value &= ~(0 | ... | values);
 		return *this;
 	}
 };


### PR DESCRIPTION
makes it actually be a compiler error when you input something invalid