### PR TITLE
Documentation for setting up D++ in CLion with CMake and vcpkg

### DIFF
--- a/docpages/01_installing.md
+++ b/docpages/01_installing.md
@@ -6,7 +6,7 @@ There are many ways to install D++, either from a package manager, or from sourc
 * \subpage install-linux-rpm
 * \subpage install-vcpkg
 * \subpage install-arch-aur
-* \subpage install-clion
-* \subpage install-windows-zip
+* \subpage install-windows-vs-zip
+* \subpage install-windows-clion-vcpkg
 * \subpage install-xmake
 * \subpage install-from-source

--- a/docpages/01_installing.md
+++ b/docpages/01_installing.md
@@ -6,6 +6,7 @@ There are many ways to install D++, either from a package manager, or from sourc
 * \subpage install-linux-rpm
 * \subpage install-vcpkg
 * \subpage install-arch-aur
+* \subpage install-clion
 * \subpage install-windows-zip
 * \subpage install-xmake
 * \subpage install-from-source

--- a/docpages/install/install-clion.md
+++ b/docpages/install/install-clion.md
@@ -1,0 +1,34 @@
+To add D++ to a CLion project, you need obtain the library through vcpkg and then configure your CLion project and `CMakeLists.txt`.
+
+1. Build [vcpkg](https://vcpkg.io/) on your system (skip if you already have it).
+2. Run `vcpkg install dpp:x64-windows` (replace x64-windows with whichever OS and architecture you want the library to be built for).
+3. VCPKG will install the dpp library along with the dependencies for you.
+4. Now check if dpp has been installed using `vcpkg list dpp`.
+    ```
+    C:/vcpkg>vcpkg list dpp
+    dpp:x64-windows     10.0.23     D++ Extremely Lightweight C++ Discord Library.
+    ```
+   
+5. To use vcpkg in CLion, add the following line to your CMake options in the settings (Located under Settings > Build, Execution, Deployment > CMake)
+    ```
+   -DCMAKE_TOOLCHAIN_FILE=path_to_vcpkg_root_folder/scripts/buildsystems/vcpkg.cmake
+    ```
+   For example, if your root folder is `C:/vcpkg/` then the CMake option will be:
+    ```
+   -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+    ```
+
+6. Now proceed to add the following lines to your `CMakeLists.txt`:
+    ```cmake
+    find_package(dpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE dpp::dpp)
+    target_include_directories(main PRIVATE path_to_vcpkg_root_folder/installed/architecture-os/include)
+    ```
+   For example, if built for x64-windows and vcpkg root is `C:/vcpkg/` then your `CMakeLists.txt` should look like this:
+    ```cmake
+    find_package(dpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE dpp::dpp)
+    target_include_directories(main PRIVATE C:/vcpkg/installed/x64-windows/include)
+    ```
+   
+7. Congratulations! Now try to build a test program to see if the installation succeeded. For further help, join  the [discord server](https://discord.gg/dpp).

--- a/docpages/install/install-windows-clion-vcpkg.md
+++ b/docpages/install/install-windows-clion-vcpkg.md
@@ -1,8 +1,10 @@
+\page install-windows-clion-vcpkg Installing from vcpkg for CLion
+
 To add D++ to a CLion project, you need obtain the library through vcpkg and then configure your CLion project and `CMakeLists.txt`.
 
 1. Build [vcpkg](https://vcpkg.io/) on your system (skip if you already have it).
 2. Run `vcpkg install dpp:x64-windows` (replace x64-windows with whichever OS and architecture you want the library to be built for).
-3. VCPKG will install the dpp library along with the dependencies for you.
+3. vcpkg will install the library along with the dependencies for you.
 4. Now check if dpp has been installed using `vcpkg list dpp`.
     ```
     C:/vcpkg>vcpkg list dpp
@@ -31,4 +33,4 @@ To add D++ to a CLion project, you need obtain the library through vcpkg and the
     target_include_directories(main PRIVATE C:/vcpkg/installed/x64-windows/include)
     ```
    
-7. Congratulations! Now try to build a test program to see if the installation succeeded. For further help, join  the [discord server](https://discord.gg/dpp).
+7. Congratulations! Now try to build a test program to see if the installation succeeded. If you get stuck somewhere, feel free to ask us on the D++ [discord server](https://discord.gg/dpp).

--- a/docpages/install/install-windows-vs-zip.md
+++ b/docpages/install/install-windows-vs-zip.md
@@ -1,4 +1,4 @@
-\page install-windows-zip Installing from zip (Windows)
+\page install-windows-vs-zip Installing from zip (Windows) for Visual Studio
 
 To add D++ to a Visual Studio project, using **Visual Studio 2019** or **Visual Studio 2022**, follow the steps below. The steps below assume an empty project, if you are adding to an existing project simply skip steps 1 through 4, and step 13.
 


### PR DESCRIPTION
Clear instructions on how to set up the D++ library by installation through vcpkg and then updating CLion project settings and CMakeLists.txt

Tested for ping/pong bot