### PR TITLE
Fix `discord_voice_client` `voice_payload` priority when two payloads have the same timestamp.

### DIFF
--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -68,7 +68,40 @@ struct rtp_header {
 bool discord_voice_client::sodium_initialised = false;
 
 bool discord_voice_client::voice_payload::operator<(const voice_payload& other) const {
-	return timestamp > other.timestamp;
+	if (timestamp != other.timestamp) {
+		return timestamp > other.timestamp;
+	}
+
+	constexpr rtp_seq_t wrap_around_test_boundary = 5000;
+	if (seq < wrap_around_test_boundary != other.seq < wrap_around_test_boundary) {
+		/* Match the cases where exactly one of the sequence numbers "may have"
+		 * wrapped around.
+		 *
+		 * Examples:
+		 * 1. this->seq = 65530, other.seq = 10  // Did wrap around
+		 * 2. this->seq = 5002, other.seq = 4990 // Not wrapped around
+		 *
+		 * Add 5000 to both sequence numbers to force wrap around so they can be
+		 * compared. This should be fine to do to case 2 as well, as long as the
+		 * addend (5000) is not too large to cause one of them to wrap around.
+		 *
+		 * In practice, we should be unlikely to hit the case where
+		 *
+		 *           this->seq = 65530, other.seq = 5001
+		 *
+		 * because we shouldn't receive more than 5000 payloads in one batch, unless
+		 * the voice courier thread is super slow. Also remember that the timestamp
+		 * is compared first, and payloads this far apart shouldn't have the same
+		 * timestamp.
+		 */
+
+		/* Casts here ensure the sum wraps around and not implicitly converted to
+		 * wider types. */
+		return   static_cast<rtp_seq_t>(seq + wrap_around_test_boundary)
+		       > static_cast<rtp_seq_t>(other.seq + wrap_around_test_boundary);
+	} else {
+		return seq > other.seq;
+	}
 }
 
 #ifdef HAVE_VOICE


### PR DESCRIPTION
## Issue

Using a web client to provide voice, found that the voice courier thread can easily run into the same symptoms as that prior to #391.
Turns out there can be multiple payloads with the same timestamp, so the approach of depending only on timestamps breaks the payload ordering and doesn't work. Have to bring back sequence number comparison.

Also hopefully now it should be properly handling the wrap around case for sequence number.

## Commit Message
```txt
Seems to be prevalent in payloads from web clients; two payloads
with different sequence numebrs can have the same timestamp. We can't
be lazy and not look at the sequence number to order the payloads.
```