### PR TITLE
Add static mentions for channel user and role

### DIFF
--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -336,6 +336,13 @@ public:
 	/** Destructor */
 	virtual ~channel();
 
+    /**
+    * @brief Return a ping/mention for the channel
+    * @param id the channel id to make mention of
+    * @return std::string mention
+    */
+    static std::string get_mention(const snowflake& id);
+
 	/** Read class values from json object
 	 * @param j A json object to read from
 	 * @return A reference to self

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -88,6 +88,13 @@ public:
 	 */
 	virtual ~role();
 
+    /**
+    * @brief Return a ping/mention for the role
+    * @param id the role id to make mention of
+    * @return std::string mention
+    */
+    static std::string get_mention(const snowflake& id);
+
 	/**
 	 * @brief Set the name of the role
 	 * Maximum length: 100

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -109,6 +109,13 @@ public:
 	 */
 	virtual ~user();
 
+    /**
+     * @brief Return a ping/mention for the user
+     * @param id the user id to make mention of
+     * @return std::string mention
+     */
+    static std::string get_mention(const snowflake& id);
+
 	/** Fill this record from json.
 	 * @param j The json to fill this record from
 	 * @return Reference to self

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -126,6 +126,10 @@ channel::~channel()
 {
 }
 
+std::string channel::get_mention(const snowflake& id){
+    return "<#" + std::to_string(id) + ">";
+}
+
 std::string channel::get_mention() const {
 	return "<#" + std::to_string(id) + ">";
 }

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -50,6 +50,10 @@ role::~role()
 	}
 }
 
+std::string role::get_mention(const snowflake& id){
+    return "<@&" + std::to_string(id) + ">";
+}
+
 role& role::fill_from_json(nlohmann::json* j)
 {
 	return fill_from_json(0, j);

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -58,6 +58,10 @@ user::~user()
 {
 }
 
+std::string user::get_mention(const snowflake& id){
+    return "<@" + std::to_string(id) + ">";
+}
+
 std::string user::build_json(bool with_id) const {
 	return "";
 }


### PR DESCRIPTION
Adding functionality to get mention string of channel user and role by just snowflake id, without creating complex object.

```cpp
dpp::user::get_mention(id) + dpp::channel::get_mention(id) + dpp::role::get_mention(id)
```
