### PR TITLE
fixed permissions getter like channel::get_user_permissions

### DIFF
--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -25,6 +25,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/voicestate.h>
+#include <dpp/guild.h>
 #include <dpp/nlohmann/json_fwd.hpp>
 #include <dpp/permissions.h>
 #include <dpp/json_interface.h>
@@ -389,8 +390,18 @@ public:
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
 	 * Note that if the user is not on the channel or the guild is
 	 * not in the cache, the function will always return 0.
+	 * @deprecated
 	 */
 	permission get_user_permissions(const class user* member) const;
+
+	/**
+	 * @brief Get the user permissions for a user on this channel including channel overwrites
+	 *
+	 * @param member The user to resolve the permissions for
+	 * @return permission Permissions bitmask made of bits in dpp::permissions.
+	 * Note that if the user is not on the channel, the function will always return 0.
+	 */
+	permission get_user_permissions(const guild_member* member) const;
 
 	/**
 	 * @brief Return a map of members on the channel, built from the guild's

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -397,11 +397,11 @@ public:
 	/**
 	 * @brief Get the user permissions for a user on this channel including channel overwrites
 	 *
-	 * @param member The user to resolve the permissions for
+	 * @param member The member to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * Note that if the user is not on the channel, the function will always return 0.
+	 * @note If the guild this channel belongs to is not in the cache, the function will always return 0.
 	 */
-	permission get_user_permissions(const guild_member* member) const;
+	permission get_member_overwrites(const guild_member* member) const;
 
 	/**
 	 * @brief Return a map of members on the channel, built from the guild's

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -25,7 +25,6 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/voicestate.h>
-#include <dpp/guild.h>
 #include <dpp/nlohmann/json_fwd.hpp>
 #include <dpp/permissions.h>
 #include <dpp/json_interface.h>
@@ -399,7 +398,7 @@ public:
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
 	 * @note If the guild this channel belongs to is not in the cache, the function will always return 0.
 	 */
-	permission get_member_overwrites(const guild_member* member) const;
+	permission get_member_overwrites(const class guild_member* member) const;
 
 	/**
 	 * @brief Return a map of members on the channel, built from the guild's
@@ -407,6 +406,7 @@ public:
 	 * Does not return reliable information for voice channels, use
 	 * dpp::channel::get_voice_members() instead for this.
 	 * @return A map of guild members keyed by user id.
+	 * @note If the guild this channel belongs to is not in the cache, the function will always return 0.
 	 */
 	std::map<snowflake, class guild_member*> get_members();
 

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -383,7 +383,7 @@ public:
 	std::string get_mention() const;
 
 	/**
-	 * @brief Get the user permissions for a user on this channel
+	 * @brief Get the user permissions for a user on this channel including channel overwrites
 	 * 
 	 * @param member The user to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -383,16 +383,17 @@ public:
 	std::string get_mention() const;
 
 	/**
-	 * @brief Get the user permissions for a member on this channel including channel overwrites
+	 * @brief Get the user permissions for a member on this channel, including channel overwrites.
 	 * 
 	 * @param user The user to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * @note If the guild member is not in cache, the method will always return 0.
+	 * @note The method will search for the guild member in the cache by the user id.
+	 * If the guild member is not in cache, the method will always return 0.
 	 */
 	permission get_user_permissions(const class user* user) const;
 
 	/**
-	 * @brief Get the user permissions for a member on this channel including channel overwrites
+	 * @brief Get the user permissions for a member on this channel, including channel overwrites.
 	 *
 	 * @param member The member to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -387,7 +387,7 @@ public:
 	 * 
 	 * @param user The user to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * @note If the guild member or the guild this channel belongs to is not in cache, the method will always return 0.
+	 * @note If the guild member is not in cache, the method will always return 0.
 	 */
 	permission get_user_permissions(const class user* user) const;
 
