### PR TITLE
Suggestion: Replace map with array.

### DIFF
--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -119,7 +119,6 @@ http_request_completion_t http_request::run(cluster* owner) {
 		}
 	}
 
-
 	rv.ratelimit_limit = rv.ratelimit_remaining = rv.ratelimit_reset_after = rv.ratelimit_retry_after = 0;
 	rv.status = 0;
 	rv.latency = 0;
@@ -143,12 +142,12 @@ http_request_completion_t http_request::run(cluster* owner) {
 		}
 	}
 
-	std::map<http_method, std::string> request_verb = {
-		{m_get, "GET"},
-		{m_post, "POST"},
-		{m_put, "PUT"},
-		{m_patch, "PATCH"},
-		{m_delete, "DELETE"}
+	constexpr std::array request_verb {
+		"GET",
+		"POST",
+		"PUT",
+		"PATCH",
+		"DELETE"
 	};
 
 	multipart_content multipart;


### PR DESCRIPTION
Replaces a `std::map` runtime construction/lookup with a constant runtime index into a constexpr array. This removes heap allocations that would otherwise be made for every http request made by the library/client.

Downsides: Potential for unseen errors if values outside of the typical range for `http_method` are passed (not worth considering). Potential for error if more `http_method` options are added in the future and the map is not updated (maybe worth considering).

Alternatives - make the map static, use a static `unordered_map` instead (no clue if it's more performant in this specific instance, but it should be generally), make a `to_string` function for `http_method` to increase coupling/decrease risk of not updating the mapping.