### PR TITLE
Added a role position comparison operator for dpp::role 

### DIFF
--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -219,6 +219,16 @@ public:
 	 */
 	virtual std::string build_json(bool with_id = false) const;
 
+        /**
+     * @brief Compares this role with another role in terms of their position in guild roles.
+     * 
+     * @param other_role The other role this role is being compared to.
+     * @return true if @param role is above @param other_role in terms of position in the guild roles.
+     * @return false 
+     */
+
+    bool operator>(role& other_role) const;
+
 	/**
 	 * @brief Get the mention/ping for the role
 	 * 

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -110,6 +110,10 @@ std::string role::build_json(bool with_id) const {
 	return j.dump();
 }
 
+bool role::operator>(role& other_role) const {
+    return this->position != other_role.position ? this->position > other_role.position : this->id > other_role.id; 
+}
+
 std::string role::get_mention() const {
 	return "<&" + std::to_string(id) + ">";
 }


### PR DESCRIPTION
Used for sorting a vector of dpp::role if the users need to sort the roles of a dpp::guild_member or dpp::guild