@@ -396,7 +396,6 @@ public:
 	 *
 	 * @param member The member to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * @note If the guild this channel belongs to is not in the cache, the function will always return 0.
 	 */
 	permission get_member_overwrites(const class guild_member* member) const;
 

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -383,22 +383,25 @@ public:
 	std::string get_mention() const;
 
 	/**
-	 * @brief Get the user permissions for a member on this channel, including channel overwrites.
+	 * @brief Get the user overall permissions for a member on this channel, including channel overwrites.
 	 * 
 	 * @param user The user to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * @note The method will search for the guild member in the cache by the user id.
+	 * @note Requires role cache to be enabled (it's enabled by default).
+	 *
+	 * @note The method will search for the guild member in the cache by the users id.
 	 * If the guild member is not in cache, the method will always return 0.
 	 */
 	permission get_user_permissions(const class user* user) const;
 
 	/**
-	 * @brief Get the user permissions for a member on this channel, including channel overwrites.
+	 * @brief Get the overall user permissions for a member on this channel, including channel overwrites.
 	 *
 	 * @param member The member to resolve the permissions for
-	 * @return permission Permissions bitmask made of bits in dpp::permissions.
+	 * @return The permission overwrites for the member. Made of bits in dpp::permissions.
+	 * @note Requires role cache to be enabled (it's enabled by default).
 	 */
-	permission get_member_overwrites(const class guild_member* member) const;
+	permission get_user_permissions(const class guild_member &member) const;
 
 	/**
 	 * @brief Return a map of members on the channel, built from the guild's

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -384,18 +384,16 @@ public:
 	std::string get_mention() const;
 
 	/**
-	 * @brief Get the user permissions for a user on this channel including channel overwrites
+	 * @brief Get the user permissions for a member on this channel including channel overwrites
 	 * 
-	 * @param member The user to resolve the permissions for
+	 * @param user The user to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.
-	 * Note that if the user is not on the channel or the guild is
-	 * not in the cache, the function will always return 0.
-	 * @deprecated
+	 * @note If the guild member or the guild this channel belongs to is not in cache, the method will always return 0.
 	 */
-	permission get_user_permissions(const class user* member) const;
+	permission get_user_permissions(const class user* user) const;
 
 	/**
-	 * @brief Get the user permissions for a user on this channel including channel overwrites
+	 * @brief Get the user permissions for a member on this channel including channel overwrites
 	 *
 	 * @param member The member to resolve the permissions for
 	 * @return permission Permissions bitmask made of bits in dpp::permissions.

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -904,7 +904,7 @@ public:
 	/**
 	 * @brief Called when a guild is deleted.
 	 * A guild can be deleted via the bot being kicked, the bot leaving the guild
-	 * explicitly with dpp::guild_delete, or via the guild being unavailable due to
+	 * explicitly with dpp::cluster::guild_delete, or via the guild being unavailable due to
 	 * an outage.
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
@@ -938,7 +938,7 @@ public:
 	
 	/**
 	 * @brief Called when a shard is connected and ready.
-	 * A set of on_guild_create events will follow this event.
+	 * A set of cluster::on_guild_create events will follow this event.
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
 	 * The function signature for this event takes a single `const` reference of type ready_t&, and returns void.
@@ -1006,7 +1006,7 @@ public:
 	
 	/**
 	 * @brief Called when a set of members is received for a guild.
-	 * D++ will request these for all new guilds if needed, after the on_guild_create
+	 * D++ will request these for all new guilds if needed, after the cluster::on_guild_create
 	 * events.
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
@@ -1220,7 +1220,7 @@ public:
 	
 	/**
 	 * @brief Called when a user is updated.
-	 * This is separate to guild_member_update and includes things such as an avatar change,
+	 * This is separate to cluster::on_guild_member_update and includes things such as an avatar change,
 	 * username change, discriminator change or change in subscription status for nitro.
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
@@ -1234,6 +1234,7 @@ public:
 	 * Note that D++ does not cache messages. If you want to cache these objects you
 	 * should create something yourself within your bot. Caching of messages is not on
 	 * the roadmap to be supported as it consumes excessive amounts of RAM.
+	 * For an example for caching of messages, please see \ref caching-messages
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
 	 * The function signature for this event takes a single `const` reference of type message_create_t&, and returns void.
@@ -1294,8 +1295,8 @@ public:
 
 	
 	/**
-	 * @brief Called when a thread is created
-	 * Note: Threads are not cached by D++, but a list of thread IDs is accessible in a guild object
+	 * @brief Called when a thread is created.
+	 * Note that threads are not cached by D++, but a list of thread IDs is accessible in a guild object
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
 	 * The function signature for this event takes a single `const` reference of type thread_create_t&, and returns void.
@@ -1322,8 +1323,8 @@ public:
 
 	
 	/**
-	 * @brief Called when thread list is synced (upon gaining access to a channel)
-	 * Note: Threads are not cached by D++, but a list of thread IDs is accessible in a guild object
+	 * @brief Called when thread list is synced (upon gaining access to a channel).
+	 * Note that threads are not cached by D++, but a list of thread IDs is accessible in a guild object
 	 *
 	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
 	 * The function signature for this event takes a single `const` reference of type thread_list_sync_t&, and returns void.
@@ -1398,7 +1399,7 @@ public:
 	 * @brief Called when packets are sent from the voice buffer.
 	 * The voice buffer contains packets that are already encoded with Opus and encrypted
 	 * with Sodium, and merged into packets by the repacketizer, which is done in the
-	 * dpp::discord_voice_client::send_audio method. You should use the buffer size properties
+	 * dpp::discord_voice_client::send_audio_opus method. You should use the buffer size properties
 	 * of dpp::voice_buffer_send_t to determine if you should fill the buffer with more
 	 * content.
 	 *

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1399,7 +1399,7 @@ public:
 	 * @brief Called when packets are sent from the voice buffer.
 	 * The voice buffer contains packets that are already encoded with Opus and encrypted
 	 * with Sodium, and merged into packets by the repacketizer, which is done in the
-	 * dpp::discord_voice_client::send_audio_opus method. You should use the buffer size properties
+	 * dpp::discord_voice_client::send_audio method. You should use the buffer size properties
 	 * of dpp::voice_buffer_send_t to determine if you should fill the buffer with more
 	 * content.
 	 *

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -556,7 +556,7 @@ public:
 	 * @param member member to get permissions for
 	 * @return permission permissions bitmask
 	 */
