### PR TITLE
Fixed various C++23 issues

### DIFF
--- a/src/dpp/events/ready.cpp
+++ b/src/dpp/events/ready.cpp
@@ -43,7 +43,7 @@ std::mutex protect_the_loot;
  */
 void ready::handle(discord_client* client, json &j, const std::string &raw) {
 	client->log(dpp::ll_info, "Shard id " + std::to_string(client->shard_id) + " (" + std::to_string(client->shard_id + 1) + "/" + std::to_string(client->max_shards) + ") ready!");
-	client->sessionid = j["d"]["session_id"];
+	client->sessionid = j["d"]["session_id"].get<std::string>();
 	/* Session-specific gateway resume url
 	 * https://discord.com/developers/docs/change-log#sessionspecific-gateway-resume-urls
 	 *

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -116,7 +116,7 @@ bool integration::expiry_kicks_user() const {
 	return flags & if_expire_kick;
 }
 
-connection::connection() : id(0), revoked(false), verified(false), friend_sync(false), show_activity(false), visible(false) {
+connection::connection() : id({}), revoked(false), verified(false), friend_sync(false), show_activity(false), visible(false) {
 }
 
 connection& connection::fill_from_json(nlohmann::json* j) {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -762,10 +762,10 @@ attachment::attachment(struct message* o)
 attachment::attachment(struct message* o, json *j) : attachment(o) {
 	this->id = snowflake_not_null(j, "id");
 	this->size = (*j)["size"];
-	this->filename = (*j)["filename"];
+	this->filename = (*j)["filename"].get<std::string>();;
 	this->description = string_not_null(j, "description");
-	this->url = (*j)["url"];
-	this->proxy_url = (*j)["proxy_url"];
+	this->url = (*j)["url"].get<std::string>();;
+	this->proxy_url = (*j)["proxy_url"].get<std::string>();;
 	this->width = int32_not_null(j, "width");
 	this->height = int32_not_null(j, "height");
 	this->content_type = string_not_null(j, "content_type");

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -179,7 +179,7 @@ presence& presence::fill_from_json(nlohmann::json* j) {
 				for (auto &b : act["buttons"]) {
 					activity_button btn;
 					if (b.is_string()) { // its may be just a string (label) because normal bots cannot access the button URLs
-						btn.label = b;
+						btn.label = b.get<std::string>();;
 					} else {
 						btn.label = string_not_null(&b, "label");
 						btn.url = string_not_null(&b, "url");

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -310,7 +310,7 @@ command_option_choice &command_option_choice::fill_from_json(nlohmann::json *j) 
 	}
 	if (j->contains("name_localizations")) {
 		for(auto loc = (*j)["name_localizations"].begin(); loc != (*j)["name_localizations"].end(); ++loc) {
-			name_localizations[loc.key()] = loc.value();
+			name_localizations[loc.key()] = loc.value().get<std::string>();;
 		}
 	}
 
@@ -370,12 +370,12 @@ command_option &command_option::fill_from_json(nlohmann::json *j) {
 
 		if (j->contains("name_localizations")) {
 			for(auto loc = (*j)["name_localizations"].begin(); loc != (*j)["name_localizations"].end(); ++loc) {
-				o.name_localizations[loc.key()] = loc.value();
+				o.name_localizations[loc.key()] = loc.value().get<std::string>();;
 			}
 		}
 		if (j->contains("description_localizations")) {
 			for(auto loc = (*j)["description_localizations"].begin(); loc != (*j)["description_localizations"].end(); ++loc) {
-				o.description_localizations[loc.key()] = loc.value();
+				o.description_localizations[loc.key()] = loc.value().get<std::string>();
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a few issues when building in C++23 mode using GCC.

- One instance of undefined behaviour with `std::string` which now correctly causes a compile error
- A few ambiguous conversions from json objects to strings 