### PR TITLE
Automod REST endpoints, websocket events, JSON structures

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -77,7 +77,8 @@
 		"gifv",
 		"ctls",
 		"ctest",
-		"automod"
+		"automod",
+		"amod"
 	],
 	"flagWords": [
 		"hte"

--- a/.cspell.json
+++ b/.cspell.json
@@ -76,7 +76,8 @@
 		"followup",
 		"gifv",
 		"ctls",
-		"ctest"
+		"ctest",
+		"automod"
 	],
 	"flagWords": [
 		"hte"

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -29,34 +29,91 @@
 
 namespace dpp {
 
+/**
+ * @brief Possible types of preset filter lists
+ */
 enum automod_preset_type : uint8_t {
+	/**
+	 * @brief Strong swearing
+	 */
 	amod_preset_profanity = 1,
+	/**
+	 * @brief Sexual phrases and words
+	 */
 	amod_preset_sexual_content = 2,
+	/**
+	 * @brief Racial and other slurs, hate speech
+	 */
 	amod_preset_slurs = 3,
 };
 
+/**
+ * @brief Action types to perform on filtering
+ */
 enum automod_action_type : uint8_t {
+	/**
+	 * @brief Block the message
+	 */
 	amod_action_block_message = 1,
+	/**
+	 * @brief Send an alert to a given channel
+	 */
 	amod_action_send_alert = 2,
+	/**
+	 * @brief time out the user
+	 */
 	amod_action_timeout = 3,
 };
 
+/**
+ * @brief Event types, only message send is currently supported
+ */
 enum automod_event_type : uint8_t {
-	/// Trigger on message send
+	/**
+	 * @brief Trigger on message send
+	 */
 	amod_message_send = 1,
 };
 
+/**
+ * @brief Types of moderation to trigger
+ */
 enum automod_trigger_type : uint8_t {
+	/**
+	 * @brief Keyword filtering
+	 */
 	amod_type_keyword = 1,
+	/**
+	 * @brief Harmful/malware links
+	 */
 	amod_type_harmful_link = 2,
+	/**
+	 * @brief Spamming
+	 */
 	amod_type_spam = 3,
+	/**
+	 * @brief Preset lists of filter words
+	 */
 	amod_type_keyword_preset = 4,
 };
 
+/**
+ * @brief Metadata associated with an automod action
+ */
 struct DPP_EXPORT automod_metadata : public json_interface<automod_metadata> {
+	/**
+	 * @brief Keywords to moderate
+	 */
 	std::vector<std::string> keywords;
+	/**
+	 * @brief Preset keyword list types to moderate
+	 * @see automod_preset_type
+	 */
 	std::vector<automod_preset_type> presets;
 
+	/**
+	 * @brief Destroy the automod metadata object
+	 */
 	virtual ~automod_metadata();
 
 	/**
@@ -76,13 +133,34 @@ struct DPP_EXPORT automod_metadata : public json_interface<automod_metadata> {
 
 };
 
+/**
+ * @brief Represents an automod action
+ */
 struct DPP_EXPORT automod_action : public json_interface<automod_action> {
+	/**
+	 * @brief Type of action to take
+	 */
 	automod_action_type type;
+
+	/**
+	 * @brief Channel ID, for type amod_action_send_alert
+	 */
 	snowflake channel_id;
+
+	/**
+	 * @brief Silence duration in seconds, for amod_action_timeout
+	 * 
+	 */
 	int32_t duration_seconds;
 
+	/**
+	 * @brief Construct a new automod action object
+	 */
 	automod_action();
 
+	/**
+	 * @brief Destroy the automod action object
+	 */
 	virtual ~automod_action();
 
 	/**
@@ -101,22 +179,65 @@ struct DPP_EXPORT automod_action : public json_interface<automod_action> {
 	virtual std::string build_json(bool with_id = false) const;
 };
 
+/**
+ * @brief Represnets an automod rule
+ */
 class DPP_EXPORT automod_rule : public managed, public json_interface<automod_rule> {
 public:
-	snowflake       	id;		//!< the id of this rule
-	snowflake       	guild_id;	//!< the guild which this rule belongs to
-	std::string     	name;		//!< the rule name
-	snowflake       	creator_id;	//!< the user which first created this rule
-	automod_event_type	event_type;	//!< the rule event type
-	automod_trigger_type	trigger_type;	//!< the rule trigger type
-	automod_metadata	trigger_metadata;//!< the rule trigger metadata
-	std::vector<automod_action> actions;	//!< the actions which will execute when the rule is triggered
-	bool			enabled;	//!< whether the rule is enabled
-	std::vector<snowflake>	exempt_roles;	//!< the role ids that should not be affected by the rule (Maximum of 20)
-	std::vector<snowflake>	exempt_channels;//!< the channel ids that should not be affected by the rule (Maximum of 50)
+	/**
+	 * @brief the id of this rule
+	 */
+	snowflake       	id;
+	/**
+	 * @brief the guild which this rule belongs to
+	 */
+	snowflake       	guild_id;
+	/**
+	 * @brief the rule name
+	 */
+	std::string     	name;
+	/**
+	 * @brief The user which first created this rule
+	 */
+	snowflake       	creator_id;
+	/**
+	 * @brief The rule event type
+	 */
+	automod_event_type	event_type;
+	/**
+	 * @brief The rule trigger type
+	 */
+	automod_trigger_type	trigger_type;
+	/**
+	 * @brief The rule trigger metadata
+	 * 
+	 */
+	automod_metadata	trigger_metadata;
+	/**
+	 * @brief the actions which will execute when the rule is triggered
+	 */
+	std::vector<automod_action> actions;
+	/**
+	 * @brief Whether the rule is enabled
+	 */
+	bool			enabled;
+	/**
+	 * @brief the role ids that should not be affected by the rule (Maximum of 20)
+	 */
+	std::vector<snowflake>	exempt_roles;
+	/**
+	 * @brief the channel ids that should not be affected by the rule (Maximum of 50)
+	 */
+	std::vector<snowflake>	exempt_channels;
 
+	/**
+	 * @brief Construct a new automod rule object
+	 */
 	automod_rule();
 
+	/**
+	 * @brief Destroy the automod rule object
+	 */
 	virtual ~automod_rule();
 
 	/**

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -1,0 +1,142 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+
+#pragma once
+#include <dpp/export.h>
+#include <dpp/snowflake.h>
+#include <dpp/managed.h>
+#include <dpp/utility.h>
+#include <dpp/nlohmann/json_fwd.hpp>
+#include <dpp/json_interface.h>
+
+namespace dpp {
+
+enum automod_preset_type : uint8_t {
+	amod_preset_profanity = 1,
+	amod_preset_sexual_content = 2,
+	amod_preset_slurs = 3,
+};
+
+enum automod_action_type : uint8_t {
+	amod_action_block_message = 1,
+	amod_action_send_alert = 2,
+	amod_action_timeout = 3,
+};
+
+enum automod_event_type : uint8_t {
+	/// Trigger on message send
+	amod_message_send = 1,
+};
+
+enum automod_trigger_type : uint8_t {
+	amod_type_keyword = 1,
+	amod_type_harmful_link = 2,
+	amod_type_spam = 3,
+	amod_type_keyword_preset = 4,
+};
+
+struct DPP_EXPORT automod_metadata : public json_interface<automod_metadata> {
+	std::vector<std::string> keyword_filter;
+	std::vector<automod_preset_type> keyword_preset_types;
+
+	virtual ~automod_metadata();
+
+	/**
+	 * @brief Fill object properties from JSON
+	 *
+	 * @param j JSON to fill from
+	 * @return automod_metadata& Reference to self
+	 */
+	automod_metadata& fill_from_json(nlohmann::json* j);
+
+	/**
+	 * @brief Build a json string for this object
+	 *
+	 * @return std::string JSON string
+	 */
+	virtual std::string build_json(bool with_id = false) const;
+
+};
+
+struct DPP_EXPORT automod_action : public json_interface<automod_action> {
+	automod_action_type type;
+	snowflake channel_id;
+	int32_t duration_seconds;
+
+	automod_action();
+
+	virtual ~automod_action();
+
+	/**
+	 * @brief Fill object properties from JSON
+	 *
+	 * @param j JSON to fill from
+	 * @return automod_action& Reference to self
+	 */
+	automod_action& fill_from_json(nlohmann::json* j);
+
+	/**
+	 * @brief Build a json string for this object
+	 *
+	 * @return std::string JSON string
+	 */
+	virtual std::string build_json(bool with_id = false) const;
+};
+
+class DPP_EXPORT automod_rule : public managed, public json_interface<automod_rule> {
+public:
+	snowflake       	id;		//!< the id of this rule
+	snowflake       	guild_id;	//!< the guild which this rule belongs to
+	std::string     	name;		//!< the rule name
+	snowflake       	creator_id;	//!< the user which first created this rule
+	automod_event_type	event_type;	//!< the rule event type
+	automod_trigger_type	trigger_type;	//!< the rule trigger type
+	automod_metadata	trigger_metadata;//!< the rule trigger metadata
+	std::vector<automod_action> actions;	//!< the actions which will execute when the rule is triggered
+	bool			enabled;	//!< whether the rule is enabled
+	std::vector<snowflake>	exempt_roles;	//!< the role ids that should not be affected by the rule (Maximum of 20)
+	std::vector<snowflake>	exempt_channels;//!< the channel ids that should not be affected by the rule (Maximum of 50)
+
+	automod_rule();
+
+	virtual ~automod_rule();
+
+	/**
+	 * @brief Fill object properties from JSON
+	 *
+	 * @param j JSON to fill from
+	 * @return automod_rule& Reference to self
+	 */
+	automod_rule& fill_from_json(nlohmann::json* j);
+
+	/**
+	 * @brief Build a json string for this object
+	 *
+	 * @return std::string JSON string
+	 */
+	virtual std::string build_json(bool with_id = false) const;
+};
+
+/** A group of automod rules.
+ */
+typedef std::unordered_map<snowflake, automod_rule> automod_rule_map;
+
+};

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -54,8 +54,8 @@ enum automod_trigger_type : uint8_t {
 };
 
 struct DPP_EXPORT automod_metadata : public json_interface<automod_metadata> {
-	std::vector<std::string> keyword_filter;
-	std::vector<automod_preset_type> keyword_preset_types;
+	std::vector<std::string> keywords;
+	std::vector<automod_preset_type> presets;
 
 	virtual ~automod_metadata();
 

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -186,7 +186,9 @@ typedef std::variant<
 		scheduled_event,
 		scheduled_event_map,
 		event_member,
-		event_member_map
+		event_member_map,
+		automod_rule,
+		automod_rule_map
 	> confirmable_t;
 
 /**
@@ -3583,6 +3585,55 @@ public:
 	 * On success the callback will contain a dpp::scheduled_event object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void user_set_voice_state(snowflake user_id, snowflake guild_id, snowflake channel_id, bool suppress = false, command_completion_event_t callback = utility::log_error());
+
+	/**
+	 * @brief Get all auto moderation rules for a guild
+	 * 
+	 * @param guild_id Guild id of the auto moderation rule
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::automod_rule_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void automod_rules_get(snowflake guild_id, command_completion_event_t callback);
+
+	/**
+	 * @brief Get a single auto moderation rule
+	 * 
+	 * @param guild_id Guild id of the auto moderation rule
+	 * @param rule_id  Rule id to retrieve
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::automod_rule object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void automod_rule_get(snowflake guild_id, snowflake rule_id, command_completion_event_t callback);
+
+	/**
+	 * @brief Create an auto moderation rule
+	 * 
+	 * @param guild_id Guild id of the auto moderation rule
+	 * @param r Auto moderation rule to create
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::automod_rule object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void automod_rule_create(snowflake guild_id, const automod_rule& r, command_completion_event_t callback = utility::log_error());
+
+	/**
+	 * @brief Edit an auto moderation rule
+	 * 
+	 * @param guild_id Guild id of the auto moderation rule
+	 * @param r Auto moderation rule to edit. The rule's id must be set.
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::automod_rule object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void automod_rule_edit(snowflake guild_id, const automod_rule& r, command_completion_event_t callback = utility::log_error());
+
+	/**
+	 * @brief Delete an auto moderation rule
+	 * 
+	 * @param guild_id Guild id of the auto moderation rule
+	 * @param rule_id Auto moderation rule id to delete
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void automod_rule_delete(snowflake guild_id, snowflake rule_id, command_completion_event_t callback = utility::log_error());
 
 #include <dpp/cluster_sync_calls.h>
 

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1151,7 +1151,39 @@ public:
 	 */
 	event_router_t<webhooks_update_t> on_webhooks_update;
 
+	/**
+	 * @brief Called when a new automod rule is created.
+	 *
+	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
+	 * The function signature for this event takes a single `const` reference of type automod_rule_create_t&, and returns void.
+	 */
+	event_router_t<automod_rule_create_t> on_automod_rule_create;
+
+
+	/**
+	 * @brief Called when an automod rule is updated.
+	 *
+	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
+	 * The function signature for this event takes a single `const` reference of type automod_rule_update_t&, and returns void.
+	 */
+	event_router_t<automod_rule_update_t> on_automod_rule_update;
 	
+	/**
+	 * @brief Called when an automod rule is deleted.
+	 *
+	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
+	 * The function signature for this event takes a single `const` reference of type automod_rule_delete_t&, and returns void.
+	 */
+	event_router_t<automod_rule_delete_t> on_automod_rule_delete;
+
+	/**
+	 * @brief Called when an automod rule is triggered/executed.
+	 *
+	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
+	 * The function signature for this event takes a single `const` reference of type automod_rule_execute_t&, and returns void.
+	 */
+	event_router_t<automod_rule_execute_t> on_automod_rule_execute;
+
 	/**
 	 * @brief Called when a new member joins a guild.
 	 *

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -368,6 +368,70 @@ confirmation interaction_followup_edit_sync(const std::string &token, const mess
 message interaction_followup_get_sync(const std::string &token, snowflake message_id);
 
 /**
+ * @brief Get all auto moderation rules for a guild
+ * 
+ * @param guild_id Guild id of the auto moderation rule
+ * @return automod_rule_map returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+automod_rule_map automod_rules_get_sync(snowflake guild_id);
+
+/**
+ * @brief Get a single auto moderation rule
+ * 
+ * @param guild_id Guild id of the auto moderation rule
+ * @param rule_id  Rule id to retrieve
+ * @return automod_rule returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+automod_rule automod_rule_get_sync(snowflake guild_id, snowflake rule_id);
+
+/**
+ * @brief Create an auto moderation rule
+ * 
+ * @param guild_id Guild id of the auto moderation rule
+ * @param r Auto moderation rule to create
+ * @return automod_rule returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+automod_rule automod_rule_create_sync(snowflake guild_id, const automod_rule& r);
+
+/**
+ * @brief Edit an auto moderation rule
+ * 
+ * @param guild_id Guild id of the auto moderation rule
+ * @param r Auto moderation rule to edit. The rule's id must be set.
+ * @return automod_rule returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+automod_rule automod_rule_edit_sync(snowflake guild_id, const automod_rule& r);
+
+/**
+ * @brief Delete an auto moderation rule
+ * 
+ * @param guild_id Guild id of the auto moderation rule
+ * @param rule_id Auto moderation rule id to delete
+ * @return confirmation returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+confirmation automod_rule_delete_sync(snowflake guild_id, snowflake rule_id);
+
+/**
  * @brief Create a channel
  * 
  * Create a new channel object for the guild. Requires the `MANAGE_CHANNELS` permission. If setting permission overwrites,

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -31,6 +31,7 @@
 #include <dpp/invite.h>
 #include <dpp/emoji.h>
 #include <dpp/ban.h>
+#include <dpp/automod.h>
 #include <dpp/webhook.h>
 #include <dpp/presence.h>
 #include <dpp/message.h>
@@ -229,6 +230,58 @@ struct DPP_EXPORT guild_scheduled_event_delete_t : public event_dispatch_t {
 	 * @brief deleted event
 	 */
 	scheduled_event deleted;
+};
+
+/** @brief Create automod rule */
+struct DPP_EXPORT automod_rule_create_t : public event_dispatch_t {
+	/** Constructor
+	 * @param client The shard the event originated on. CAN BE NULL
+	 * for log events originating from the cluster object
+	 * @param raw Raw event text as JSON
+	 */
+	automod_rule_create_t(class discord_client* client, const std::string& raw);
+	/**
+	 * @brief updated event
+	 */
+	automod_rule created;
+};
+
+/** @brief Update automod rule */
+struct DPP_EXPORT automod_rule_update_t : public event_dispatch_t {
+	/** Constructor
+	 * @param client The shard the event originated on. CAN BE NULL
+	 * for log events originating from the cluster object
+	 * @param raw Raw event text as JSON
+	 */
+	automod_rule_update_t(class discord_client* client, const std::string& raw);
+	/**
+	 * @brief updated event
+	 */
+	automod_rule updated;
+};
+
+/** @brief Delete automod rule */
+struct DPP_EXPORT automod_rule_delete_t : public event_dispatch_t {
+	/** Constructor
+	 * @param client The shard the event originated on. CAN BE NULL
+	 * for log events originating from the cluster object
+	 * @param raw Raw event text as JSON
+	 */
+	automod_rule_delete_t(class discord_client* client, const std::string& raw);
+	/**
+	 * @brief updated event
+	 */
+	automod_rule deleted;
+};
+
+/** @brief Execute/trigger automod rule */
+struct DPP_EXPORT automod_rule_execute_t : public event_dispatch_t {
+	/** Constructor
+	 * @param client The shard the event originated on. CAN BE NULL
+	 * for log events originating from the cluster object
+	 * @param raw Raw event text as JSON
+	 */
+	automod_rule_execute_t(class discord_client* client, const std::string& raw);
 };
 
 

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -282,6 +282,18 @@ struct DPP_EXPORT automod_rule_execute_t : public event_dispatch_t {
 	 * @param raw Raw event text as JSON
 	 */
 	automod_rule_execute_t(class discord_client* client, const std::string& raw);
+
+	snowflake		guild_id;			//!< the id of the guild in which action was executed
+	automod_action		action;				//!< the action which was executed
+	snowflake		rule_id;			//!< the id of the rule which action belongs to
+	automod_trigger_type	rule_trigger_type;		//!< the trigger type of rule which was triggered
+	snowflake		user_id;			//!< the id of the user which generated the content which triggered the rule
+	snowflake		channel_id;			//!< Optional: the id of the channel in which user content was posted
+	snowflake		message_id;			//!< Optional: the id of any user message which content belongs to
+	snowflake		alert_system_message_id;	//!< Optional: the id of any system auto moderation messages posted as a result of this action
+	std::string		content;			//!< the user generated text content
+	std::string		matched_keyword;		//!< the word or phrase configured in the rule that triggered the rule (may be empty)
+	std::string		matched_content;		//!< the substring in content that triggered the rule (may be empty)
 };
 
 

--- a/include/dpp/event.h
+++ b/include/dpp/event.h
@@ -142,4 +142,10 @@ event_decl(guild_scheduled_event_delete,GUILD_SCHEDULED_EVENT_DELETE);
 event_decl(guild_scheduled_event_user_add,GUILD_SCHEDULED_EVENT_USER_ADD);
 event_decl(guild_scheduled_event_user_remove,GUILD_SCHEDULED_EVENT_USER_REMOVE);
 
+/* Auto moderation */
+event_decl(automod_rule_create, AUTO_MODERATION_RULE_CREATE);
+event_decl(automod_rule_update, AUTO_MODERATION_RULE_UPDATE);
+event_decl(automod_rule_delete, AUTO_MODERATION_RULE_DELETE);
+event_decl(automod_rule_execute, AUTO_MODERATION_ACTION_EXECUTION);
+
 }};

--- a/include/dpp/intents.h
+++ b/include/dpp/intents.h
@@ -66,8 +66,15 @@ enum intents {
 	i_guild_scheduled_events	= (1 << 16),
 	/// Auto moderation configuration
 	i_auto_moderation_configuration	= (1 << 20),
+	/// Auto moderation configuration
+	i_auto_moderation_execution	= (1 << 21),
 	/// Default D++ intents (all non-privileged intents)
-	i_default_intents		= dpp::i_guilds | dpp::i_guild_bans | dpp::i_guild_emojis | dpp::i_guild_integrations | dpp::i_guild_webhooks | dpp::i_guild_invites | dpp::i_guild_voice_states | dpp::i_guild_messages | dpp::i_guild_message_reactions | dpp::i_guild_message_typing | dpp::i_direct_messages | dpp::i_direct_message_typing | dpp::i_direct_message_reactions | dpp::i_guild_scheduled_events | dpp::i_auto_moderation_configuration, 
+	i_default_intents		= dpp::i_guilds | dpp::i_guild_bans | dpp::i_guild_emojis | dpp::i_guild_integrations |
+					dpp::i_guild_webhooks | dpp::i_guild_invites | dpp::i_guild_voice_states |
+					dpp::i_guild_messages | dpp::i_guild_message_reactions | dpp::i_guild_message_typing |
+					dpp::i_direct_messages | dpp::i_direct_message_typing | dpp::i_direct_message_reactions |
+					dpp::i_guild_scheduled_events | dpp::i_auto_moderation_configuration |
+					dpp::i_auto_moderation_execution, 
 	/// Privileged intents requiring ID
 	i_privileged_intents		= dpp::i_guild_members | dpp::i_guild_presences | dpp::i_message_content,
 	/// Every single intent

--- a/include/dpp/intents.h
+++ b/include/dpp/intents.h
@@ -64,8 +64,10 @@ enum intents {
 	i_message_content		= (1 << 15),
 	/// Scheduled events
 	i_guild_scheduled_events	= (1 << 16),
+	/// Auto moderation configuration
+	i_auto_moderation_configuration	= (1 << 20),
 	/// Default D++ intents (all non-privileged intents)
-	i_default_intents		= dpp::i_guilds | dpp::i_guild_bans | dpp::i_guild_emojis | dpp::i_guild_integrations | dpp::i_guild_webhooks | dpp::i_guild_invites | dpp::i_guild_voice_states | dpp::i_guild_messages | dpp::i_guild_message_reactions | dpp::i_guild_message_typing | dpp::i_direct_messages | dpp::i_direct_message_typing | dpp::i_direct_message_reactions | dpp::i_guild_scheduled_events,
+	i_default_intents		= dpp::i_guilds | dpp::i_guild_bans | dpp::i_guild_emojis | dpp::i_guild_integrations | dpp::i_guild_webhooks | dpp::i_guild_invites | dpp::i_guild_voice_states | dpp::i_guild_messages | dpp::i_guild_message_reactions | dpp::i_guild_message_typing | dpp::i_direct_messages | dpp::i_direct_message_typing | dpp::i_direct_message_reactions | dpp::i_guild_scheduled_events | dpp::i_auto_moderation_configuration, 
 	/// Privileged intents requiring ID
 	i_privileged_intents		= dpp::i_guild_members | dpp::i_guild_presences | dpp::i_message_content,
 	/// Every single intent

--- a/src/dpp/automod.cpp
+++ b/src/dpp/automod.cpp
@@ -1,0 +1,98 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/discordevents.h>
+#include <dpp/nlohmann/json.hpp>
+
+namespace dpp {
+
+using json = nlohmann::json;
+
+automod_action::automod_action() : channel_id(0), duration_seconds(0)
+{
+}
+
+automod_action::~automod_action() = default;
+
+automod_action& automod_action::fill_from_json(nlohmann::json* j) {
+	type = (automod_action_type)uint8_not_null(j, "type");
+	switch (type) {
+		case amod_action_send_alert:
+			channel_id = snowflake_not_null(&((*j)["metadata"]), "channel_id");
+			break;
+		case amod_action_timeout:
+			duration_seconds = int32_not_null(&((*j)["metadata"]), "duration_seconds");
+			break;
+	}
+	if (j->contains("user")) {
+		json & user = (*j)["user"];
+		user_id = snowflake_not_null(&user, "id");
+	}
+	return *this;
+}
+
+std::string automod_action::build_json(bool with_id) const {
+	json j({
+		{ "type", type }
+	});
+	switch (type) {
+		case amod_action_send_alert:
+			if (channel_id) {
+				j["metadata"] = json::object();
+				j["metadata"]["channel_id"] = std::to_string(channel_id);
+			}
+			break;
+		case amod_action_timeout:
+			if (duration_seconds) {
+				j["metadata"] = json::object();
+				j["metadata"]["duration_seconds"] = duration_seconds;
+			}
+			break;
+	}
+	return j.dump();
+}
+
+automod_metadata::~automod_metadata() = default;
+
+automod_metadata& automod_metadata::fill_from_json(nlohmann::json* j) {
+	return *this;
+}
+
+std::string automod_metadata::build_json(bool with_id) const {
+	return "{}";
+}
+
+automod_rule::automod_rule() : managed(), guild_id(0), creator_id(0), event_type(amod_message_send), trigger_type(amod_type_keyword), enabled(true)
+{
+}
+
+automod_action::~automod_action() = default;
+
+automod_action& ban::fill_from_json(nlohmann::json* j) {
+	return *this;
+}
+
+std::string automod_action::build_json(bool with_id) const {
+	return "{}";
+}
+
+};
+

--- a/src/dpp/automod.cpp
+++ b/src/dpp/automod.cpp
@@ -33,7 +33,7 @@ automod_action::automod_action() : channel_id(0), duration_seconds(0)
 automod_action::~automod_action() = default;
 
 automod_action& automod_action::fill_from_json(nlohmann::json* j) {
-	type = (automod_action_type)uint8_not_null(j, "type");
+	type = (automod_action_type)int8_not_null(j, "type");
 	switch (type) {
 		case amod_action_send_alert:
 			channel_id = snowflake_not_null(&((*j)["metadata"]), "channel_id");
@@ -41,11 +41,9 @@ automod_action& automod_action::fill_from_json(nlohmann::json* j) {
 		case amod_action_timeout:
 			duration_seconds = int32_not_null(&((*j)["metadata"]), "duration_seconds");
 			break;
-	}
-	if (j->contains("user")) {
-		json & user = (*j)["user"];
-		user_id = snowflake_not_null(&user, "id");
-	}
+		default:
+			break;
+	};
 	return *this;
 }
 
@@ -66,13 +64,21 @@ std::string automod_action::build_json(bool with_id) const {
 				j["metadata"]["duration_seconds"] = duration_seconds;
 			}
 			break;
-	}
+		default:
+			break;
+	};
 	return j.dump();
 }
 
 automod_metadata::~automod_metadata() = default;
 
 automod_metadata& automod_metadata::fill_from_json(nlohmann::json* j) {
+	for (auto k : (*j)["keyword_filter"]) {
+		keywords.push_back(k);
+	}
+	for (auto k : (*j)["presets"]) {
+		presets.push_back((automod_preset_type)k.get<uint32_t>());
+	}
 	return *this;
 }
 
