### PR TITLE
Added voice action bitflag for guild_member fixed #417

### DIFF
--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -138,7 +138,8 @@ enum guild_flags_extra : uint8_t {
 };
 
 /**
- * @brief Various flags that can be used to indicate the status of a guild member
+ * @brief Various flags that can be used to indicate the status of a guild member.
+ * @note Use set_mute and set_deaf member functions and do not toggle the bits yourself.
  */
 enum guild_member_flags : uint8_t {
 	/** Member deafened in voice channels */
@@ -149,6 +150,8 @@ enum guild_member_flags : uint8_t {
 	gm_pending =		0b00100,
 	/** Member has animated guild-specific avatar */
 	gm_animated_avatar = 	0b01000,
+	/** gm_deaf or gm_mute has been toggled */
+	gm_voice_action = 			0b10000,
 };
 
 /**

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -108,11 +108,13 @@ guild_member& guild_member::set_nickname(const std::string& nick) {
 
 guild_member& guild_member::set_mute(const bool is_muted) {
 	this->flags = (is_muted) ? flags | gm_mute : flags & ~gm_mute;
+	this->flags |= gm_voice_action;
 	return *this;
 }
 
 guild_member& guild_member::set_deaf(const bool is_deafened) {
 	this->flags = (is_deafened) ? flags | gm_deaf : flags & ~gm_deaf;
+	this->flags |= gm_voice_action;
 	return *this;
 }
 
@@ -125,6 +127,7 @@ guild_member& guild_member::fill_from_json(nlohmann::json* j, snowflake g_id, sn
 	this->guild_id = g_id;
 	this->user_id = u_id;
 	j->get_to(*this);
+
 	return *this;
 }
 
@@ -200,8 +203,12 @@ std::string guild_member::build_json(bool with_id) const {
 			j["roles"].push_back(std::to_string(role));
 		}
 	}
-	j["mute"] = is_muted();
-	j["deaf"] = is_deaf();
+
+	if (flags & gm_voice_action) {
+		j["mute"] = is_muted();
+		j["deaf"] = is_deaf();
+	}
+
 	return j.dump();
 }
 


### PR DESCRIPTION
set_deaf and set_mute now set a bitflag, guild_member_update only sets deaf and mute parameters if the flag is on.
Provides a fix for the bug i found and that is described in #417 