### PR TITLE
feat: added support for application role connection metadata

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -84,7 +84,8 @@
 		"xmake",
 		"CORO",
 		"cback",
-		"mentionables"
+		"mentionables",
+		"stringified"
 	],
 	"flagWords": [
 		"hte"

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -121,6 +121,7 @@ public:
 	std::vector<std::string> tags;	//!< Up to 5 tags describing the content and functionality of the application
 	application_install_params install_params;	//!< Settings for the application's default in-app authorization link, if enabled
 	std::string custom_install_url;	//!< The application's default custom authorization link, if enabled
+	std::string role_connections_verification_url; //!< The application's role connection verification entry point, which when configured will render the app as a verification method in the guild role verification configuration
 
 	/** Constructor */
 	application();

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2757,7 +2757,7 @@ public:
 	 * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records
 	 * @param application_id The application ID
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::application_role_connection_metadata object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::application_role_connection_metadata_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void application_role_connection_get(snowflake application_id, command_completion_event_t callback);
 
@@ -2768,7 +2768,7 @@ public:
 	 * @param application_id The application ID
 	 * @param connection_metadata The application role connection metadata to update
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::application_role_connection_metadata object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::application_role_connection_metadata_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 * @note An application can have a maximum of 5 metadata records.
 	 */
 	void application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback = utility::log_error());

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2752,6 +2752,49 @@ public:
 	void role_delete(snowflake guild_id, snowflake role_id, command_completion_event_t callback = utility::log_error());
 
 	/**
+	 * @brief Get the application's role connection metadata records
+	 *
+	 * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records
+	 * @param application_id The application ID
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::application_role_connection_metadata object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void application_role_connection_get(snowflake application_id, command_completion_event_t callback);
+
+	/**
+	 * @brief Update the application's role connection metadata records
+	 *
+	 * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#update-application-role-connection-metadata-records
+	 * @param application_id The application ID
+	 * @param connection_metadata The application role connection metadata to update
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::application_role_connection_metadata object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * @note An application can have a maximum of 5 metadata records.
+	 */
+	void application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback = utility::log_error());
+
+	/**
+	 * @brief Get user application role connection
+	 *
+	 * @see https://discord.com/developers/docs/resources/user#get-user-application-role-connection
+	 * @param application_id The application ID
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::application_role_connection object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void user_application_role_connection_get(snowflake application_id, command_completion_event_t callback);
+
+	/**
+	 * @brief Update user application role connection
+	 *
+	 * @see https://discord.com/developers/docs/resources/user#update-user-application-role-connection
+	 * @param application_id The application ID
+	 * @param connection The application role connection to update
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::application_role_connection object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void user_application_role_connection_update(snowflake application_id, const application_role_connection &connection, command_completion_event_t callback = utility::log_error());
+
+	/**
 	 * @brief Get a user by id
 	 *
 	 * @see https://discord.com/developers/docs/resources/user#get-user

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2757,7 +2757,7 @@ public:
 	 * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records
 	 * @param application_id The application ID
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::application_role_connection_metadata_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::application_role_connection_metadata_list object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void application_role_connection_get(snowflake application_id, command_completion_event_t callback);
 
@@ -2768,7 +2768,7 @@ public:
 	 * @param application_id The application ID
 	 * @param connection_metadata The application role connection metadata to update
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::application_role_connection_metadata_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::application_role_connection_metadata_list object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 * @note An application can have a maximum of 5 metadata records.
 	 */
 	void application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback = utility::log_error());

--- a/include/dpp/restrequest.h
+++ b/include/dpp/restrequest.h
@@ -172,6 +172,34 @@ template<> inline void rest_request_list<voiceregion>(dpp::cluster* c, const cha
 		}
 	});
 }
+/**
+ * @brief Templated REST request helper to save on typing (for returned lists, specialised for application_role_connection_metadata)
+ *
+ * @tparam T singular type to return in lambda callback
+ * @tparam T map type to return in lambda callback
+ * @param c calling cluster
+ * @param basepath base path for API call
+ * @param major major API function
+ * @param minor minor API function
+ * @param method HTTP method
+ * @param postdata Post data or empty string
+ * @param key Key name of elements in the json list
+ * @param callback Callback lambda
+ */
+template<> inline void rest_request_list<application_role_connection_metadata>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
+		std::unordered_map<std::string, application_role_connection_metadata> list;
+		confirmation_callback_t e(c, confirmation(), http);
+		if (!e.is_error()) {
+			for (auto & curr_item : j) {
+				list[string_not_null(&curr_item, "key")] = application_role_connection_metadata().fill_from_json(&curr_item);
+			}
+		}
+		if (callback) {
+			callback(confirmation_callback_t(c, list, http));
+		}
+	});
+}
 
 
 };