-	permission base_permissions(const guild_member& member) const;
+	permission base_permissions(const guild_member* member) const;
 
 	/**
 	 * @brief Get the permission overwrites for a member
@@ -579,7 +579,7 @@ public:
 	 * @param channel Channel to get permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
 	 */
-	permission permission_overwrites(const guild_member& member, const channel& channel) const;
+	permission permission_overwrites(const guild_member* member, const channel* channel) const;
 
 	/**
 	 * @brief Rehash members map

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -540,7 +540,7 @@ public:
 	std::string build_json(bool with_id = false) const;
 
 	/**
-	 * @brief Get the base permissions for a member on this guild,
+	 * @brief Compute the base permissions for a member on this guild,
 	 * before channel overwrites are applied.
 	 *
 	 * @param user User to get permissions for
@@ -551,7 +551,7 @@ public:
 	permission base_permissions(const class user* user) const;
 
 	/**
-	 * @brief Get the base permissions for a member on this guild,
+	 * @brief Compute the base permissions for a member on this guild,
 	 * before channel overwrites are applied.
 	 *
 	 * @param member member to get permissions for
@@ -560,12 +560,12 @@ public:
 	permission base_permissions(const guild_member* member) const;
 
 	/**
-	 * @brief Get the permission overwrites for a member in a channel.
+	 * @brief Compute the permission overwrites for a member in a channel, including base permissions.
 	 *
 	 * @param base_permissions base permissions before overwrites,
 	 * from channel::base_permissions
 	 * @param user User to resolve the permissions for
-	 * @param channel Channel to get permission overwrites for
+	 * @param channel Channel to compute permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
 	 * @note The method will search for the guild member in the cache by the user id.
 	 * If the guild member is not in cache, the method will always return 0.
@@ -573,10 +573,10 @@ public:
 	permission permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const;
 
 	/**
-	 * @brief Get the permission overwrites for a member in a channel.
+	 * @brief Compute the permission overwrites for a member in a channel, including base permissions.
 	 *
 	 * @param member Member to resolve the permissions for
-	 * @param channel Channel to get permission overwrites for
+	 * @param channel Channel to compute permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
 	 */
 	permission permission_overwrites(const guild_member* member, const channel* channel) const;

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -541,7 +541,7 @@ public:
 
 	/**
 	 * @brief Get the base permissions for a member on this guild,
-	 * before permission overwrites are applied.
+	 * before channel overwrites are applied.
 	 *
 	 * @param member member to get permissions for
 	 * @return permission permissions bitmask

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -543,11 +543,12 @@ public:
 	 * @brief Get the base permissions for a member on this guild,
 	 * before channel overwrites are applied.
 	 *
-	 * @param member member to get permissions for
+	 * @param user User to get permissions for
 	 * @return permission permissions bitmask
-	 * @deprecated
+	 * @note The method will search for the guild member in the cache by the user id.
+	 * If the guild member is not in cache, the method will always return 0.
 	 */