@@ -84,13 +90,13 @@ automod_rule::automod_rule() : managed(), guild_id(0), creator_id(0), event_type
 {
 }
 
-automod_action::~automod_action() = default;
+automod_rule::~automod_rule() = default;
 
-automod_action& ban::fill_from_json(nlohmann::json* j) {
+automod_rule& automod_rule::fill_from_json(nlohmann::json* j) {
 	return *this;
 }
 
-std::string automod_action::build_json(bool with_id) const {
+std::string automod_rule::build_json(bool with_id) const {
 	return "{}";
 }
 

--- a/src/dpp/cluster/automod.cpp
+++ b/src/dpp/cluster/automod.cpp
@@ -1,0 +1,46 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/restrequest.h>
+
+namespace dpp {
+
+void cluster::automod_rules_get(snowflake guild_id, command_completion_event_t callback) {
+	rest_request_list<automod_rule>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules", m_get, "", callback);
+}
+
+void cluster::automod_rule_get(snowflake guild_id, snowflake rule_id, command_completion_event_t callback) {
+	rest_request<automod_rule>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules/" + std::to_string(rule_id), m_get, "", callback);
+}
+
+void cluster::automod_rule_create(snowflake guild_id, const automod_rule& r, command_completion_event_t callback) {
+	rest_request<automod_rule>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules", m_post, r.build_json(), callback);
+}
+
+void cluster::automod_rule_edit(snowflake guild_id, const automod_rule& r, command_completion_event_t callback) {
+	rest_request<automod_rule>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules/" + std::to_string(r.id), m_patch, r.build_json(true), callback);
+}
+
+void cluster::automod_rule_delete(snowflake guild_id, snowflake rule_id, command_completion_event_t callback) {
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules/" + std::to_string(rule_id), m_delete, "", callback);
+}
+
+};

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -78,9 +78,19 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"thread_id", thread_id},
 	});
 	std::string body;
