### PR TITLE
Fixes to the DPP installlation on Linux

### DIFF
--- a/cmake/CPackSetup.cmake
+++ b/cmake/CPackSetup.cmake
@@ -1,17 +1,15 @@
 include(GNUInstallDirs)
 set(DPP_EXPORT_NAME dpp)
-set(DPP_VERSIONED ${DPP_EXPORT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+set(DPP_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${DPP_EXPORT_NAME})
 set(DPP_VERSION_FILE ${PROJECT_BINARY_DIR}/${DPP_EXPORT_NAME}-config-version.cmake)
-set(DPP_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR}/${DPP_VERSIONED})
-set(DPP_INSTALL_LIBRARY_DIR ${CMAKE_INSTALL_LIBDIR}/${DPP_VERSIONED})
 
 ## Pack the binary output
 install(TARGETS dpp
 		EXPORT ${DPP_EXPORT_NAME}
-		LIBRARY DESTINATION  ${DPP_INSTALL_LIBRARY_DIR}
-		ARCHIVE DESTINATION  ${DPP_INSTALL_LIBRARY_DIR}
+		LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBRARY_DIR}
+		ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBRARY_DIR}
 		RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR}
-		INCLUDES DESTINATION ${DPP_INSTALL_INCLUDE_DIR})
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDE_DIR})
 
 ## Allow for a specific version to be chosen in the `find_package` command
 include(CMakePackageConfigHelpers)
@@ -19,15 +17,11 @@ write_basic_package_version_file(${DPP_VERSION_FILE}
 		VERSION ${PROJECT_VERSION}
 		COMPATIBILITY SameMajorVersion)
 
-## Package the include headers (the trailing slash is important, otherwise
-## the include folder will be copied, instead of it's contents)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/" DESTINATION "${DPP_INSTALL_INCLUDE_DIR}")
-
 ## Include the file which allows `find_package(libdpp)` to function.
-install(FILES "${CMAKE_SOURCE_DIR}/cmake/libdpp-config.cmake" "${DPP_VERSION_FILE}" DESTINATION "${DPP_INSTALL_LIBRARY_DIR}")
+install(FILES "${CMAKE_SOURCE_DIR}/cmake/libdpp-config.cmake" "${DPP_VERSION_FILE}" DESTINATION "${DPP_CMAKE_DIR}")
 
 ## Export the targets to allow other projects to easily include this project
-install(EXPORT "${DPP_EXPORT_NAME}" DESTINATION "${DPP_INSTALL_LIBRARY_DIR}" NAMESPACE dpp::)
+install(EXPORT "${DPP_EXPORT_NAME}" DESTINATION "${DPP_CMAKE_DIR}" NAMESPACE dpp::)
 
 # Prepare information for packaging into .zip, .deb, .rpm
 ## Project installation metadata

--- a/cmake/libdpp-config.cmake
+++ b/cmake/libdpp-config.cmake
@@ -3,8 +3,8 @@
 ## Get current filesystem path (will a prefixed by where this package was installed)
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-## Use this directory to include libdpp which has the rest of the project targets
-include(${SELF_DIR}/libdpp.cmake)
+## Use this directory to include dpp which has the rest of the project targets
+include(${SELF_DIR}/dpp.cmake)
 
 ## Set OpenSSl directory for macos. It is also in our main CMakeLists.txt, but this file is independent from that.
 if(APPLE)


### PR DESCRIPTION
This PR contains fixes for the CMake installation on Linux, removing redundant dirs, fixing `include()` statements and adhering to standard system directories, thus allowing reverse dependencies to find this package easily without any special configuration.

Note: These are the same fixes used in a Gentoo ebuild I use locally on my systems to install DPP. A similar set of patches (although not in the form of patch files) is applied in the AUR to make the package work. Thus, we have proof of concept that this patchset does what it should.

Closes: #590 