### PR TITLE
fix channel bitrate calculation

### DIFF
--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -306,7 +306,7 @@ public:
 	/** Sorting position, lower number means higher up the list */
 	uint16_t position;
 
-	/** the bitrate (in bits) of the voice channel */
+	/** the bitrate (in kilobits) of the voice channel */
 	uint16_t bitrate;
 
 	/** amount of seconds a user has to wait before sending another message (0-21600); bots, as well as users with the permission manage_messages or manage_channel, are unaffected*/
@@ -438,7 +438,7 @@ public:
 	/**
 	 * @brief Set bitrate of this channel object
 	 *
-	 * @param bitrate Bitrate to set
+	 * @param bitrate Bitrate to set (in kilobits)
 	 * @return Reference to self, so these method calls may be chained 
 	 */
 	channel& set_bitrate(const uint16_t bitrate);

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -332,7 +332,7 @@ channel& channel::fill_from_json(json* j) {
 	set_int16_not_null(j, "default_thread_rate_limit_per_user", this->default_thread_rate_limit_per_user);
 	set_snowflake_not_null(j, "owner_id", this->owner_id);
 	set_snowflake_not_null(j, "parent_id", this->parent_id);
-	this->bitrate = int16_not_null(j, "bitrate")/1024;
+	this->bitrate = int16_not_null(j, "bitrate")/1000;
 	this->flags |= bool_not_null(j, "nsfw") ? dpp::c_nsfw : 0;
 
 	uint16_t arc = int16_not_null(j, "default_auto_archive_duration");
@@ -468,7 +468,7 @@ std::string channel::build_json(bool with_id) const {
 	}
 	if (is_voice_channel()) {
 		j["user_limit"] = user_limit; 
-		j["bitrate"] = bitrate*1024;
+		j["bitrate"] = bitrate*1000;
 	}
 	if (is_forum()) {
 		j["flags"] = (flags & dpp::c_require_tag) ? dpp::dc_require_tag : 0;


### PR DESCRIPTION
the issue was when creating a voice channel,
```c++
dpp::channel channel;
		channel.set_name("test-voice-channel");
		channel.set_guild_id(GUILD_ID);
		channel.set_type(dpp::channel_type::CHANNEL_VOICE);
		channel.set_bitrate(96);
		channel.set_user_limit(2);
		bot.channel_create(channel);
```
i got this error:
```
ERROR: Error 50035 [Invalid Form Body] on API request, returned content was: {"code": 50035, "errors": {"bitrate": {"_errors": [{"code": "NUMBER_TYPE_MAX", "message": "int value should be less than or equal to 96000."}]}}, "message": "Invalid Form Body"}
```
The `bitrate` attribute will now be multiplied by 1000 instead of 1024.