--- a/include/dpp/restrequest.h
+++ b/include/dpp/restrequest.h
@@ -172,27 +172,27 @@ template<> inline void rest_request_list<voiceregion>(dpp::cluster* c, const cha
 		}
 	});
 }
+
 /**
- * @brief Templated REST request helper to save on typing (for returned lists, specialised for application_role_connection_metadata)
+ * @brief Templated REST request helper to save on typing (for returned vectors)
  *
  * @tparam T singular type to return in lambda callback
- * @tparam T map type to return in lambda callback
+ * @tparam T vector type to return in lambda callback
  * @param c calling cluster
  * @param basepath base path for API call
  * @param major major API function
  * @param minor minor API function
  * @param method HTTP method
  * @param postdata Post data or empty string
- * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<> inline void rest_request_list<application_role_connection_metadata>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+template<class T> inline void rest_request_vector(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
-		std::unordered_map<std::string, application_role_connection_metadata> list;
+		std::vector<T> list;
 		confirmation_callback_t e(c, confirmation(), http);
 		if (!e.is_error()) {
 			for (auto & curr_item : j) {
-				list[string_not_null(&curr_item, "key")] = application_role_connection_metadata().fill_from_json(&curr_item);
+				list.push_back(T().fill_from_json(&curr_item));
 			}
 		}
 		if (callback) {

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -134,6 +134,7 @@ struct DPP_EXPORT confirmation {
 typedef std::variant<
 		application_role_connection,
 		application_role_connection_metadata,
+		application_role_connection_metadata_map,
 		confirmation,
 		message,
 		message_map,

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -132,6 +132,8 @@ struct DPP_EXPORT confirmation {
  *
  */
 typedef std::variant<
+		application_role_connection,
+		application_role_connection_metadata,
 		confirmation,
 		message,
 		message_map,

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -133,8 +133,7 @@ struct DPP_EXPORT confirmation {
  */
 typedef std::variant<
 		application_role_connection,
-		application_role_connection_metadata,
-		application_role_connection_metadata_map,
+		application_role_connection_metadata_list,
 		confirmation,
 		message,
 		message_map,

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -613,7 +613,7 @@ class DPP_EXPORT application_role_connection : public json_interface<application
 public:
 	std::string platform_name; //!< Optional: The vanity name of the platform a bot has connected (max 50 characters)
 	std::string platform_username; //!< Optional: The username on the platform a bot has connected (max 100 characters)
-	application_role_connection_metadata metadata; //!< Object mapping application role connection metadata keys to their string-ified value (max 100 characters) for the user on the platform a bot has connected
+	application_role_connection_metadata metadata; //!< Object mapping application role connection metadata keys to their stringified value (max 100 characters) for the user on the platform a bot has connected
 
 	/**
 	 * Constructor
@@ -640,7 +640,7 @@ public:
 /** A group of roles */
 typedef std::unordered_map<snowflake, role> role_map;
 
-typedef std::unordered_map<std::string, application_role_connection_metadata> application_role_connection_metadata_map;
+typedef std::vector<application_role_connection_metadata> application_role_connection_metadata_list;
 
 };
 

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -640,5 +640,7 @@ public:
 /** A group of roles */
 typedef std::unordered_map<snowflake, role> role_map;
 
+typedef std::unordered_map<std::string, application_role_connection_metadata> application_role_connection_metadata_map;
+
 };
 

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -19,6 +19,7 @@
  *
  ************************************************************************************/
 #pragma once
+#include <variant>
 #include <dpp/export.h>
 #include <dpp/managed.h>
 #include <dpp/nlohmann/json_fwd.hpp>
@@ -613,7 +614,7 @@ class DPP_EXPORT application_role_connection : public json_interface<application
 public:
 	std::string platform_name; //!< Optional: The vanity name of the platform a bot has connected (max 50 characters)
 	std::string platform_username; //!< Optional: The username on the platform a bot has connected (max 100 characters)
-	application_role_connection_metadata metadata; //!< Object mapping application role connection metadata keys to their stringified value (max 100 characters) for the user on the platform a bot has connected
+	std::variant<std::monostate, application_role_connection_metadata> metadata; //!< Optional: Object mapping application role connection metadata keys to their stringified value (max 100 characters) for the user on the platform a bot has connected
 
 	/**
 	 * Constructor
@@ -640,6 +641,7 @@ public:
 /** A group of roles */
 typedef std::unordered_map<snowflake, role> role_map;
 
+/** A group of application_role_connection_metadata objects */
 typedef std::vector<application_role_connection_metadata> application_role_connection_metadata_list;
 
 };

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -556,6 +556,87 @@ public:
 	members_container get_members() const;
 };
 