-	permission base_permissions(const class user* member) const;
+	permission base_permissions(const class user* user) const;
 
 	/**
 	 * @brief Get the base permissions for a member on this guild,
@@ -559,21 +560,20 @@ public:
 	permission base_permissions(const guild_member* member) const;
 
 	/**
-	 * @brief Get the permission overwrites for a member
-	 * merged into a bitmask.
+	 * @brief Get the permission overwrites for a member in a channel.
 	 *
 	 * @param base_permissions base permissions before overwrites,
 	 * from channel::base_permissions
-	 * @param member Member to resolve the permissions for
-	 * @param channel Channel to fetch permissions against
+	 * @param user User to resolve the permissions for
+	 * @param channel Channel to get permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
-	 * @deprecated
+	 * @note The method will search for the guild member in the cache by the user id.
+	 * If the guild member is not in cache, the method will always return 0.
 	 */
-	permission permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const;
+	permission permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const;
 
 	/**
-	 * @brief Get the permission overwrites for a member
-	 * merged into a bitmask.
+	 * @brief Get the permission overwrites for a member in a channel.
 	 *
 	 * @param member Member to resolve the permissions for
 	 * @param channel Channel to get permission overwrites for

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -542,10 +542,15 @@ public:
 	/**
 	 * @brief Compute the base permissions for a member on this guild,
 	 * before channel overwrites are applied.
+	 * This method takes into consideration the following cases:
+	 *   - Guild owner
+	 *   - Guild roles including \@everyone
 	 *
 	 * @param user User to get permissions for
 	 * @return permission permissions bitmask
-	 * @note The method will search for the guild member in the cache by the user id.
+	 * @note Requires role cache to be enabled (it's enabled by default).
+	 *
+	 * @note The method will search for the guild member in the cache by the users id.
 	 * If the guild member is not in cache, the method will always return 0.
 	 */
 	permission base_permissions(const class user* user) const;
@@ -553,11 +558,15 @@ public:
 	/**
 	 * @brief Compute the base permissions for a member on this guild,
 	 * before channel overwrites are applied.
+	 * This method takes into consideration the following cases:
+	 *   - Guild owner
+	 *   - Guild roles including \@everyone
 	 *
 	 * @param member member to get permissions for
 	 * @return permission permissions bitmask
+	 * @note Requires role cache to be enabled (it's enabled by default).
 	 */
-	permission base_permissions(const guild_member* member) const;
+	permission base_permissions(const guild_member &member) const;
 
 	/**
 	 * @brief Compute the permission overwrites for a member in a channel, including base permissions.
@@ -567,7 +576,9 @@ public:
 	 * @param user User to resolve the permissions for
 	 * @param channel Channel to compute permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
-	 * @note The method will search for the guild member in the cache by the user id.
+	 * @note Requires role cache to be enabled (it's enabled by default).
+	 *
+	 * @note The method will search for the guild member in the cache by the users id.
 	 * If the guild member is not in cache, the method will always return 0.
 	 */
 	permission permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const;
@@ -578,8 +589,9 @@ public:
 	 * @param member Member to resolve the permissions for
 	 * @param channel Channel to compute permission overwrites for
 	 * @return permission Merged permissions bitmask of overwrites.