-	if (!thread_name.empty()) { // only use json::parse if thread_name is set
+	if (!thread_name.empty() || wh.image_data || wh.avatar || !wh.name.empty()) { // only use json::parse if thread_name is set
 		json j = json::parse(m.build_json(false));
-		j["thread_name"] = thread_name;
+		if (!thread_name.empty()) {
+			j["thread_name"] = thread_name;
+		}
+		if (wh.avatar) {
+			j["avatar_url"] = wh.avatar;
+		} else if (wh.image_data) {
+			j["avatar_url"] = *image_data;
+		}
+		if (!wh.name.empty()) {
+			j["username"] = wh.name;
+		}
 		body = j.dump();
 	}
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -78,15 +78,15 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"thread_id", thread_id},
 	});
 	std::string body;
-	if (!thread_name.empty() || wh.image_data || wh.avatar || !wh.name.empty()) { // only use json::parse if thread_name is set
+	if (!thread_name.empty() || wh.image_data || !wh.avatar.empty() || !wh.name.empty()) { // only use json::parse if thread_name is set
 		json j = json::parse(m.build_json(false));
 		if (!thread_name.empty()) {
 			j["thread_name"] = thread_name;
 		}
-		if (wh.avatar) {
+		if (!wh.avatar.empty()) {
 			j["avatar_url"] = wh.avatar;
 		} else if (wh.image_data) {
-			j["avatar_url"] = *image_data;
+			j["avatar_url"] = *wh.image_data;
 		}
 		if (!wh.name.empty()) {
 			j["username"] = wh.name;

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -124,6 +124,26 @@ message cluster::interaction_followup_get_sync(const std::string &token, snowfla
 	return dpp::sync<message>(this, &cluster::interaction_followup_get, token, message_id);
 }
 
+automod_rule_map cluster::automod_rules_get_sync(snowflake guild_id) {
+	return dpp::sync<automod_rule_map>(this, &cluster::automod_rules_get, guild_id);
+}
+
+automod_rule cluster::automod_rule_get_sync(snowflake guild_id, snowflake rule_id) {
+	return dpp::sync<automod_rule>(this, &cluster::automod_rule_get, guild_id, rule_id);
+}
+
+automod_rule cluster::automod_rule_create_sync(snowflake guild_id, const automod_rule& r) {
+	return dpp::sync<automod_rule>(this, &cluster::automod_rule_create, guild_id, r);
+}
+
+automod_rule cluster::automod_rule_edit_sync(snowflake guild_id, const automod_rule& r) {
+	return dpp::sync<automod_rule>(this, &cluster::automod_rule_edit, guild_id, r);
+}
+
+confirmation cluster::automod_rule_delete_sync(snowflake guild_id, snowflake rule_id) {
+	return dpp::sync<confirmation>(this, &cluster::automod_rule_delete, guild_id, rule_id);
+}
+
 channel cluster::channel_create_sync(const class channel &c) {
 	return dpp::sync<channel>(this, &cluster::channel_create, c);
 }

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -342,6 +342,10 @@ const std::map<std::string, dpp::events::event*> eventmap = {
 	{ "GUILD_SCHEDULED_EVENT_DELETE", new dpp::events::guild_scheduled_event_delete() },
 	{ "GUILD_SCHEDULED_EVENT_USER_ADD", new dpp::events::guild_scheduled_event_user_add() },
 	{ "GUILD_SCHEDULED_EVENT_USER_REMOVE", new dpp::events::guild_scheduled_event_user_remove() },
+	{ "AUTO_MODERATION_RULE_CREATE", new dpp::events::automod_rule_create() },
+	{ "AUTO_MODERATION_RULE_UPDATE", new dpp::events::automod_rule_update() },
+	{ "AUTO_MODERATION_RULE_DELETE", new dpp::events::automod_rule_delete() },
+	{ "AUTO_MODERATION_ACTION_EXECUTION", new dpp::events::automod_rule_execute() },
 };
 
 void discord_client::handle_event(const std::string &event, json &j, const std::string &raw)

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -336,5 +336,8 @@ event_ctor(guild_scheduled_event_update_t, event_dispatch_t);
 event_ctor(guild_scheduled_event_delete_t, event_dispatch_t);
 event_ctor(guild_scheduled_event_user_add_t, event_dispatch_t);
 event_ctor(guild_scheduled_event_user_remove_t, event_dispatch_t);
-
+event_ctor(automod_rule_create_t, event_dispatch_t);
+event_ctor(automod_rule_delete_t, event_dispatch_t);
+event_ctor(automod_rule_update_t, event_dispatch_t);
+event_ctor(automod_rule_execute_t, event_dispatch_t);
 };

--- a/src/dpp/events/automod_rule_create.cpp
+++ b/src/dpp/events/automod_rule_create.cpp
@@ -1,0 +1,48 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/cluster.h>
+#include <dpp/stringops.h>
+#include <dpp/nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace dpp { namespace events {
+
+using namespace dpp;
+
+/**
+ * @brief Handle event
+ * 
+ * @param client Websocket client (current shard)
+ * @param j JSON data for the event
+ * @param raw Raw JSON string
+ */
+void automod_rule_create::handle(discord_client* client, json &j, const std::string &raw) {
+	if (!client->creator->on_automod_rule_create.empty()) {
+		json& d = j["d"];
+		automod_rule_create_t arc(client, raw);
+		arc.created = automod_rule().fill_from_json(&d);
+		client->creator->on_automod_rule_create.call(arc);
+	}
+}
+
+}};

--- a/src/dpp/events/automod_rule_delete.cpp
+++ b/src/dpp/events/automod_rule_delete.cpp
@@ -1,0 +1,48 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/cluster.h>
+#include <dpp/stringops.h>
+#include <dpp/nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace dpp { namespace events {
+
+using namespace dpp;
+
+/**
+ * @brief Handle event
+ * 
+ * @param client Websocket client (current shard)
+ * @param j JSON data for the event
+ * @param raw Raw JSON string
+ */
+void automod_rule_delete::handle(discord_client* client, json &j, const std::string &raw) {
+	if (!client->creator->on_automod_rule_create.empty()) {
+		json& d = j["d"];
+		automod_rule_delete_t ard(client, raw);
+		ard.deleted = automod_rule().fill_from_json(&d);
+		client->creator->on_automod_rule_delete.call(ard);
+	}
+}
+
+}};

