### PR TITLE
Fix m_suppress_notifications

### DIFF
--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -52,7 +52,8 @@ enum automod_preset_type : uint8_t {
  */
 enum automod_action_type : uint8_t {
 	/**
-	 * @brief Block the message
+	 * @brief Blocks the message and prevents it from being posted.
+	 * A custom explanation can be specified and shown to members whenever their message is blocked
 	 */
 	amod_action_block_message = 1,
 	/**
@@ -60,7 +61,8 @@ enum automod_action_type : uint8_t {
 	 */
 	amod_action_send_alert = 2,
 	/**
-	 * @brief time out the user
+	 * @brief timeout the user
+	 * @note Can only be set up for rules with trigger types of dpp::amod_type_keyword and dpp::amod_type_mention_spam
 	 */
 	amod_action_timeout = 3,
 };
@@ -244,15 +246,19 @@ struct DPP_EXPORT automod_action : public json_interface<automod_action> {
 	automod_action_type type;
 
 	/**
-	 * @brief Channel ID, for type dpp::amod_action_send_alert
+	 * @brief Channel ID to which user content should be logged, for type dpp::amod_action_send_alert
 	 */
 	snowflake channel_id;
 
 	/**
-	 * @brief Timeout duration in seconds (Maximum of 2419200), for dpp::amod_action_timeout
-	 * 
+	 * @brief Additional explanation that will be shown to members whenever their message is blocked. For type dpp::amod_action_block_message
 	 */
-	int32_t duration_seconds;
+	std::string custom_message;
+
+	/**
+	 * @brief Timeout duration in seconds (Maximum of 2419200), for dpp::amod_action_timeout
+	 */
+	uint32_t duration_seconds;
 
 	/**
 	 * @brief Construct a new automod action object

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -440,7 +440,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void edit_response(const std::string & mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
-	 * @brief Set the bot to 'thinking' state
+	 * @brief Set the bot to 'thinking' state where you have up to 15 minutes to respond
 	 *
 	 * @param ephemeral True if the thinking state should be ephemeral
 	 * @param callback User function to execute when the api call completes.

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1166,7 +1166,7 @@ struct DPP_EXPORT message : public managed {
 	std::vector<channel> mention_channels;
 	/** any attached files */
 	std::vector<attachment> attachments;
-	/** zero or more dpp::embed objects */
+	/** Up to 10 dpp::embed objects */
 	std::vector<embed> embeds;
 	/** Optional: reactions to the message */
 	std::vector<reaction> reactions;

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -980,7 +980,7 @@ enum message_flags : uint16_t {
 	/// this message failed to mention some roles and add their members to the thread
 	m_thread_mention_failed = 1 << 8,
 	/// this message will not trigger push and desktop notifications
-	m_suppress_notifications = 1 << 9,
+	m_suppress_notifications = 1 << 12,
 };
 
 /**

--- a/src/dpp/automod.cpp
+++ b/src/dpp/automod.cpp
@@ -35,6 +35,9 @@ automod_action::~automod_action() = default;
 automod_action& automod_action::fill_from_json(nlohmann::json* j) {
 	type = (automod_action_type)int8_not_null(j, "type");
 	switch (type) {
+		case amod_action_block_message:
+			custom_message = string_not_null(&((*j)["metadata"]), "custom_message");
+			break;
 		case amod_action_send_alert:
 			channel_id = snowflake_not_null(&((*j)["metadata"]), "channel_id");
 			break;
@@ -52,6 +55,12 @@ std::string automod_action::build_json(bool with_id) const {
 		{ "type", type }
 	});
 	switch (type) {
+		case amod_action_block_message:
+			if (!custom_message.empty()) {
+				j["metadata"] = json::object();
+				j["metadata"]["custom_message"] = custom_message;
+			}
+			break;
 		case amod_action_send_alert:
 			if (channel_id) {
 				j["metadata"] = json::object();

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -486,8 +486,10 @@ std::string channel::build_json(bool with_id) const {
 		j["default_thread_rate_limit_per_user"] = default_thread_rate_limit_per_user;
 	}
 	if (is_voice_channel()) {
-		j["user_limit"] = user_limit; 
-		j["bitrate"] = bitrate*1000;
+		j["user_limit"] = user_limit;
+		if (bitrate) {
+			j["bitrate"] = bitrate * 1000;
+		}
 	}
 	if (is_forum()) {
 		j["flags"] = (flags & dpp::c_require_tag) ? dpp::dc_require_tag : 0;


### PR DESCRIPTION
m_suppress notifications in the discord api is 1 << 12 (4096) but we have it as 1 << 9 (512) currently.