+	 * @note Requires role cache to be enabled (it's enabled by default).
 	 */
-	permission permission_overwrites(const guild_member* member, const channel* channel) const;
+	permission permission_overwrites(const guild_member &member, const channel &channel) const;
 
 	/**
 	 * @brief Rehash members map

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -545,8 +545,18 @@ public:
 	 *
 	 * @param member member to get permissions for
 	 * @return permission permissions bitmask
+	 * @deprecated
 	 */
 	permission base_permissions(const class user* member) const;
+
+	/**
+	 * @brief Get the base permissions for a member on this guild,
+	 * before channel overwrites are applied.
+	 *
+	 * @param member member to get permissions for
+	 * @return permission permissions bitmask
+	 */
+	permission base_permissions(const guild_member& member) const;
 
 	/**
 	 * @brief Get the permission overwrites for a member
@@ -557,8 +567,19 @@ public:
 	 * @param member Member to resolve the permissions for
 	 * @param channel Channel to fetch permissions against
 	 * @return permission Merged permissions bitmask of overwrites.
+	 * @deprecated
 	 */
 	permission permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const;
+
+	/**
+	 * @brief Get the permission overwrites for a member
+	 * merged into a bitmask.
+	 *
+	 * @param member Member to resolve the permissions for
+	 * @param channel Channel to get permission overwrites for
+	 * @return permission Merged permissions bitmask of overwrites.
+	 */
+	permission permission_overwrites(const guild_member& member, const channel& channel) const;
 
 	/**
 	 * @brief Rehash members map

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -387,6 +387,15 @@ permission channel::get_user_permissions(const user* member) const
 	return g->permission_overwrites(g->base_permissions(member), member, this);
 }
 
+permission channel::get_user_permissions(const guild_member* member) const
+{
+	guild* g = dpp::find_guild(guild_id);
+	if (g == nullptr)
+		return 0;
+
+	return g->permission_overwrites(member, this);
+}
+
 std::map<snowflake, guild_member*> channel::get_members() {
 	std::map<snowflake, guild_member*> rv;
 	guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -389,6 +389,9 @@ permission channel::get_user_permissions(const user* member) const
 
 permission channel::get_member_overwrites(const guild_member* member) const
 {
+	if (member == nullptr)
+		return 0;
+
 	guild* g = dpp::find_guild(guild_id);
 	if (g == nullptr)
 		return 0;

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -375,8 +375,7 @@ std::string channel::build_json(bool with_id) const {
 	return j.dump();
 }
 
-permission channel::get_user_permissions(const user* user) const
-{
+permission channel::get_user_permissions(const user* user) const {
 	if (user == nullptr)
 		return 0;
 
@@ -387,8 +386,7 @@ permission channel::get_user_permissions(const user* user) const
 	return g->permission_overwrites(g->base_permissions(user), user, this);
 }
 
-permission channel::get_member_overwrites(const guild_member* member) const
-{
+permission channel::get_member_overwrites(const guild_member* member) const {
 	if (member == nullptr)
 		return 0;
 
@@ -404,7 +402,7 @@ std::map<snowflake, guild_member*> channel::get_members() {
 	guild* g = dpp::find_guild(guild_id);
 	if (g) {
 		for (auto m = g->members.begin(); m != g->members.end(); ++m) {
-			if (get_member_overwrites(&m->second) & p_view_channel) {
+			if (g->permission_overwrites(&m->second, this) & p_view_channel) {
 				rv[m->second.user_id] = &(m->second);
 			}
 		}

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -375,16 +375,16 @@ std::string channel::build_json(bool with_id) const {
 	return j.dump();
 }
 
-permission channel::get_user_permissions(const user* member) const
+permission channel::get_user_permissions(const user* user) const
 {
-	if (member == nullptr)
+	if (user == nullptr)
 		return 0;
 
 	guild* g = dpp::find_guild(guild_id);
 	if (g == nullptr)
 		return 0;
 
-	return g->permission_overwrites(g->base_permissions(member), member, this);
+	return g->permission_overwrites(g->base_permissions(user), user, this);
 }
 
 permission channel::get_member_overwrites(const guild_member* member) const

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -387,7 +387,7 @@ permission channel::get_user_permissions(const user* member) const
 	return g->permission_overwrites(g->base_permissions(member), member, this);
 }
 
-permission channel::get_user_permissions(const guild_member* member) const
+permission channel::get_member_overwrites(const guild_member* member) const
 {
 	guild* g = dpp::find_guild(guild_id);
 	if (g == nullptr)
@@ -401,11 +401,8 @@ std::map<snowflake, guild_member*> channel::get_members() {
 	guild* g = dpp::find_guild(guild_id);
 	if (g) {
 		for (auto m = g->members.begin(); m != g->members.end(); ++m) {
-			user* u = dpp::find_user(m->second.user_id);
-			if (u) {
-				if (get_user_permissions(u) & p_view_channel) {
-					rv[m->second.user_id] = &(m->second);
-				}
+			if (get_member_overwrites(&m->second) & p_view_channel) {
+				rv[m->second.user_id] = &(m->second);
 			}
 		}
 	}

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -386,15 +386,13 @@ permission channel::get_user_permissions(const user* user) const {
 	return g->permission_overwrites(g->base_permissions(user), user, this);
 }
 
-permission channel::get_member_overwrites(const guild_member* member) const {
-	if (member == nullptr)
-		return 0;
+permission channel::get_user_permissions(const guild_member &member) const {
 
 	guild* g = dpp::find_guild(guild_id);
 	if (g == nullptr)
 		return 0;
 
-	return g->permission_overwrites(member, this);
+	return g->permission_overwrites(member, *this);
 }
 
 std::map<snowflake, guild_member*> channel::get_members() {
@@ -402,7 +400,7 @@ std::map<snowflake, guild_member*> channel::get_members() {
 	guild* g = dpp::find_guild(guild_id);
 	if (g) {
 		for (auto m = g->members.begin(); m != g->members.end(); ++m) {
-			if (g->permission_overwrites(&m->second, this) & p_view_channel) {
+			if (g->permission_overwrites(m->second, *this) & p_view_channel) {
 				rv[m->second.user_id] = &(m->second);
 			}
 		}

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -565,15 +565,15 @@ permission guild::base_permissions(const user* member) const
 	return permissions;
 }
 
-permission guild::base_permissions(const guild_member &member) const {
-	if (owner_id == member.user_id)
+permission guild::base_permissions(const guild_member *member) const {
+	if (owner_id == member->user_id)
 		return ~0;
 
 	role* everyone = dpp::find_role(id);
 
 	permission permissions = everyone->permissions;
 
-	for (auto& rid : member.roles) {
+	for (auto& rid : member->roles) {
 		role* r = dpp::find_role(rid);
 		if (r) {
 			permissions |= r->permissions;
@@ -628,14 +628,14 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 	return permissions;
 }
 
-permission guild::permission_overwrites(const guild_member &member, const channel& channel) const {
+permission guild::permission_overwrites(const guild_member *member, const channel* channel) const {
 	permission base_permissions = this->base_permissions(member);
 
 	if (base_permissions & p_administrator)
 		return ~0;
 
 	permission permissions = base_permissions;
-	for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
+	for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
 		if (it->id == id && it->type == ot_role) {
 			permissions &= ~it->deny;
 			permissions |= it->allow;
@@ -643,21 +643,17 @@ permission guild::permission_overwrites(const guild_member &member, const channe
 		}
 	}
 
-	auto mi = members.find(member.user_id);
-	if (mi == members.end())
-		return 0;
-	guild_member gm = mi->second;
 	uint64_t allow = 0;
 	uint64_t deny = 0;
 
-	for (auto& rid : gm.roles) {
+	for (auto& rid : member->roles) {
 
 		/* Skip \@everyone, calculated above */
 		if (rid == id)
 			continue;
 
-		for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
-			if ((rid == it->id && it->type == ot_role) || (member.user_id == it->id && it->type == ot_member)) {
+		for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
+			if ((rid == it->id && it->type == ot_role) || (member->user_id == it->id && it->type == ot_member)) {
 				allow |= it->allow;
 				deny |= it->deny;
 				break;

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -543,31 +543,12 @@ permission guild::base_permissions(const user* user) const {
 	if (user == nullptr)
 		return 0;
 
-	if (owner_id == user->id)
-		return ~0; // return all permissions if it's the owner of the guild
-
-	role* everyone = dpp::find_role(id);
-	if (everyone == nullptr)
-		return 0;
-
 	auto mi = members.find(user->id);
 	if (mi == members.end())
 		return 0;
 	guild_member gm = mi->second;
 
-	permission permissions = everyone->permissions;
-
-	for (auto& rid : gm.roles) {
-		role* r = dpp::find_role(rid);
-		if (r) {
-			permissions |= r->permissions;
-		}
-	}
-
-	if (permissions & p_administrator)
-		return ~0;
-
-	return permissions;
+	return base_permissions(&gm);
 }
 
 permission guild::base_permissions(const guild_member *member) const {

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -539,15 +539,17 @@ std::string guild_widget::build_json(bool with_id) const {
 }
 
 
-permission guild::base_permissions(const user* user) const
-{
+permission guild::base_permissions(const user* user) const {
 	if (user == nullptr)
 		return 0;
 
 	if (owner_id == user->id)
-		return ~0; // owner of the guild
+		return ~0; // return all permissions if it's the owner of the guild
 
 	role* everyone = dpp::find_role(id);
+	if (everyone == nullptr)
+		return 0;
+
 	auto mi = members.find(user->id);
 	if (mi == members.end())
 		return 0;
@@ -573,9 +575,11 @@ permission guild::base_permissions(const guild_member *member) const {
 		return 0;
 
 	if (owner_id == member->user_id)
-		return ~0; // owner of the guild
+		return ~0; // return all permissions if it's the owner of the guild
 
 	role* everyone = dpp::find_role(id);
+	if (everyone == nullptr)
+		return 0;
 
 	permission permissions = everyone->permissions;
 
@@ -592,8 +596,7 @@ permission guild::base_permissions(const guild_member *member) const {
 	return permissions;
 }
 
-permission guild::permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const
-{
+permission guild::permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const {
 	if (user == nullptr || channel == nullptr)
 		return 0;
 
@@ -613,6 +616,7 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 	if (mi == members.end())
 		return 0;
 	guild_member gm = mi->second;
+
 	uint64_t allow = 0;
 	uint64_t deny = 0;
 

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -548,16 +548,14 @@ permission guild::base_permissions(const user* user) const {
 		return 0;
 	guild_member gm = mi->second;
 
-	return base_permissions(&gm);
+	return base_permissions(gm);
 }
 
-permission guild::base_permissions(const guild_member *member) const {
-	if (member == nullptr)
-		return 0;
+permission guild::base_permissions(const guild_member &member) const {
 
 	/* this method is written with the help of discord's pseudocode available here https://discord.com/developers/docs/topics/permissions#permission-overwrites */
 
-	if (owner_id == member->user_id)
+	if (owner_id == member.user_id)
 		return ~0; // return all permissions if it's the owner of the guild
 
 	role* everyone = dpp::find_role(id);
@@ -566,7 +564,7 @@ permission guild::base_permissions(const guild_member *member) const {
 
 	permission permissions = everyone->permissions;
 
-	for (auto& rid : member->roles) {
+	for (auto& rid : member.roles) {
 		role* r = dpp::find_role(rid);
 		if (r) {
 			permissions |= r->permissions;
@@ -639,9 +637,7 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 	return permissions;
 }
 
-permission guild::permission_overwrites(const guild_member *member, const channel* channel) const {
-	if (member == nullptr || channel == nullptr)
-		return 0;
+permission guild::permission_overwrites(const guild_member &member, const channel &channel) const {
 
 	permission base_permissions = this->base_permissions(member);
 
@@ -654,7 +650,7 @@ permission guild::permission_overwrites(const guild_member *member, const channe
 	permission permissions = base_permissions;
 
 	// find \@everyone role overwrite and apply it.
-	for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
+	for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
 		if (it->id == this->id && it->type == ot_role) {
 			permissions &= ~it->deny;
 			permissions |= it->allow;
@@ -666,13 +662,13 @@ permission guild::permission_overwrites(const guild_member *member, const channe
 	uint64_t allow = 0;
 	uint64_t deny = 0;
 
-	for (auto& rid : member->roles) {
+	for (auto& rid : member.roles) {
 
 		/* Skip \@everyone role to not break the hierarchy. It's calculated above */
 		if (rid == this->id)
 			continue;
 
-		for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
+		for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
 			if (rid == it->id && it->type == ot_role) {
 				deny |= it->deny;
 				allow |= it->allow;
@@ -685,8 +681,8 @@ permission guild::permission_overwrites(const guild_member *member, const channe
 	permissions |= allow;
 
 	// Apply member specific overwrite if exists.
-	for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
-		if (member->user_id == it->id && it->type == ot_member) {
+	for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
+		if (member.user_id == it->id && it->type == ot_member) {
 			permissions &= ~it->deny;
 			permissions |= it->allow;
 			break;

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -566,6 +566,9 @@ permission guild::base_permissions(const user* member) const
 }
 
 permission guild::base_permissions(const guild_member *member) const {
+	if (member == nullptr)
+		return 0;
+
 	if (owner_id == member->user_id)
 		return ~0;
 
@@ -629,6 +632,9 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 }
 
 permission guild::permission_overwrites(const guild_member *member, const channel* channel) const {
+	if (member == nullptr || channel == nullptr)
+		return 0;
+
 	permission base_permissions = this->base_permissions(member);
 
 	if (base_permissions & p_administrator)

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -539,13 +539,16 @@ std::string guild_widget::build_json(bool with_id) const {
 }
 
 
-permission guild::base_permissions(const user* member) const
+permission guild::base_permissions(const user* user) const
 {
-	if (owner_id == member->id)
-		return ~0;
+	if (user == nullptr)
+		return 0;
+
+	if (owner_id == user->id)
+		return ~0; // owner of the guild
 
 	role* everyone = dpp::find_role(id);
-	auto mi = members.find(member->id);
+	auto mi = members.find(user->id);
 	if (mi == members.end())
 		return 0;
 	guild_member gm = mi->second;
@@ -570,7 +573,7 @@ permission guild::base_permissions(const guild_member *member) const {
 		return 0;
 
 	if (owner_id == member->user_id)
-		return ~0;
+		return ~0; // owner of the guild
 
 	role* everyone = dpp::find_role(id);
 
@@ -589,8 +592,11 @@ permission guild::base_permissions(const guild_member *member) const {
 	return permissions;
 }
 
-permission guild::permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const
+permission guild::permission_overwrites(const uint64_t base_permissions, const user* user, const channel* channel) const
 {
+	if (user == nullptr || channel == nullptr)
+		return 0;
+
 	if (base_permissions & p_administrator)
 		return ~0;
 
@@ -603,7 +609,7 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 		}
 	}
 
-	auto mi = members.find(member->id);
+	auto mi = members.find(user->id);
 	if (mi == members.end())
 		return 0;
 	guild_member gm = mi->second;
@@ -617,7 +623,7 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 			continue;
 
 		for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
-			if ((rid == it->id && it->type == ot_role) || (member->id == it->id && it->type == ot_member)) {
+			if ((rid == it->id && it->type == ot_role) || (user->id == it->id && it->type == ot_member)) {
 				allow |= it->allow;
 				deny |= it->deny;
 				break;

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -565,6 +565,27 @@ permission guild::base_permissions(const user* member) const
 	return permissions;
 }
 
+permission guild::base_permissions(const guild_member &member) const {
+	if (owner_id == member.user_id)
+		return ~0;
+
+	role* everyone = dpp::find_role(id);
+
+	permission permissions = everyone->permissions;
+
+	for (auto& rid : member.roles) {
+		role* r = dpp::find_role(rid);
+		if (r) {
+			permissions |= r->permissions;
+		}
+	}
+
+	if (permissions & p_administrator)
+		return ~0;
+
+	return permissions;
+}
+
 permission guild::permission_overwrites(const uint64_t base_permissions, const user*  member, const channel* channel) const
 {
 	if (base_permissions & p_administrator)
@@ -594,6 +615,49 @@ permission guild::permission_overwrites(const uint64_t base_permissions, const u
 
 		for (auto it = channel->permission_overwrites.begin(); it != channel->permission_overwrites.end(); ++it) {
 			if ((rid == it->id && it->type == ot_role) || (member->id == it->id && it->type == ot_member)) {
+				allow |= it->allow;
+				deny |= it->deny;
+				break;
+			}
+		}
+	}
+
+	permissions &= ~deny;
+	permissions |= allow;
+
+	return permissions;
+}
+
+permission guild::permission_overwrites(const guild_member &member, const channel& channel) const {
+	permission base_permissions = this->base_permissions(member);
+
+	if (base_permissions & p_administrator)
+		return ~0;
+
+	permission permissions = base_permissions;
+	for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
+		if (it->id == id && it->type == ot_role) {
+			permissions &= ~it->deny;
+			permissions |= it->allow;
+			break;
+		}
+	}
+
+	auto mi = members.find(member.user_id);
+	if (mi == members.end())
+		return 0;
+	guild_member gm = mi->second;
+	uint64_t allow = 0;
+	uint64_t deny = 0;
+
+	for (auto& rid : gm.roles) {
+
+		/* Skip \@everyone, calculated above */
+		if (rid == id)
+			continue;
+
+		for (auto it = channel.permission_overwrites.begin(); it != channel.permission_overwrites.end(); ++it) {
+			if ((rid == it->id && it->type == ot_role) || (member.user_id == it->id && it->type == ot_member)) {
 				allow |= it->allow;
 				deny |= it->deny;
 				break;


### PR DESCRIPTION
The following permissions getters calculated the permissions wrong. Discord probably changed the permission hierarchy. However the methods didn't follow the correct permission hierarchy.
- `channel::get_user_permissions()`
- `guild::base_permissions()`
- `guild::permission_overwrites()`

btw some of them didn't checked for null pointer.

I also added the same getters with `guild_member` param and references instead of pointers, because the don't require the user cache then.
Im wondering why the old ones got the `user` param, as they're immediately searching for the guild member in cache and doesn't really need the user.
They all still requires the role cache as they go through the roles etc.

I also updated some comments in this pr :)

The whole thing is tested of course.

**Additional Content**
https://discord.com/developers/docs/topics/permissions#permission-overwrites