--- a/src/dpp/events/automod_rule_execute.cpp
+++ b/src/dpp/events/automod_rule_execute.cpp
@@ -40,7 +40,17 @@ void automod_rule_execute::handle(discord_client* client, json &j, const std::st
 	if (!client->creator->on_automod_rule_execute.empty()) {
 		json& d = j["d"];
 		automod_rule_execute_t are(client, raw);
-		//arc.created = automod_rule().fill_from_json(&d);
+		are.guild_id = snowflake_not_null(&d, "guild_id");
+		are.action = dpp::automod_action().fill_from_json(&(d["action"]));
+		are.rule_id = snowflake_not_null(&d, "rule_id");
+		are.rule_trigger_type = (automod_trigger_type)int8_not_null(&d, "rule_trigger_type");
+		are.user_id = snowflake_not_null(&d, "user_id");
+		are.channel_id = snowflake_not_null(&d, "channel_id");
+		are.message_id = snowflake_not_null(&d, "message_id");
+		are.alert_system_message_id = snowflake_not_null(&d, "alert_system_message_id");
+		are.content = string_not_null(&d, "content");
+		are.matched_keyword = string_not_null(&d, "matched_keyword");
+		are.matched_content = string_not_null(&d, "matched_content");
 		client->creator->on_automod_rule_execute.call(are);
 	}
 }

