### PR TITLE
fix: permissions for the invoking member in an interaction_create_t event wasn't parsed

### DIFF
--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -34,7 +34,7 @@ using json = nlohmann::json;
 namespace dpp {
 
 component::component() :
-	type(static_cast<component_type>(1)), label(""), style(static_cast<component_style>(1)), custom_id(""),
+	type(cot_action_row), label(""), style(cos_primary), custom_id(""),
 	min_values(-1), max_values(-1), min_length(0), max_length(0), disabled(false), required(false)
 {
 	emoji.animated = false;

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -616,6 +616,13 @@ void from_json(const nlohmann::json& j, interaction& i) {
 				g->members[i.member.user_id] = i.member;
 			}
 		}
+		/* store the included permissions of this member in the resolved set */
+		if (j.at("member").contains("permissions") && !j.at("member").at("permissions").is_null()) {
+			dpp::snowflake id(i.member.user_id);
+			if (id) {
+				i.resolved.member_permissions[id] = snowflake_not_null(&(j.at("member")), "permissions");
+			}
+		}
 	} else if (j.contains("user") && !j.at("user").is_null()) {
 		/* Command invoked from a DM */
 		j.at("user").get_to(i.usr);


### PR DESCRIPTION
- Issue: The permissions of the invoking member of an interaction was missing. [Because they're send within the member field](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure) and wasn't parsed. They're now parsed into the resolved set of the interaction object.

- The ctor of dpp::component are now using the proper enum value instead of the cast