### PR TITLE
fix: make execute_webhook supports avatar

### DIFF
--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -78,12 +78,12 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"thread_id", thread_id},
 	});
 	std::string body;
-	if (!thread_name.empty()) { // only use json::parse if thread_name is set
-		json j = json::parse(m.build_json(false));
-		j["thread_name"] = thread_name;
-		body = j.dump();
-	}
-	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
+	json j = json::parse(m.build_json(false));
+	if (!thread_name.empty()) j["thread_name"] = thread_name;
+	if (!wh.name.empty()) j["username"] = wh.name;
+	if (!wh.avatar.empty()) j["avatar_url"] = wh.avatar;
+	body = j.dump();
+	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token : token) + parameters, m_post, body, [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}


### PR DESCRIPTION
1. It wasn't possible to edit webhook to change avatar, so edited it to use `wh.avatar`
2. This will override message.author.username if `wh.name` present