+/**
+ * @brief Application Role Connection Metadata Type
+ *
+ * @note Each metadata type offers a comparison operation that allows guilds to configure role requirements based on metadata values stored by the bot. Bots specify a `metadata value` for each user and guilds specify the required `guild's configured value` within the guild role settings.
+ */
+enum application_role_connection_metadata_type : uint8_t {
+	rc_integer_less_than_or_equal = 1, //!< The metadata value (integer) is less than or equal to the guild's configured value (integer)
+	rc_integer_greater_than_or_equal = 2, //!< The metadata value (integer) is greater than or equal to the guild's configured value (integer)
+	rc_integer_equal = 3, //!< The metadata value (integer) is equal to the guild's configured value (integer)
+	rc_integer_not_equal = 4, //!< The metadata value (integer) is not equal to the guild's configured value (integer)
+	rc_datetime_less_than_or_equal = 5, //!< The metadata value (ISO8601 string) is less than or equal to the guild's configured value (integer; days before current date)
+	rc_datetime_greater_than_or_equal = 6, //!< The metadata value (ISO8601 string) is greater than or equal to the guild's configured value (integer; days before current date)
+	rc_boolean_equal = 7, //!< The metadata value (integer) is equal to the guild's configured value (integer; 1)
+	rc_boolean_not_equal = 8, //!< The metadata value (integer) is not equal to the guild's configured value (integer; 1)
+};
+
+/**
+ * @brief Application Role Connection Metadata. Represents a role connection metadata for an dpp::application
+ */
+class DPP_EXPORT application_role_connection_metadata : public json_interface<application_role_connection_metadata> {
+public:
+	application_role_connection_metadata_type type; //!< Type of metadata value
+	std::string key; //!< Dictionary key for the metadata field (must be `a-z`, `0-9`, or `_` characters; max 50 characters)
+	std::string name; //!< Name of the metadata field (max 100 characters)
+	std::map<std::string, std::string> name_localizations; //!< Translations of the name
+	std::string description; //!< Description of the metadata field (max 200 characters)
+	std::map<std::string, std::string> description_localizations; //!< Translations of the description
+
+	/**
+	 * Constructor
+	 */
+	application_role_connection_metadata();
+
+	virtual ~application_role_connection_metadata() = default;
+
+	/** Fill this record from json.
+	 * @param j The json to fill this record from
+	 * @return Reference to self
+	 */
+	application_role_connection_metadata& fill_from_json(nlohmann::json* j);
+
+	/**
+	 * @brief Convert to JSON string
+	 *
+	 * @param with_id include ID in output
+	 * @return std::string JSON output
+	 */
+	virtual std::string build_json(bool with_id = false) const;
+};
+
+/**
+ * @brief The application role connection that an application has attached to a user.
+ */
+class DPP_EXPORT application_role_connection : public json_interface<application_role_connection> {
+public:
+	std::string platform_name; //!< Optional: The vanity name of the platform a bot has connected (max 50 characters)
+	std::string platform_username; //!< Optional: The username on the platform a bot has connected (max 100 characters)
+	application_role_connection_metadata metadata; //!< Object mapping application role connection metadata keys to their string-ified value (max 100 characters) for the user on the platform a bot has connected
+
+	/**
+	 * Constructor
+	 */
+	application_role_connection();
+
+	virtual ~application_role_connection() = default;
+
+	/** Fill this record from json.
+	 * @param j The json to fill this record from
+	 * @return Reference to self
+	 */
+	application_role_connection& fill_from_json(nlohmann::json* j);
+
+	/**
+	 * @brief Convert to JSON string
+	 *
+	 * @param with_id include ID in output
+	 * @return std::string JSON output
+	 */
+	virtual std::string build_json(bool with_id = false) const;
+};
+
 /** A group of roles */
 typedef std::unordered_map<snowflake, role> role_map;
 

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -89,6 +89,7 @@ application& application::fill_from_json(nlohmann::json* j) {
 			this->team.members.emplace_back(tm);
 		}
 	}