--- a/src/dpp/events/automod_rule_execute.cpp
+++ b/src/dpp/events/automod_rule_execute.cpp
@@ -1,0 +1,48 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/cluster.h>
+#include <dpp/stringops.h>
+#include <dpp/nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace dpp { namespace events {
+
+using namespace dpp;
+
+/**
+ * @brief Handle event
+ * 
+ * @param client Websocket client (current shard)
+ * @param j JSON data for the event
+ * @param raw Raw JSON string
+ */
+void automod_rule_execute::handle(discord_client* client, json &j, const std::string &raw) {
+	if (!client->creator->on_automod_rule_execute.empty()) {
+		json& d = j["d"];
+		automod_rule_execute_t are(client, raw);
+		//arc.created = automod_rule().fill_from_json(&d);
+		client->creator->on_automod_rule_execute.call(are);
+	}
+}
+
+}};

--- a/src/dpp/events/automod_rule_update.cpp
+++ b/src/dpp/events/automod_rule_update.cpp
@@ -1,0 +1,48 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/automod.h>
+#include <dpp/cluster.h>
+#include <dpp/stringops.h>
+#include <dpp/nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace dpp { namespace events {
+
+using namespace dpp;
+
+/**
+ * @brief Handle event
+ * 
+ * @param client Websocket client (current shard)
+ * @param j JSON data for the event
+ * @param raw Raw JSON string
+ */
+void automod_rule_update::handle(discord_client* client, json &j, const std::string &raw) {
+	if (!client->creator->on_automod_rule_update.empty()) {
+		json& d = j["d"];
+		automod_rule_update_t aru(client, raw);
+		aru.updated = automod_rule().fill_from_json(&d);
+		client->creator->on_automod_rule_update.call(aru);
+	}
+}
+
+}};

