### PR TITLE
Stabilize Tick Rate in sslclient

### DIFF
--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -65,6 +65,7 @@
 #include <string>
 #include <iostream>
 #include <unordered_map>
+#include <chrono>
 #include <dpp/sslclient.h>
 #include <dpp/exception.h>
 #include <dpp/utility.h>
@@ -444,7 +445,10 @@ void ssl_client::read_loop()
 				pfd[0].events |= POLLOUT;
 			}
 
-			r = poll(pfd, sockets, 1000);
+			const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+			int poll_time = 1000 - (now % 1000);
+			poll_time = poll_time > 400 ? 1000 : poll_time + poll_time / 3 + 1;
+			r = poll(pfd, sockets, now / 1000 == (int64_t)last_tick ? poll_time : 0);
 
 			if (r == 0)
 				continue;


### PR DESCRIPTION
ssl client has
```c
1:  if (last_tick != time(nullptr)) {
2:    this->one_second_timer();
3:    last_tick = time(nullptr);
4:  }
```
The problem is, is that the time could change between the condition on line 1, and setting it on line 3. This can't be changed, as it would cause bugs in other places. The poll syscall further down can be reworked to wake up at the beginning of the second to make it less likely for the time difference on lines 1, and 3 to occur. Other parts of the code rely on specific times to operate, and they may be skipped over regardless, this just makes it far less likely to occur.

I'm aware, that sslclient is running on its own thread, and there may be many running, it might be best to stagger the wake up at a random interval `(beginning of second + rand(0 to 100) milliseconds)`.