+	set_string_not_null(j, "role_connections_verification_url", role_connections_verification_url);
 	return *this;
 }
 

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -51,7 +51,7 @@ void cluster::roles_get(snowflake guild_id, command_completion_event_t callback)
 }
 
 void cluster::application_role_connection_get(snowflake application_id, command_completion_event_t callback) {
-	rest_request<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_get, "", callback);
+	rest_request_list<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_get, "", callback);
 }
 
 void cluster::application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback) {
@@ -59,7 +59,7 @@ void cluster::application_role_connection_update(snowflake application_id, const
 	for (const auto &conn_metadata : connection_metadata) {
 		j.push_back(json::parse(conn_metadata.build_json()));
 	}
-	rest_request<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
+	rest_request_list<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
 }
 
 void cluster::user_application_role_connection_get(snowflake application_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -51,7 +51,7 @@ void cluster::roles_get(snowflake guild_id, command_completion_event_t callback)
 }
 
 void cluster::application_role_connection_get(snowflake application_id, command_completion_event_t callback) {
-	rest_request_list<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_get, "", callback);
+	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_get, "", callback);
 }
 
 void cluster::application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback) {
@@ -59,7 +59,7 @@ void cluster::application_role_connection_update(snowflake application_id, const
 	for (const auto &conn_metadata : connection_metadata) {
 		j.push_back(json::parse(conn_metadata.build_json()));
 	}
-	rest_request_list<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
+	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
 }
 
 void cluster::user_application_role_connection_get(snowflake application_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -50,4 +50,24 @@ void cluster::roles_get(snowflake guild_id, command_completion_event_t callback)
 	rest_request_list<role>(this, API_PATH "/guilds", std::to_string(guild_id), "roles", m_get, "", callback);
 }
 
+void cluster::application_role_connection_get(snowflake application_id, command_completion_event_t callback) {
+	rest_request<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_get, "", callback);
+}
+
+void cluster::application_role_connection_update(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata, command_completion_event_t callback) {
+	json j = json::array();
+	for (const auto &conn_metadata : connection_metadata) {
+		j.push_back(json::parse(conn_metadata.build_json()));
+	}
+	rest_request<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
+}
+
+void cluster::user_application_role_connection_get(snowflake application_id, command_completion_event_t callback) {
+	rest_request<application_role_connection>(this, API_PATH "/users/@me/applications", std::to_string(application_id), "role-connection", m_get, "", callback);
+}
+
+void cluster::user_application_role_connection_update(snowflake application_id, const application_role_connection &connection, command_completion_event_t callback) {
+	rest_request<application_role_connection>(this, API_PATH "/users/@me/applications", std::to_string(application_id), "role-connection", m_put, connection.build_json(), callback);
+}
+
 };

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -435,7 +435,9 @@ std::string application_role_connection::build_json(bool with_id) const {
 	if (!platform_username.empty()) {
 		j["platform_username"] = platform_username;
 	}
-	j["metadata"] = json::parse(metadata.build_json());
+	if (std::holds_alternative<application_role_connection_metadata>(metadata)) {
+		j["metadata"] = json::parse(std::get<application_role_connection_metadata>(metadata).build_json());
+	}
 	return j.dump();
 }
 

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -374,5 +374,70 @@ std::string role::get_icon_url(uint16_t size) const {
 	}
 }
 
+application_role_connection_metadata::application_role_connection_metadata() : key(""), name(""), description("") {
+}
+
+application_role_connection_metadata &application_role_connection_metadata::fill_from_json(nlohmann::json *j) {
+	type = (application_role_connection_metadata_type)int8_not_null(j, "type");
+	key = string_not_null(j, "key");
+	name = string_not_null(j, "name");
+	if (j->contains("name_localizations")) {
+		for (auto loc = (*j)["name_localizations"].begin(); loc != (*j)["name_localizations"].end(); ++loc) {
+			name_localizations[loc.key()] = loc.value().get<std::string>();
+		}
+	}
+	description = string_not_null(j, "description");
+	if (j->contains("description_localizations")) {
+		for(auto loc = (*j)["description_localizations"].begin(); loc != (*j)["description_localizations"].end(); ++loc) {
+			description_localizations[loc.key()] = loc.value().get<std::string>();
+		}
+	}
+	return *this;
+}
+
+std::string application_role_connection_metadata::build_json(bool with_id) const {
+	json j;
+	j["type"] = type;
+	j["key"] = key;
+	j["name"] = name;
+	if (!name_localizations.empty()) {
+		j["name_localizations"] = json::object();
+		for(auto& loc : name_localizations) {
+			j["name_localizations"][loc.first] = loc.second;
+		}
+	}
+	j["description"] = description;
+	if (!description_localizations.empty()) {
+		j["description_localizations"] = json::object();
+		for(auto& loc : description_localizations) {
+			j["description_localizations"][loc.first] = loc.second;
+		}
+	}
+	return j.dump();
+}
+
+
+application_role_connection::application_role_connection() : platform_name(""), platform_username("") {
+}
+
+application_role_connection &application_role_connection::fill_from_json(nlohmann::json *j) {
+	platform_name = string_not_null(j, "platform_name");
+	platform_username = string_not_null(j, "platform_username");
+	metadata = application_role_connection_metadata().fill_from_json(&((*j)["metadata"]));
+	return *this;
+}
+
+std::string application_role_connection::build_json(bool with_id) const {
+	json j;
+	if (!platform_name.empty()) {
+		j["platform_name"] = platform_name;
+	}
+	if (!platform_username.empty()) {
+		j["platform_username"] = platform_username;
+	}
+	j["metadata"] = json::parse(metadata.build_json());
+	return j.dump();
+}
+
 
 };


### PR DESCRIPTION
Only tested `application_role_connection_get` and `application_role_connection_get`. Couldn't test the others yet.