### PR TITLE
Moved json typedef inside the namespace

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -49,9 +49,11 @@
 #include <dpp/coro.h>
 #include <dpp/event_router.h>
 
-using  json = nlohmann::json;
+
 
 namespace dpp {
+
+using  json = nlohmann::json;
 
 /**
  * @brief Types of startup for cluster::start()


### PR DESCRIPTION
Having the typedef inside the global namespace will give an overshadowing error if any `using json=...` statement is used.