### PR TITLE
refactor: removed code redundancy by get_parameter and make it private instead of overwriting it

### DIFF
--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -475,6 +475,8 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 
 	/**
 	 * @brief Get a command line parameter
+	 *
+	 * @note Doesn't work on subcommands. If you want to get a parameter from a subcommand, you have to loop through the options by yourself.
 	 * 
 	 * @param name The command line parameter to retrieve
 	 * @return const command_value& If the command line parameter does not 
@@ -509,20 +511,15 @@ public:
  * @brief Click on button
  */
 struct DPP_EXPORT button_click_t : public interaction_create_t {
-
+private:
+	using interaction_create_t::get_parameter;
+public:
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
 	 */
 	button_click_t(class discord_client* client, const std::string& raw);
 
-	/**
-	 * @brief Get a command line parameter
-	 * 
-	 * @param name The command line parameter to retrieve
-	 * @return Always returns an empty parameter as buttons dont have parameters!
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
 	/**
 	 * @brief button custom id
 	 */
@@ -534,19 +531,15 @@ struct DPP_EXPORT button_click_t : public interaction_create_t {
 };
 
 struct DPP_EXPORT form_submit_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
 	 */
 	form_submit_t(class discord_client* client, const std::string& raw);
 
-	/**
-	 * @brief Get a command line parameter
-	 * 
-	 * @param name The command line parameter to retrieve
-	 * @return Always returns an empty parameter as buttons dont have parameters!
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
 	/**
 	 * @brief button custom id
 	 */
@@ -561,20 +554,15 @@ struct DPP_EXPORT form_submit_t : public interaction_create_t {
  * @brief Discord requests that we fill a list of auto completion choices for a command option
  */
 struct DPP_EXPORT autocomplete_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
 	 */
 	autocomplete_t(class discord_client* client, const std::string& raw);
-
-	/**
-	 * @brief Get a command line parameter
-	 * 
-	 * @param name The command line parameter to retrieve
-	 * @return Always returns an empty parameter as auto complete requests dont have parameters!
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
 
 	/**
 	 * @brief Command ID
@@ -674,20 +662,15 @@ public:
  * @brief Click on select
  */
 struct DPP_EXPORT select_click_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
 	 */
 	select_click_t(class discord_client* client, const std::string& raw);
-
-	/**
-	 * @brief Get a command line parameter
-	 * 
-	 * @param name The command line parameter to retrieve
-	 * @return Always returns an empty parameter as buttons dont have parameters!
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
 
 	/**
 	 * @brief select menu custom id

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -221,34 +221,6 @@ const command_value& interaction_create_t::get_parameter(const std::string& name
 	return dummy_value;
 }
 
-const command_value& button_click_t::get_parameter(const std::string& name) const
-{
-	/* Buttons don't have parameters, so override this */
-	static command_value dummy_b_value = {};
-	return dummy_b_value;
-}
-
-const command_value& select_click_t::get_parameter(const std::string& name) const
-{
-	/* Selects don't have parameters, so override this */
-	static command_value dummy_b_value = {};
-	return dummy_b_value;
-}
-
-const command_value& form_submit_t::get_parameter(const std::string& name) const
-{
-	/* Buttons don't have parameters, so override this */
-	static command_value dummy_b_value = {};
-	return dummy_b_value;
-}
-
-const command_value& autocomplete_t::get_parameter(const std::string& name) const
-{
-	/* Autocomplete don't have parameters, so override this */
-	static command_value dummy_b_value = {};
-	return dummy_b_value;
-}
-
 voice_receive_t::voice_receive_t(class discord_client* client, const std::string &raw, class discord_voice_client* vc, snowflake _user_id, uint8_t* pcm, size_t length) : event_dispatch_t(client, raw), voice_client(vc), user_id(_user_id) {
 	reassign(vc, _user_id, pcm, length);
 }


### PR DESCRIPTION
Instead of overwriting the inherited get_parameter method in classes who doesn't have parameters, we can just make it private.