### PR TITLE
fix, feat: Add MIME type to HTTP file transfer API

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1169,8 +1169,9 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param filename Filename to post for POST requests (for uploading files)
 	 * @param filecontent File content to post for POST requests (for uploading files)
+	 * @param filemimetype File content to post for POST requests (for uploading files)
 	 */
-	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "");
+	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "");
 
 	/**
 	 * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
@@ -1183,8 +1184,9 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param filename List of filenames to post for POST requests (for uploading files)
 	 * @param filecontent List of file content to post for POST requests (for uploading files)
+	 * @param filemimetypes List of mime types for each file to post for POST requests (for uploading files)
 	 */
-	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string>& filecontent = {}, const std::vector<std::string>& filemimetypes = {});
 
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asynchronous access to HTTP APIs outside of Discord.

--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -248,9 +248,10 @@ public:
 	 * @param json The json content
 	 * @param filenames File names of files to send
 	 * @param contents Contents of each of the files to send
+	 * @param contents MIME types of each of the files to send
 	 * @return multipart mime content and headers
 	 */
-	static multipart_content build_multipart(const std::string &json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {});
+	static multipart_content build_multipart(const std::string &json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {}, const std::vector<std::string>& mimetypes = {});
 
 	/**
 	 * @brief Processes incoming data from the SSL socket input buffer.

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1183,6 +1183,9 @@ struct DPP_EXPORT message : public managed {
 	/** File content to upload (raw binary) */
 	std::vector<std::string>	filecontent;
 
+	/** Mime type of files to upload */
+	std::vector<std::string>	filemimetype;
+
 	/**
 	 * @brief Reference to another message, e.g. a reply
 	 */
@@ -1466,9 +1469,10 @@ struct DPP_EXPORT message : public managed {
 	 *
 	 * @param filename filename
 	 * @param filecontent raw file content contained in std::string
+	 * @param filemimetype optional mime type of the file
 	 * @return message& reference to self
 	 */
-	message& add_file(const std::string &filename, const std::string &filecontent);
+	message& add_file(const std::string &filename, const std::string &filecontent, const std::string &filemimetype = "");
 
 	/**
 	 * @brief Set the message content

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -149,6 +149,8 @@ public:
 	std::vector<std::string> file_name;
 	/** @brief Upload file contents (binary) */
 	std::vector<std::string> file_content;
+	/** @brief Upload file mime types (application/octet-stream if unspecified) */
+	std::vector<std::string> file_mimetypes;
 	/** @brief Request mime type */
 	std::string mimetype;
 	/** @brief Request headers (non-discord requests only) */
@@ -166,8 +168,9 @@ public:
 	 * @param audit_reason Audit log reason to send, empty to send none
 	 * @param filename The filename (server side) of any uploaded file
 	 * @param filecontent The binary content of any uploaded file for the request
+	 * @param filemimetype The MIME type of any uploaded file for the request
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "");
+	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "");
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
@@ -179,8 +182,9 @@ public:
 	 * @param audit_reason Audit log reason to send, empty to send none
 	 * @param filename The filename (server side) of any uploaded file
 	 * @param filecontent The binary content of any uploaded file for the request
+	 * @param filemimetypes The MIME type of any uploaded file for the request
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {}, const std::vector<std::string> &filemimetypes = {});
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -295,7 +295,7 @@ json error_response(const std::string& message, http_request_completion_t& rv)
 	return j;
 }
 
-void cluster::post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename, const std::string &filecontent) {
+void cluster::post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename, const std::string &filecontent, const std::string &filemimetype) {
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback](http_request_completion_t rv) {
 		json j;
@@ -310,10 +310,10 @@ void cluster::post_rest(const std::string &endpoint, const std::string &major_pa
 		if (callback) {
 			callback(j, rv);
 		}
-	}, postdata, method, get_audit_reason(), filename, filecontent));
+	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetype));
 }
 
