### PR TITLE
Added a voice client option to skip throttling for live audio data.

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -493,6 +493,34 @@ public:
 	snowflake channel_id;
 
 	/**
+	 * @brief The audio type to be sent. The default type is recorded audio.
+	 *
+	 * If the audio is recorded, the sending of audio packets is throttled.
+	 * Otherwise, if the audio is live, the sending is not throttled.
+	 *
+	 * Discord voice engine is expecting audio data as if they were from
+	 * some audio device, e.g. microphone, where the data become available
+	 * as they get captured from the audio device.
+	 *
+	 * In case of recorded audio, unlike from a device, the audio data are
+	 * usually instantly available in large chunks. Throttling is needed to
+	 * simulate audio data coming from an audio device. In case of live audio,
+	 * the throttling is by nature, so no extra throttling is needed.
+	 *
+	 * Using live audio mode for recorded audio can cause Discord to skip
+	 * audio data because Discord does not expect to receive, say, 3 minutes'
+	 * worth of audio data in 1 second.
+	 *
+	 * Use discord_voice_client::set_send_audio_type to change this value as
+	 * it ensures thread safety.
+	 */
+	enum send_audio_type_t
+	{
+	    satype_recorded_audio,
+	    satype_live_audio,
+	} send_audio_type = satype_recorded_audio;
+
+	/**
 	 * @brief Sets the gain for the specified user.
 	 *
 	 * Similar to the User Volume slider, controls the listening volume per user.
@@ -678,6 +706,13 @@ public:
 	 * @throw dpp::voice_exception if voice support is not compiled into D++
 	 */
 	discord_voice_client& send_silence(const uint64_t duration);
+
+	/**
+	 * @brief Sets the audio type that will be sent with send_audio_* methods.
+	 *
+	 * @see send_audio_type_t
+	 */
+	discord_voice_client& set_send_audio_type(send_audio_type_t type);
 
 	/**
 	 * @brief Set the timescale in nanoseconds.


### PR DESCRIPTION
# Issue

Was trying to send live audio data to a voice channel. Observed that the audio data has occasional silence and speed
changes. Determined that the sleep in `discord_voice_client::write_ready` contributed to the issue. However, it seems
that the sleep is useful for recorded data to simulate VoIP, so adding an option to effectively turn it on/off and enables
both use cases.

# Commit Message

```txt
So far, the primary use case for sending audio data has been sending
recorded audio, which usually has large chunks of data available
instantly. Built-in throttling simulates the VoIP behavior where data
becomes available over time.

For live audio, however, built-in throttling isn't necessary because
the throttling is already inherent in capturing live audio. Extra
throttling can cause delays in delivering the audio packets, which
can further cause occasional silence and allegedly lost packets on
the receiving end.

Adding an option to discord_voice_client so client can identify the
kind of audio data before sending, which effectively turns on/off the
built-in throttling in discord_voice_client.
```