### PR TITLE
Updated m_suppress_notifications flag

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -980,7 +980,7 @@ enum message_flags : uint16_t {
 	/// this message failed to mention some roles and add their members to the thread
 	m_thread_mention_failed = 1 << 8,
 	/// this message will not trigger push and desktop notifications
-	m_suppress_notifications = 1 << 9,
+	m_suppress_notifications = 1 << 12,
 };
 
 /**


### PR DESCRIPTION
The m_suppress_notifications should be 4096, but it was 512.