-void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent) {
+void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent, const std::vector<std::string> &filemimetypes) {
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback](http_request_completion_t rv) {
 		json j;
@@ -328,7 +328,7 @@ void cluster::post_rest_multipart(const std::string &endpoint, const std::string
 		if (callback) {
 			callback(j, rv);
 		}
-	}, postdata, method, get_audit_reason(), filename, filecontent));
+	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetypes));
 }
 
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -132,7 +132,7 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, r.msg->filename, r.msg->filecontent);
+	}, r.msg->filename, r.msg->filecontent, r.msg->filemimetype);
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -140,7 +140,7 @@ void cluster::interaction_response_edit(const std::string &token, const message 
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -148,7 +148,7 @@ void cluster::interaction_followup_create(const std::string &token, const messag
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -156,7 +156,7 @@ void cluster::interaction_followup_edit_original(const std::string &token, const
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_delete(const std::string &token, command_completion_event_t callback) {
@@ -168,7 +168,7 @@ void cluster::interaction_followup_edit(const std::string &token, const message 
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -40,7 +40,7 @@ void cluster::message_create(const message &m, command_completion_event_t callba
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 
@@ -116,7 +116,7 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 

--- a/src/dpp/cluster/sticker.cpp
+++ b/src/dpp/cluster/sticker.cpp
@@ -23,12 +23,25 @@
 
 namespace dpp {
 
+namespace {
+	std::string get_sticker_mimetype(const sticker &s) {
+		static const std::map<sticker_format, std::string> mime_types = {
+				{ sticker_format::sf_png, "image/png" },
+				{ sticker_format::sf_apng, "image/png" },
+				{ sticker_format::sf_lottie, "application/json" },
+				{ sticker_format::sf_gif, "image/gif" },
+		};
+
+		return mime_types.find(s.format_type)->second;
+	}
+}
+
 void cluster::guild_sticker_create(sticker &s, command_completion_event_t callback) {
 	this->post_rest(API_PATH "/guilds", std::to_string(s.guild_id), "stickers", m_post, s.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, sticker().fill_from_json(&j), http));
 		}
-	}, s.filename, s.filecontent);
+	}, s.filename, s.filecontent, get_sticker_mimetype(s));
 }
 
 void cluster::guild_sticker_delete(snowflake sticker_id, snowflake guild_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -118,7 +118,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			}
 			callback(confirmation_callback_t(this, t, http));
 		}
