### PR TITLE
fix: array of error parsing

### DIFF
--- a/src/dpp/cluster/confirmation.cpp
+++ b/src/dpp/cluster/confirmation.cpp
@@ -85,14 +85,25 @@ error_info confirmation_callback_t::get_error() const {
 			if (obj->find("0") != obj->end()) {
 				/* An array of error messages */
 				for (auto index = obj->begin(); index != obj->end(); ++index) {
-					for (auto fields = index->begin(); fields != index->end(); ++fields) {
-						for (auto errordetails = (*fields)["_errors"].begin(); errordetails != (*fields)["_errors"].end(); ++errordetails) {
+					if (index->find("_errors") != index->end()) {
+						for (auto errordetails = (*index)["_errors"].begin(); errordetails != (*index)["_errors"].end(); ++errordetails) {
 							error_detail detail;
 							detail.code = (*errordetails)["code"].get<std::string>();
 							detail.reason = (*errordetails)["message"].get<std::string>();
-							detail.field = fields.key();
-							detail.object = obj.key();
+							detail.object.clear();
+							detail.field = obj.key();
 							e.errors.emplace_back(detail);
+						}
+					} else {
+						for (auto fields = index->begin(); fields != index->end(); ++fields) {
+							for (auto errordetails = (*fields)["_errors"].begin(); errordetails != (*fields)["_errors"].end(); ++errordetails) {
+								error_detail detail;
+								detail.code = (*errordetails)["code"].get<std::string>();
+								detail.reason = (*errordetails)["message"].get<std::string>();
+								detail.field = fields.key();
+								detail.object = obj.key();
+								e.errors.emplace_back(detail);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
While toying around, I got the following discord api error:
```json
{
  "code": 50035,
  "errors": {
    "options": {
      "0": {
        "_errors": [
          {
            "code": "UNION_TYPE_CHOICES",
            "message": "Value of field \"type\" must be one of (3, 7, 10, 4, 5, 11, 6, 8, 9, 1, 2)."
          }
        ]
      }
    }
  },
  "message": "Invalid Form Body"
}
```
Which throws an exception because dpp expects the '_errors' array to be in an intermediate 'field' object.
This PR fixes that.
