### PR TITLE
Print status message from find_package(PkgConfig)

### DIFF
--- a/cmake/FindSodium.cmake
+++ b/cmake/FindSodium.cmake
@@ -46,7 +46,7 @@ endif()
 # UNIX
 if(UNIX)
   # import pkg-config
-  find_package(PkgConfig QUIET)
+  find_package(PkgConfig)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(sodium_PKG QUIET libsodium)
   endif()


### PR DESCRIPTION
Related to #545. Not sure if this is just a Debian related issue (or any distro without pkg-config installed by default), but not silencing `find_package` output should help spot the issue earlier if someone else runs into this.