-	}, msg.filename, msg.filecontent);
+	}, msg.filename, msg.filecontent, msg.filemimetype);
 }
 
 void cluster::thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -59,7 +59,7 @@ void cluster::edit_webhook_message(const class webhook &wh, const struct message
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 
@@ -95,7 +95,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -196,7 +196,7 @@ void interaction_create_t::edit_original_response(const message & m, command_com
 		if (callback) {
 			callback(confirmation_callback_t(creator, message().fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void interaction_create_t::delete_original_response(command_completion_event_t callback) const

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -534,9 +534,10 @@ message& message::set_file_content(const std::string &fc)
 	return *this;
 }
 
-message& message::add_file(const std::string &fn, const std::string &fc) {
-	filecontent.push_back(fc);
+message& message::add_file(const std::string &fn, const std::string &fc, const std::string &fm) {
 	filename.push_back(fn);
+	filecontent.push_back(fc);
+	filemimetype.push_back(fm);
 	return *this;
 }
 

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -35,18 +35,22 @@ namespace dpp {
 static std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, " + std::to_string(DPP_VERSION_MAJOR) + "." + std::to_string(DPP_VERSION_MINOR) + "." + std::to_string(DPP_VERSION_PATCH) + ")";
 static const char* DISCORD_HOST = "https://discord.com";
 
-http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method _method, const std::string &audit_reason, const std::string &filename, const std::string &filecontent)
+http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method _method, const std::string &audit_reason, const std::string &filename, const std::string &filecontent, const std::string &filemimetype)
  : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(_method), reason(audit_reason), mimetype("application/json"), waiting(false)
 {
 		if (!filename.empty())
 			file_name.push_back(filename);
 		if (!filecontent.empty())
 			file_content.push_back(filecontent);
+	if (!filemimetype.empty())
+		file_mimetypes.push_back(filemimetype);
 }
 
-http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method method, const std::string &audit_reason, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent)
- : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(method), reason(audit_reason), file_name(filename), file_content(filecontent), mimetype("application/json"), waiting(false)
+http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method method, const std::string &audit_reason, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent, const std::vector<std::string> &filemimetypes)
+ : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(method), reason(audit_reason), file_name(filename), file_content(filecontent), file_mimetypes(filemimetypes), mimetype("application/json"), waiting(false)
 {
+	if (filecontent.size() && !filemimetypes.size())
+		std::cout << "hi" << std::endl;
 }
 
 
@@ -167,7 +171,7 @@ http_request_completion_t http_request::run(cluster* owner) {
 		multipart = { postdata, "" };
 	} else {
 
-		multipart = https_client::build_multipart(postdata, file_name, file_content);
+		multipart = https_client::build_multipart(postdata, file_name, file_content, file_mimetypes);
 		if (!multipart.mimetype.empty()) {
 			headers.emplace("Content-Type", multipart.mimetype);
 		}

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -106,7 +106,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 	set_test("HTTPS", false);
 	if (!offline) {
 		dpp::multipart_content multipart = dpp::https_client::build_multipart(
-			"{\"content\":\"test\"}", {"test.txt", "blob.blob"}, {"ABCDEFGHI", "BLOB!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"}
+			"{\"content\":\"test\"}", {"test.txt", "blob.blob"}, {"ABCDEFGHI", "BLOB!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"}, {"text/plain", "application/octet-stream"}
 		);
 		try {
 			dpp::https_client c("discord.com", 443, "/api/channels/" + std::to_string(TEST_TEXT_CHANNEL_ID) + "/messages", "POST", multipart.body,


### PR DESCRIPTION
As I found out the hard way on my bot [B-12](https://github.com/Mishura4/B-12) while adding a command to add stickers, it turns out the sticker create API expects the file it receives to have a MIME type that corresponds to its data. I spent hours trying to troubleshoot my bot's code, but while digging into DPP code it became clear that the `application/octet-stream` MIME type it sent by default was what was causing the issue, as changing it to `image/png` allowed it to be accepted by the API.

This pull request adds MIME types to APIs that deal with raw file uploading through the REST API. This includes data members in `dpp::http_request`, in `dpp::message`, and function signature changes. MIME type defaults to `application/octet-stream` if unspecified by the user.
This effectively :
 - Fixes the creation of new stickers through the REST API
 - Allows attachments to have their MIME type set, which allows them to be displayed in corresponding ways in the Discord app. For example a file with `text/plain` as type will have its text shown in the app, a file with `application/octet-stream` will be available for download, and so on.

Changes of note :
 - New defaulted parameter to [dpp::http_request::post_rest](https://github.com/Mishura4/DPP-PRs/commit/4ddadd55186ec5eb885f88b56f1ee91fd4d2ada8#diff-6339985ecf337b206f9c8e02397963c3884a86562391f4863b0c8dc152ac074aR1174)
 - New defaulted parameter to [dpp::message::add_file](https://github.com/Mishura4/DPP-PRs/commit/4ddadd55186ec5eb885f88b56f1ee91fd4d2ada8#diff-f68aabe94d953dd3b1322cfe12dae9854a749c9d468667c83bc4daa79d912b51R1475)
 - New defaulted parameter to [dpp::http_request](https://github.com/Mishura4/DPP-PRs/commit/4ddadd55186ec5eb885f88b56f1ee91fd4d2ada8#diff-f7e79c7ab7239e153e768848200665b558af779d49ea3b333a8d8e831292af33R173)'s constructors
 - New data fields in [dpp::message](https://github.com/Mishura4/DPP-PRs/commit/4ddadd55186ec5eb885f88b56f1ee91fd4d2ada8#diff-f68aabe94d953dd3b1322cfe12dae9854a749c9d468667c83bc4daa79d912b51R1187) and [dpp::http_request](https://github.com/Mishura4/DPP-PRs/commit/4ddadd55186ec5eb885f88b56f1ee91fd4d2ada8#diff-f7e79c7ab7239e153e768848200665b558af779d49ea3b333a8d8e831292af33R153)

⚠️ This breaks ABI, as function signatures were changed around and data members were added. API is preserved through the new parameters being defaulted.

Tested on my own bot, on MSVC, clang-cl, Linux-GCC. Unit tests also pass (I also added the new MIME type parameters to it).