--- a/src/dpp/webhook.cpp
+++ b/src/dpp/webhook.cpp
@@ -66,7 +66,7 @@ webhook& webhook::fill_from_json(nlohmann::json* j) {
 		user_id = snowflake_not_null(&user, "id");
 	}
 	name = string_not_null(j, "name");
-	avatar = string_not_null(j, "name");
+	avatar = string_not_null(j, "avatar");
 	token = string_not_null(j, "token");
 	application_id = snowflake_not_null(j, "application_id");
 


### PR DESCRIPTION
closes #420 

implements:
https://discord.com/developers/docs/change-log#auto-moderation
https://github.com/discord/discord-api-docs/pull/4860 
https://github.com/discord/discord-api-docs/pull/5063
https://github.com/discord/discord-api-docs/pull/5083

* implements: automod REST endpoints: `cluster::automod_rules_get()`, `cluster::automod_rule_get()`, `cluster::automod_rule_create()`, `cluster::automod_rule_edit()`, `cluster::automod_rule_delete()`, `cluster::automod_rules_get_sync()`, `cluster::automod_rule_get_sync()`, `cluster::automod_rule_create_sync()`, `cluster::automod_rule_edit_sync()`, cluster::automod_rule_delete_sync()
* auto moderation websocket events: `on_automod_rule_execute`, `on_automod_rule_create`, `on_automod_rule_update`, `on_automod_rule_delete`
* serialisation functions for automod structs: `enum automod_preset_type`, `enum automod_action_type`, `enum automod_event_type`, `enum automod_trigger_type`, `struct automod_metadata`, `struct automod_action`, `class automod_rule`, `typedef automod_rule_map`