### PR TITLE
fix: dpp::cluster::thread_create_in_forum() crashes the bot without a clear error when the bot has insufficient permissions (#577)

### DIFF
--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -92,8 +92,11 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			auto t = thread().fill_from_json(&j);
-			if (j.contains("message")) {
-				t.msg = message().fill_from_json(&(j["message"]));
+			confirmation_callback_t e(this, confirmation(), http);
+			if (!e.is_error()) {
+				if (j.contains("message")) {
+					t.msg = message().fill_from_json(&(j["message"]));
+				}
 			}
 			callback(confirmation_callback_t(this, t, http));
 		}

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -452,6 +452,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 							raw_flags |= flags;
 						}
 						// testing all user flags from https://discord.com/developers/docs/resources/user#user-object-user-flags
+						// they're manually set here because the dpp::user_flags don't match to the discord API, so we can't use them to compare with the raw flags!
 						if (
 								u.is_discord_employee() == 			((raw_flags & (1 << 0)) != 0) &&
 								u.is_partnered_owner() == 			((raw_flags & (1 << 1)) != 0) &&


### PR DESCRIPTION
fix #577 