### PR TITLE
some docs updated

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -78,7 +78,8 @@
 		"ctls",
 		"ctest",
 		"automod",
-		"amod"
+		"amod",
+		"apult"
 	],
 	"flagWords": [
 		"hte"

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -70,7 +70,7 @@ enum automod_action_type : uint8_t {
  */
 enum automod_event_type : uint8_t {
 	/**
-	 * @brief Trigger on message send
+	 * @brief Trigger on message send or edit
 	 */
 	amod_message_send = 1,
 };
@@ -102,7 +102,39 @@ enum automod_trigger_type : uint8_t {
  */
 struct DPP_EXPORT automod_metadata : public json_interface<automod_metadata> {
 	/**
-	 * @brief Keywords to moderate
+	 * @brief Keywords to moderate. A keyword can be a phrase which contains multiple words. All keywords are case insensitive.
+	 * `*` can be used to customize how each keyword will be matched.
+	 *
+	 * **Examples for the `*` wildcard symbol:**
+	 *
+	 * Prefix - word must start with the keyword
+	 *
+	 * | keyword  | matches                             |
+     * |----------|-------------------------------------|
+     * | cat*     | <u><b>cat</b></u>ch, <u><b>Cat</b></u>apult, <u><b>CAt</b></u>tLE |
+     * | the mat* | <u><b>the mat</b></u>rix                      |
+     *
+     * Suffix - word must end with the keyword
+     *
+     * | keyword  | matches                  |
+     * |----------|--------------------------|
+     * | *cat     | wild<u><b>cat</b></u>, copy<u><b>Cat</b></u> |
+     * | *the mat | brea<u><b>the mat</b></u>          |
+     *
+     * Anywhere - keyword can appear anywhere in the content
+     *
+     * | keyword   | matches                     |
+     * |-----------|-----------------------------|
+     * | \*cat*     | lo<u><b>cat</b></u>ion, edu<u><b>Cat</b></u>ion |
+     * | \*the mat* | brea<u><b>the mat</b></u>ter          |
+     *
+     * Whole Word - keyword is a full word or phrase and must be surrounded by whitespace at the beginning and end
+     *
+     * | keyword | matches     |
+     * |---------|-------------|
+     * | cat     | <u><b>Cat</b></u>     |
+     * | the mat | <u><b>the mat</b></u> |
+     *
 	 */
 	std::vector<std::string> keywords;
 	/**

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -792,8 +792,8 @@ struct DPP_EXPORT attachment {
 	 * @param callback A callback which is called when the download completes.
 	 * @note The content of the file will be in the http_info.body parameter of the
 	 * callback parameter.
-	 * @throw dpp::exception If there is no owner associated with this attachment that
-	 * itself has an owning cluster, this method will throw a dpp::exception when called.
+	 * @throw dpp::logic_exception If there is no owner associated with this attachment that
+	 * itself has an owning cluster, this method will throw a dpp::logic_exception when called.
 	 */
 	void download(http_completion_event callback) const;
 };

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -209,10 +209,6 @@ struct DPP_EXPORT select_option : public json_interface<select_option> {
  * then insert one or more additional components into it
  * using component::add_component(), so that the parent
  * object is an action row and the child objects are buttons.
- *
- * @note At present this only works for whitelisted
- * guilds. The beta is **closed**. When this feature is
- * released, then the functionality will work correctly.
  */
 class DPP_EXPORT component : public json_interface<component> {
 public:

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -95,7 +95,7 @@ namespace dpp {
 		 * @param tf Format of timestamp using dpp::utility::time_format
 		 * @return std::string The formatted timestamp
 		 */
-		std::string DPP_EXPORT timestamp(time_t ts, time_format tf);
+		std::string DPP_EXPORT timestamp(time_t ts, time_format tf = tf_short_datetime);
 
 		/**
 		 * @brief Returns current date and time

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -89,7 +89,7 @@ namespace dpp {
 		void DPP_EXPORT exec(const std::string& cmd, std::vector<std::string> parameters = {}, cmd_result_t callback = {});
 
 		/**
-		 * @brief Return a mentionable timestamp (used in a discord embed). These timestamps will display the given timestamp in the user's timezone and locale.
+		 * @brief Return a mentionable timestamp (used in a message). These timestamps will display the given timestamp in the user's timezone and locale.
 		 * 
 		 * @param ts Time stamp to convert
 		 * @param tf Format of timestamp using dpp::utility::time_format
@@ -100,7 +100,7 @@ namespace dpp {
 		/**
 		 * @brief Returns current date and time
 		 * 
-		 * @return std::string Current date and time
+		 * @return std::string Current date and time in "Y-m-d H:M:S" format
 		 */
 		std::string DPP_EXPORT current_date_time();
 		/**
@@ -362,19 +362,19 @@ namespace dpp {
 		std::string DPP_EXPORT bot_invite_url(const snowflake bot_id, const uint64_t permissions = 0, const std::vector<std::string>& scopes = {"bot", "applications.commands"});
 
 		/**
-		 * @brief Escapes markdown sequences in a string
+		 * @brief Escapes Discord's markdown sequences in a string
 		 * 
 		 * @param text Text to escape
 		 * @param escape_code_blocks If set to false, then code blocks are not escaped.
 		 * This means that you can still use a code block, and the text within will be left as-is.
 		 * If set to true, code blocks will also be escaped so that ` symbol may be used as a normal
 		 * character.
-		 * @return std::string escaped text
+		 * @return std::string The text with the markdown special characters escaped with a backslash
 		 */
 		std::string DPP_EXPORT markdown_escape(const std::string& text, bool escape_code_blocks = false);
 
 		/**
-		 * @brief Encodes a url parameter similar to php urlencode()
+		 * @brief Encodes a url parameter similar to [php urlencode()](https://www.php.net/manual/en/function.urlencode.php)
 		 * 
 		 * @param value String to encode
 		 * @return std::string URL encoded string
@@ -389,7 +389,7 @@ namespace dpp {
 		std::string DPP_EXPORT version();
 
 		/**
-		 * @brief Build a URL parameter string e.g. "a=b&c=d&e=f" from a map of key/value pairs.
+		 * @brief Build a URL parameter string e.g. "?a=b&c=d&e=f" from a map of key/value pairs.
 		 * Entries with empty key names or values are omitted.
 		 * 
 		 * @param parameters parameters to create a url query string for
@@ -398,7 +398,7 @@ namespace dpp {
 		std::string DPP_EXPORT make_url_parameters(const std::map<std::string, std::string>& parameters);
 
 		/**
-		 * @brief Build a URL parameter string e.g. "a=b&c=d&e=f" from a map of key/value pairs.
+		 * @brief Build a URL parameter string e.g. "?a=b&c=d&e=f" from a map of key/value pairs.
 		 * Entries with empty key names or zero values are omitted.
 		 * 
 		 * @param parameters parameters to create a url query string for

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -728,7 +728,7 @@ void attachment::download(http_completion_event callback) const {
 	if (owner == nullptr || owner->owner == nullptr) {
 		throw dpp::logic_exception("attachment has no owning message/cluster");
 	}
-	if (callback && !this->url.empty()) {
+	if (callback && this->id && !this->url.empty()) {
 		owner->owner->request(this->url, dpp::m_get, callback);
 	}
 }

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -725,10 +725,10 @@ attachment::attachment(struct message* o, json *j) : attachment(o) {
 
 void attachment::download(http_completion_event callback) const {
 	/* Download attachment if there is one attached to this object */
-	if (!owner->owner) {
+	if (owner == nullptr || owner->owner == nullptr) {
 		throw dpp::logic_exception("attachment has no owning message/cluster");
 	}
-	if (callback && this->id && !this->url.empty()) {
+	if (callback && !this->url.empty()) {
 		owner->owner->request(this->url, dpp::m_get, callback);
 	}
 }


### PR DESCRIPTION
added [discord's keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies) to `dpp::automod_metadata::keywords`

maked the second param of utility::timestamp optional!