### PR TITLE
refactor: modernize dpp::permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
 
       - name: Upload Binary (DEB)
         if: ${{ matrix.cfg.cpp-version == 'g++-10' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "libdpp - Debian Package ${{matrix.cfg.arch}}"
           path: '${{github.workspace}}/build/*.deb'
 
       - name: Upload Binary (RPM)
         if: ${{ matrix.cfg.cpp-version == 'g++-10' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "libdpp - RPM Package ${{matrix.cfg.arch}}"
           path: '${{github.workspace}}/build/*.rpm'
@@ -179,7 +179,7 @@ jobs:
           DONT_RUN_VCPKG: true
 
       - name: Upload Binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "libdpp - Windows ${{matrix.cfg.name}}-${{matrix.cfg.config}}-vs${{matrix.cfg.vs}}"
           path: '${{github.workspace}}/main/build/*.zip'
@@ -213,13 +213,13 @@ jobs:
         run: cd build && cpack --verbose
 
       - name: Upload Binaries (DEB)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "libdpp - Debian Package ${{matrix.cfg.name}}"
           path: "${{github.workspace}}/build/*.deb"
 
       - name: Upload Binaries (RPM)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "libdpp - RPM Package ${{matrix.cfg.name}}"
           path: "${{github.workspace}}/build/*.rpm"
@@ -246,7 +246,7 @@ jobs:
 #          cpack --verbose
 #
 #    - name: Upload Binaries (BZ2)
-#      uses: actions/upload-artifact@v2
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: "libdpp - FreeBSD x64"
 #        path: "${{github.workspace}}/build/*.tar.bz2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install apt packages
         run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install  ${{ matrix.cfg.cpp-version }} ninja-build libsodium-dev libopus-dev zlib1g-dev rpm
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install apt packages
         run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install  ${{ matrix.cfg.cpp-version }} ninja-build libsodium-dev libopus-dev zlib1g-dev rpm
@@ -109,7 +109,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install homebrew packages
         run: brew install cmake ninja libsodium opus openssl
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{matrix.cfg.os}}
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: main
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: ${{matrix.cfg.os}}
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Packages
         run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install cmake ninja-build rpm
@@ -228,7 +228,7 @@ jobs:
 #   runs-on: macos-10.15
 #   name: FreeBSD (g++-10)
 #   steps:
-#   - uses: actions/checkout@v2
+#   - uses: actions/checkout@v3
 #   - name: FreeBSD Build and Package
 #     id: freebsdtest
 #     uses: vmactions/freebsd-vm@v0.1.5

--- a/.github/workflows/construct-vcpkg-info.yml
+++ b/.github/workflows/construct-vcpkg-info.yml
@@ -15,7 +15,7 @@ jobs:
              php-version: '8.1'
 
          - name: Checkout D++
-           uses: actions/checkout@v2
+           uses: actions/checkout@v3
            with:
              submodules: recursive
 

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check docs spelling
         run: npx -y cspell lint --language-id=cpp --no-progress --no-summary --show-context --show-suggestions --relative --color docpages/*.md include/dpp/*.h

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
           php-version: '8.0'
 
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan

--- a/.github/workflows/target-master.yml
+++ b/.github/workflows/target-master.yml
@@ -20,7 +20,7 @@ jobs:
           php-version: '8.0'
 
       - name: Checkout D++
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/buildtools/changelog.php
+++ b/buildtools/changelog.php
@@ -22,6 +22,7 @@ $categories = [
     'improvement' => '♻️ Refactoring',
     'refactor' => '♻️ Refactoring',
     'refactored' => '♻️ Refactoring',
+    'refactoring' => '♻️ Refactoring',
     'deprecated' => '♻️ Refactoring',
     'deprecate' => '♻️ Refactoring',
     'remove' => '♻️ Refactoring',

--- a/docpages/advanced_reference/coding_style_standards.md
+++ b/docpages/advanced_reference/coding_style_standards.md
@@ -73,6 +73,10 @@ Where discord provide a name in PascalCase we should stick as closely to that na
 ## Don't introduce any platform-specific code
 Do not introduce platform specific (e.g. windows only) code or libc functions. If you really must use these functions safely wrap them e.g. in `#ifdef _WIN32` and provide a cross-platform alternative so that it works for everyone.
 
+## C++ version
+
+The code must work with the C++17 standard. 
+
 ## Select the right size type for numeric types
 If a value will only hold values up to 255, use `uint8_t`. If a value cannot hold over 65536, use `uint16_t`. These types can help use a lot less ram at scale.
 
@@ -114,6 +118,12 @@ All types for the library should be within the `dpp` namespace. There are a coup
 
 ## Commit messages and Git
 
-All pull requests ("PRs") should be submitted against the `dev` branch in GitHub. It’s good to have descriptive commit messages, or PR titles so that other contributors can understand about your commit or the PR Created. Read [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.3/) for information on how we like to format commit messages.
+All pull requests ("PRs") should be submitted against the `dev` branch in GitHub.
+
+### Naming conventions
+
+It’s good to have descriptive commit messages, or PR titles so that other contributors can understand about your commit or the PR Created. Commits must be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by a colon and a space. Other commit types can be `breaking`, `docs`, `refactor`, `deprecate`, `perf`, `test`, `chore` and `misc`. Read [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.3/) for more information on how we like to format commit messages.
+
+### GitHub Actions
 
 All PRs must pass the [GitHub Actions](https://github.com/brainboxdotcc/DPP/actions) tests before being allowed to be merged. This is to ensure that no code committed into the project fails to compile on any of our officially supported platforms or architectures.

--- a/docpages/example_programs/interactions_and_components/commandhandler.md
+++ b/docpages/example_programs/interactions_and_components/commandhandler.md
@@ -18,7 +18,7 @@ int main()
 {
 	dpp::cluster bot("token");
 
-        bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* Create command handler, and specify prefixes */
 	dpp::commandhandler command_handler(&bot);
@@ -48,7 +48,7 @@ int main()
 			/* Command description */
 			"A test ping command",
 
-			/* Guild id (omit for a global command) */
+			/* Guild id (omit for a guild command) */
 			819556414099554344
 		);
 

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -685,15 +685,16 @@ public:
 	std::variant<command_interaction, component_interaction, autocomplete_interaction> data; //!< Optional: the command data payload
 	snowflake guild_id;                                         //!< Optional: the guild it was sent from
 	snowflake channel_id;                                       //!< Optional: the channel it was sent from
+	dpp::channel channel;										//!< Optional: The partial channel object where it was sent from
 	snowflake message_id;					    //!< Originating message id for context menu actions
 	permission app_permissions;				    //!< Permissions of the bot in the channel/guild where this command was issued
 	message msg;						    //!< Originating message for context menu actions
-	guild_member member;                                        //!< Optional: guild member data for the invoking user, including permissions
+	guild_member member;                                        //!< Optional: guild member data for the invoking user, including permissions. Filled when the interaction is invoked in a guild
 	user usr;                                                   //!< User object for the invoking user
 	std::string token;                                          //!< a continuation token for responding to the interaction
 	uint8_t version;                                            //!< read-only property, always 1
 	command_resolved resolved;				    //!< Resolved user/role etc
-	std::string locale;                                         //!< User's locale (language)
+	std::string locale;                                         //!< User's [locale](https://discord.com/developers/docs/reference#locales) (language)
 	std::string guild_locale;                                   //!< Guild's locale (language) - for guild interactions only
 	cache_policy_t cache_policy;                                //!< Cache policy from cluster
 

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -105,7 +105,7 @@ struct DPP_EXPORT command_option_choice : public json_interface<command_option_c
 	/**
 	 * @brief Add a localisation for this command option choice
 	 * @see https://discord.com/developers/docs/reference#locales
-	 * @param language Name of language, see the list of locales linked to above.
+	 * @param language Name of language, see the list of locales linked to above
 	 * @param _name name of command option choice in the specified language
 	 * @return command_option_choice& reference to self for fluent chaining
 	 */
@@ -181,12 +181,12 @@ struct DPP_EXPORT command_option : public json_interface<command_option>  {
 	/**
 	 * @brief Add a localisation for this slash command option
 	 * @see https://discord.com/developers/docs/reference#locales
-	 * @param language Name of language, see the list of locales linked to above.
+	 * @param language Name of language, see the list of locales linked to above
 	 * @param _name name of slash command option in the specified language
-	 * @param _description description of slash command option in the specified language
+	 * @param _description description of slash command option in the specified language (optional)
 	 * @return command_option& reference to self for fluent chaining
 	 */
-	command_option& add_localization(const std::string& language, const std::string& _name, const std::string& _description);
+	command_option& add_localization(const std::string& language, const std::string& _name, const std::string& _description = "");
 
 	/**
 	 * @brief Construct a new command option object
@@ -211,7 +211,7 @@ struct DPP_EXPORT command_option : public json_interface<command_option>  {
 	 * @brief Set the minimum numeric value of the option. 
 	 * Only valid if the type is co_number or co_integer.
 	 * @param min_v Minimum value
-	 * @return command_option& return a reference to sef for chaining of calls
+	 * @return command_option& returns a reference to self for chaining of calls
 	 */
 	command_option& set_min_value(command_option_range min_v);
 
@@ -219,7 +219,7 @@ struct DPP_EXPORT command_option : public json_interface<command_option>  {
 	 * @brief Set the maximum numeric value of the option. 
 	 * Only valid if the type is co_number or co_integer.
 	 * @param max_v Maximum value
-	 * @return command_option& return a reference to sef for chaining of calls
+	 * @return command_option& returns a reference to self for chaining of calls
 	 */
 	command_option& set_max_value(command_option_range max_v);
 
@@ -227,7 +227,7 @@ struct DPP_EXPORT command_option : public json_interface<command_option>  {
 	 * @brief Set the minimum string length of the option. 
 	 * Only valid if the type is co_string
 	 * @param min_v Minimum value
-	 * @return command_option& return a reference to sef for chaining of calls
+	 * @return command_option& returns a reference to self for chaining of calls
 	 */
 	command_option& set_min_length(command_option_range min_v);
 
@@ -235,7 +235,7 @@ struct DPP_EXPORT command_option : public json_interface<command_option>  {
 	 * @brief Set the maximum string length of the option. 
 	 * Only valid if the type is co_string
 	 * @param max_v Maximum value
-	 * @return command_option& return a reference to sef for chaining of calls
+	 * @return command_option& returns a reference to self for chaining of calls
 	 */
 	command_option& set_max_length(command_option_range max_v);
 
@@ -528,8 +528,8 @@ struct DPP_EXPORT command_data_option {
 	/**
 	 * @brief Get an option value by index
 	 * 
-	 * @tparam Type to get from the parameter
-	 * @param index index number of parameter
+	 * @tparam T Type to get from the parameter
+	 * @param index index of the option
 	 * @return T returned type
 	 */
 	template <typename T> T& get_value(size_t index) {
@@ -582,8 +582,8 @@ struct DPP_EXPORT command_interaction {
 	/**
 	 * @brief Get an option value by index
 	 * 
-	 * @tparam Type to get from the parameter
-	 * @param index index number of parameter
+	 * @tparam T Type to get from the parameter
+	 * @param index index of the option
 	 * @return T returned type
 	 */
 	template <typename T> T& get_value(size_t index) {
@@ -1076,12 +1076,12 @@ public:
 	/**
 	 * @brief Add a localisation for this slash command
 	 * @see https://discord.com/developers/docs/reference#locales
-	 * @param language Name of language, see the list of locales linked to above.
+	 * @param language Name of language, see the list of locales linked to above
 	 * @param _name name of slash command in the specified language
-	 * @param _description description of slash command in the specified language
-	 * @return slashcommand& reference to self for fluent chaining
+	 * @param _description description of slash command in the specified language (optional)
+	 * @return slashcommand& reference to self for chaining of calls
 	 */
-	slashcommand& add_localization(const std::string& language, const std::string& _name, const std::string& _description);
+	slashcommand& add_localization(const std::string& language, const std::string& _name, const std::string& _description = "");
 
 	/**
 	 * @brief Set the dm permission for the command

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -45,6 +45,8 @@ enum team_member_status : uint8_t {
  * @brief Flags for a bot or application
  */
 enum application_flags : uint32_t {
+	/// Indicates if an app uses the Auto Moderation API
+	apf_application_automod_rule_create_badge = (1 << 6),
 	/// Has gateway presence intent
 	apf_gateway_presence = (1 << 12),
 	/// Has gateway presence intent for <100 guilds

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1169,8 +1169,9 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param filename Filename to post for POST requests (for uploading files)
 	 * @param filecontent File content to post for POST requests (for uploading files)
+	 * @param filemimetype File content to post for POST requests (for uploading files)
 	 */
-	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "");
+	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "");
 
 	/**
 	 * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
@@ -1183,8 +1184,9 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param filename List of filenames to post for POST requests (for uploading files)
 	 * @param filecontent List of file content to post for POST requests (for uploading files)
+	 * @param filemimetypes List of mime types for each file to post for POST requests (for uploading files)
 	 */
-	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string>& filecontent = {}, const std::vector<std::string>& filemimetypes = {});
 
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asynchronous access to HTTP APIs outside of Discord.

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2341,7 +2341,7 @@ public:
 	/**
 	 * @brief Get all emojis for a guild
 	 *
-	 * @see https://discord.com/developers/docs/resources/emoji#get-guild-emojis
+	 * @see https://discord.com/developers/docs/resources/emoji#list-guild-emojis
 	 * @param guild_id Guild ID to get emojis for
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::emoji_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
@@ -2376,7 +2376,7 @@ public:
 	 * @brief Edit a single emoji.
 	 * 
 	 * You must ensure that the emoji passed contained image data using the emoji::load_image() method.
-	 * @see https://discord.com/developers/docs/resources/emoji#get-guild-emoji
+	 * @see https://discord.com/developers/docs/resources/emoji#modify-guild-emoji
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @param guild_id Guild ID to edit emoji on
 	 * @param newemoji Emoji to edit

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -498,11 +498,9 @@ struct DPP_EXPORT slashcommand_t : public interaction_create_t {
 	/**
 	 * @brief Get a command line parameter
 	 *
-	 * @note Doesn't work on subcommands. If you want to get a parameter from a subcommand, you have to loop through the options by yourself.
-	 *
 	 * @param name The name of the command line parameter to retrieve the value for
-	 * @return const command_value& If the command line parameter does not
-	 * exist, an empty variant is returned.
+	 * @return const command_value& Returns the value of the first option that matches the given name.
+	 * If no matches are found, an empty variant is returned.
 	 */
 	const virtual command_value& get_parameter(const std::string& name) const;
 };

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -474,17 +474,6 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void delete_original_response(command_completion_event_t callback = utility::log_error()) const;
 
 	/**
-	 * @brief Get a command line parameter
-	 *
-	 * @note Doesn't work on subcommands. If you want to get a parameter from a subcommand, you have to loop through the options by yourself.
-	 * 
-	 * @param name The command line parameter to retrieve
-	 * @return const command_value& If the command line parameter does not 
-	 * exist, an empty variant is returned.
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
-
-	/**
 	 * @brief command interaction
 	 */
 	interaction command;
@@ -499,21 +488,30 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
  * @brief User has issued a slash command
  */
 struct DPP_EXPORT slashcommand_t : public interaction_create_t {
-public:
+
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
 	 */
 	slashcommand_t(class discord_client* client, const std::string& raw);
+
+	/**
+	 * @brief Get a command line parameter
+	 *
+	 * @note Doesn't work on subcommands. If you want to get a parameter from a subcommand, you have to loop through the options by yourself.
+	 *
+	 * @param name The name of the command line parameter to retrieve the value for
+	 * @return const command_value& If the command line parameter does not
+	 * exist, an empty variant is returned.
+	 */
+	const virtual command_value& get_parameter(const std::string& name) const;
 };
 
 /**
  * @brief Click on button
  */
 struct DPP_EXPORT button_click_t : public interaction_create_t {
-private:
-	using interaction_create_t::get_parameter;
-public:
+
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
@@ -531,9 +529,7 @@ public:
 };
 
 struct DPP_EXPORT form_submit_t : public interaction_create_t {
-private:
-	using interaction_create_t::get_parameter;
-public:
+
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
@@ -554,9 +550,6 @@ public:
  * @brief Discord requests that we fill a list of auto completion choices for a command option
  */
 struct DPP_EXPORT autocomplete_t : public interaction_create_t {
-private:
-	using interaction_create_t::get_parameter;
-public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
@@ -585,7 +578,7 @@ public:
  * user or message.
  */
 struct DPP_EXPORT context_menu_t : public interaction_create_t {
-public:
+
 	/** Constructor
 	 * @param client The shard the event originated on
 	 * @param raw Raw event text as JSON
@@ -662,9 +655,6 @@ public:
  * @brief Click on select
  */
 struct DPP_EXPORT select_click_t : public interaction_create_t {
-private:
-	using interaction_create_t::get_parameter;
-public:
 
 	/** Constructor
 	 * @param client The shard the event originated on

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -487,12 +487,12 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @brief Get a slashcommand parameter
 	 *
 	 * @param name The name of the command line parameter to retrieve the value for
-	 * @return const command_value& Returns the value of the first option that matches the given name.
+	 * @return command_value Returns the value of the first option that matches the given name.
 	 * If no matches are found, an empty variant is returned.
 	 *
 	 * @throw dpp::logic_exception if the interaction is not for a command
 	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
+	virtual command_value get_parameter(const std::string& name) const;
 };
 
 /**

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -482,6 +482,17 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @brief Destroy this object
 	 */
 	virtual ~interaction_create_t() = default;
+
+	/**
+	 * @brief Get a slashcommand parameter
+	 *
+	 * @param name The name of the command line parameter to retrieve the value for
+	 * @return const command_value& Returns the value of the first option that matches the given name.
+	 * If no matches are found, an empty variant is returned.
+	 *
+	 * @throw dpp::logic_exception if the interaction is not for a command
+	 */
+	const virtual command_value& get_parameter(const std::string& name) const;
 };
 
 /**
@@ -494,21 +505,15 @@ struct DPP_EXPORT slashcommand_t : public interaction_create_t {
 	 * @param raw Raw event text as JSON
 	 */
 	slashcommand_t(class discord_client* client, const std::string& raw);
-
-	/**
-	 * @brief Get a command line parameter
-	 *
-	 * @param name The name of the command line parameter to retrieve the value for
-	 * @return const command_value& Returns the value of the first option that matches the given name.
-	 * If no matches are found, an empty variant is returned.
-	 */
-	const virtual command_value& get_parameter(const std::string& name) const;
 };
 
 /**
  * @brief Click on button
  */
 struct DPP_EXPORT button_click_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
@@ -527,6 +532,9 @@ struct DPP_EXPORT button_click_t : public interaction_create_t {
 };
 
 struct DPP_EXPORT form_submit_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
@@ -548,6 +556,9 @@ struct DPP_EXPORT form_submit_t : public interaction_create_t {
  * @brief Discord requests that we fill a list of auto completion choices for a command option
  */
 struct DPP_EXPORT autocomplete_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
@@ -576,6 +587,9 @@ struct DPP_EXPORT autocomplete_t : public interaction_create_t {
  * user or message.
  */
 struct DPP_EXPORT context_menu_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on
@@ -653,6 +667,9 @@ public:
  * @brief Click on select
  */
 struct DPP_EXPORT select_click_t : public interaction_create_t {
+private:
+	using interaction_create_t::get_parameter;
+public:
 
 	/** Constructor
 	 * @param client The shard the event originated on

--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -248,9 +248,10 @@ public:
 	 * @param json The json content
 	 * @param filenames File names of files to send
 	 * @param contents Contents of each of the files to send
+	 * @param contents MIME types of each of the files to send
 	 * @return multipart mime content and headers
 	 */
-	static multipart_content build_multipart(const std::string &json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {});
+	static multipart_content build_multipart(const std::string &json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {}, const std::vector<std::string>& mimetypes = {});
 
 	/**
 	 * @brief Processes incoming data from the SSL socket input buffer.

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -523,7 +523,7 @@ public:
 struct DPP_EXPORT embed_footer {
 	/** Footer text */
 	std::string text;
-	/** Footer icon url */
+	/** Footer icon url (only supports http(s) and attachments) */
 	std::string icon_url;
 	/** Proxied icon url */
 	std::string proxy_url;
@@ -577,9 +577,9 @@ struct DPP_EXPORT embed_provider {
 struct DPP_EXPORT embed_author {
 	/** Author name */
 	std::string name;
-	/** Author url */
+	/** Author url (only supports http(s)) */
 	std::string url;
-	/** Author icon url */
+	/** Author icon url (only supports http(s) and attachments) */
 	std::string icon_url;
 	/** Proxied icon url */
 	std::string proxy_icon_url;
@@ -589,9 +589,9 @@ struct DPP_EXPORT embed_author {
  * @brief A dpp::embed may contain zero or more fields
  */
 struct DPP_EXPORT embed_field {
-	/** Name of field */
+	/** Name of field (max length 256) */
 	std::string name;
-	/** Value of field (max length 1000) */
+	/** Value of field (max length 1024) */
 	std::string value;
 	/** True if the field is to be displayed inline */
 	bool is_inline;
@@ -659,7 +659,7 @@ struct DPP_EXPORT embed {
 
 	 /** Set the footer of the embed. Returns the embed itself so these method calls may be "chained"
 	  * @param text string to set as footer text. It will be truncated to the maximum length of 2048 UTF-8 characters.
-	  * @param icon_url an url to set as footer icon url
+	  * @param icon_url an url to set as footer icon url (only supports http(s) and attachments)
 	  * @return A reference to self
 	  */
 	embed& set_footer(const std::string& text, const std::string& icon_url);
@@ -698,8 +698,8 @@ struct DPP_EXPORT embed {
 
 	/** Set embed author. Returns the embed itself so these method calls may be "chained"
 	 * @param name The name of the author. It will be truncated to the maximum length of 256 UTF-8 characters.
-	 * @param url The url of the author
-	 * @param icon_url The icon URL of the author
+	 * @param url The url of the author (only supports http(s))
+	 * @param icon_url The icon URL of the author (only supports http(s) and attachments)
 	 * @return A reference to self
 	 */
 	embed& set_author(const std::string& name, const std::string& url, const std::string& icon_url);
@@ -712,7 +712,7 @@ struct DPP_EXPORT embed {
 	embed& set_provider(const std::string& name, const std::string& url);
 
 	/** Set embed image. Returns the embed itself so these method calls may be "chained"
-	 * @param url The embed image URL
+	 * @param url The embed image URL (only supports http(s) and attachments)
 	 * @return A reference to self
 	 */
 	embed& set_image(const std::string& url);
@@ -724,7 +724,7 @@ struct DPP_EXPORT embed {
 	embed& set_video(const std::string& url);
 
 	/** Set embed thumbnail. Returns the embed itself so these method calls may be "chained"
-	 * @param url The embed thumbnail url
+	 * @param url The embed thumbnail url (only supports http(s) and attachments)
 	 * @return A reference to self
 	 */
 	embed& set_thumbnail(const std::string& url);

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1183,6 +1183,9 @@ struct DPP_EXPORT message : public managed {
 	/** File content to upload (raw binary) */
 	std::vector<std::string>	filecontent;
 
+	/** Mime type of files to upload */
+	std::vector<std::string>	filemimetype;
+
 	/**
 	 * @brief Reference to another message, e.g. a reply
 	 */
@@ -1466,9 +1469,10 @@ struct DPP_EXPORT message : public managed {
 	 *
 	 * @param filename filename
 	 * @param filecontent raw file content contained in std::string
+	 * @param filemimetype optional mime type of the file
 	 * @return message& reference to self
 	 */
-	message& add_file(const std::string &filename, const std::string &filecontent);
+	message& add_file(const std::string &filename, const std::string &filecontent, const std::string &filemimetype = "");
 
 	/**
 	 * @brief Set the message content

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -71,6 +71,8 @@ enum permissions : uint64_t {
 	p_send_messages_in_threads = 0x04000000000,    //!< allows for sending messages in threads
 	p_use_embedded_activities = 0x08000000000,    //!< allows for using activities (applications with the EMBEDDED flag) in a voice channel
 	p_moderate_members = 0x10000000000,    //!< allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels
+	p_view_creator_monetization_analytics = 0x20000000000,	//!< allows for viewing role subscription insights
+	p_use_soundboard = 0x40000000000, //!< allows for using soundboard in a voice channel
 };
 
 /**

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -82,38 +82,41 @@ enum permissions : uint64_t {
 using role_permissions = permissions;
 
 /**
- * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are hold in an uint64_t
+ * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are held in an uint64_t
  */
-class DPP_EXPORT permission {
-protected:
+struct DPP_EXPORT permission {
+
 	/**
 	 * @brief The permission bitmask value
 	 */
-	uint64_t value;
+	uint64_t value{0};
 
-public:
 	/**
-	 * @brief Construct a permission object
-	 * @param value A permission bitmask
+	 * @brief Default constructor, initializes permission to 0
 	 */
-	permission(const uint64_t& value);
+	constexpr permission() = default;
 
 	/**
- 	 * @brief Construct a permission object
- 	 */
-	permission();
+	 * @brief Bitmask constructor, initializes permission to the argument
+	 * @param value The bitmask to initialize the permission to
+	 */
+	constexpr permission(uint64_t value) noexcept : value{value} {}
 
 	/**
 	 * @brief For acting like an integer
 	 * @return The permission bitmask value
 	 */
-	operator uint64_t() const;
+	constexpr operator uint64_t() const noexcept {
+		return value;
+	}
 
 	/**
 	 * @brief For acting like an integer
 	 * @return A reference to the permission bitmask value
 	 */
-	operator uint64_t &();
+	constexpr operator uint64_t &() noexcept {
+		return value;
+	}
 
 	/**
 	 * @brief For building json
@@ -136,7 +139,7 @@ public:
 	 * @return bool True if it has all the given permissions
 	 */
 	template <typename... T>
-	bool has(T... values) const {
+	constexpr bool has(T... values) const noexcept {
 		return (value & (0 | ... | values)) == (0 | ... | values);
 	}
 
@@ -155,8 +158,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	add(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr add(T... values) noexcept {
 		value |= (0 | ... | values);
 		return *this;
 	}
@@ -175,8 +178,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	set(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr set(T... values) noexcept {
 		value = (0 | ... | values);
 		return *this;
 	}
@@ -196,8 +199,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	remove(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr remove(T... values) noexcept {
 		value &= ~(0 | ... | values);
 		return *this;
 	}

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -149,6 +149,8 @@ public:
 	std::vector<std::string> file_name;
 	/** @brief Upload file contents (binary) */
 	std::vector<std::string> file_content;
+	/** @brief Upload file mime types (application/octet-stream if unspecified) */
+	std::vector<std::string> file_mimetypes;
 	/** @brief Request mime type */
 	std::string mimetype;
 	/** @brief Request headers (non-discord requests only) */
@@ -166,8 +168,9 @@ public:
 	 * @param audit_reason Audit log reason to send, empty to send none
 	 * @param filename The filename (server side) of any uploaded file
 	 * @param filecontent The binary content of any uploaded file for the request
+	 * @param filemimetype The MIME type of any uploaded file for the request
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "");
+	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "");
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
@@ -179,8 +182,9 @@ public:
 	 * @param audit_reason Audit log reason to send, empty to send none
 	 * @param filename The filename (server side) of any uploaded file
 	 * @param filecontent The binary content of any uploaded file for the request
+	 * @param filemimetypes The MIME type of any uploaded file for the request
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {});
+	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {}, const std::vector<std::string> &filemimetypes = {});
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -550,6 +550,20 @@ public:
 	 * @return bool True if user has the moderate users permission or is administrator.
 	 */
 	bool has_moderate_members() const;
+	/**
+	 * @brief True if has the view creator monetization analytics permission.
+	 * @note Having the administrator permission causes this method to always return true
+	 * Channel specific overrides may apply to permissions.
+	 * @return bool True if user has the view creator monetization analytics permission or is administrator.
+	 */
+	bool has_view_creator_monetization_analytics() const;
+	/**
+	 * @brief True if has the use soundboard permission.
+	 * @note Having the administrator permission causes this method to always return true
+	 * Channel specific overrides may apply to permissions.
+	 * @return bool True if user has the use soundboard permission or is administrator.
+	 */
+	bool has_use_soundboard() const;
 
 	/**
 	 * @brief Get guild members who have this role

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -305,7 +305,7 @@ public:
 	bool has_animated_icon() const;
 
 	/**
-	 * @brief Format a username into user#discriminator
+	 * @brief Format a username into user\#discriminator
 	 * 
 	 * For example Brain#0001
 	 * 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -295,7 +295,7 @@ json error_response(const std::string& message, http_request_completion_t& rv)
 	return j;
 }
 
-void cluster::post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename, const std::string &filecontent) {
+void cluster::post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename, const std::string &filecontent, const std::string &filemimetype) {
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback](http_request_completion_t rv) {
 		json j;
@@ -310,10 +310,10 @@ void cluster::post_rest(const std::string &endpoint, const std::string &major_pa
 		if (callback) {
 			callback(j, rv);
 		}
-	}, postdata, method, get_audit_reason(), filename, filecontent));
+	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetype));
 }
 
-void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent) {
+void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent, const std::vector<std::string> &filemimetypes) {
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	rest->post_request(new http_request(endpoint + "/" + major_parameters, parameters, [endpoint, callback](http_request_completion_t rv) {
 		json j;
@@ -328,7 +328,7 @@ void cluster::post_rest_multipart(const std::string &endpoint, const std::string
 		if (callback) {
 			callback(j, rv);
 		}
-	}, postdata, method, get_audit_reason(), filename, filecontent));
+	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetypes));
 }
 
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -132,7 +132,7 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, r.msg->filename, r.msg->filecontent);
+	}, r.msg->filename, r.msg->filecontent, r.msg->filemimetype);
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -140,7 +140,7 @@ void cluster::interaction_response_edit(const std::string &token, const message 
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -148,7 +148,7 @@ void cluster::interaction_followup_create(const std::string &token, const messag
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback) {
@@ -156,7 +156,7 @@ void cluster::interaction_followup_edit_original(const std::string &token, const
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_delete(const std::string &token, command_completion_event_t callback) {
@@ -168,7 +168,7 @@ void cluster::interaction_followup_edit(const std::string &token, const message 
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void cluster::interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -40,7 +40,7 @@ void cluster::message_create(const message &m, command_completion_event_t callba
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 
@@ -116,7 +116,7 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 

--- a/src/dpp/cluster/sticker.cpp
+++ b/src/dpp/cluster/sticker.cpp
@@ -23,12 +23,25 @@
 
 namespace dpp {
 
+namespace {
+	std::string get_sticker_mimetype(const sticker &s) {
+		static const std::map<sticker_format, std::string> mime_types = {
+				{ sticker_format::sf_png, "image/png" },
+				{ sticker_format::sf_apng, "image/png" },
+				{ sticker_format::sf_lottie, "application/json" },
+				{ sticker_format::sf_gif, "image/gif" },
+		};
+
+		return mime_types.find(s.format_type)->second;
+	}
+}
+
 void cluster::guild_sticker_create(sticker &s, command_completion_event_t callback) {
 	this->post_rest(API_PATH "/guilds", std::to_string(s.guild_id), "stickers", m_post, s.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, sticker().fill_from_json(&j), http));
 		}
-	}, s.filename, s.filecontent);
+	}, s.filename, s.filecontent, get_sticker_mimetype(s));
 }
 
 void cluster::guild_sticker_delete(snowflake sticker_id, snowflake guild_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -118,7 +118,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			}
 			callback(confirmation_callback_t(this, t, http));
 		}
-	}, msg.filename, msg.filecontent);
+	}, msg.filename, msg.filecontent, msg.filemimetype);
 }
 
 void cluster::thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -59,7 +59,7 @@ void cluster::edit_webhook_message(const class webhook &wh, const struct message
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 
@@ -95,7 +95,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -208,7 +208,7 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 	});
 }
 
-const command_value& interaction_create_t::get_parameter(const std::string& name) const
+const command_value& slashcommand_t::get_parameter(const std::string& name) const
 {
 	/* Dummy STATIC return value for unknown options so we aren't returning a value off the stack */
 	static command_value dummy_value = {};

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -196,7 +196,7 @@ void interaction_create_t::edit_original_response(const message & m, command_com
 		if (callback) {
 			callback(confirmation_callback_t(creator, message().fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent);
+	}, m.filename, m.filecontent, m.filemimetype);
 }
 
 void interaction_create_t::delete_original_response(command_completion_event_t callback) const

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -208,11 +208,11 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 	});
 }
 
-const command_value& interaction_create_t::get_parameter(const std::string& name) const
+command_value interaction_create_t::get_parameter(const std::string& name) const
 {
 	/* Dummy STATIC return value for unknown options so we aren't returning a value off the stack */
 	static command_value dummy_value = {};
-	const command_interaction ci = command.get_command_interaction();
+	auto ci = command.get_command_interaction();
 
 	for (const auto &option : ci.options) {
 		if (option.type != co_sub_command && option.type != co_sub_command_group && option.name == name) {

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -210,9 +210,7 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 
 command_value interaction_create_t::get_parameter(const std::string& name) const
 {
-	/* Dummy STATIC return value for unknown options so we aren't returning a value off the stack */
-	static command_value dummy_value = {};
-	auto ci = command.get_command_interaction();
+	const command_interaction ci = command.get_command_interaction();
 
 	for (const auto &option : ci.options) {
 		if (option.type != co_sub_command && option.type != co_sub_command_group && option.name == name) {
@@ -237,7 +235,7 @@ command_value interaction_create_t::get_parameter(const std::string& name) const
 			}
 		}
 	}
-	return dummy_value;
+	return {};
 }
 
 voice_receive_t::voice_receive_t(class discord_client* client, const std::string &raw, class discord_voice_client* vc, snowflake _user_id, uint8_t* pcm, size_t length) : event_dispatch_t(client, raw), voice_client(vc), user_id(_user_id) {

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -208,11 +208,11 @@ void interaction_create_t::delete_original_response(command_completion_event_t c
 	});
 }
 
-const command_value& slashcommand_t::get_parameter(const std::string& name) const
+const command_value& interaction_create_t::get_parameter(const std::string& name) const
 {
 	/* Dummy STATIC return value for unknown options so we aren't returning a value off the stack */
 	static command_value dummy_value = {};
-	const command_interaction& ci = command.get_command_interaction();
+	const command_interaction ci = command.get_command_interaction();
 
 	for (const auto &option : ci.options) {
 		if (option.type != co_sub_command && option.type != co_sub_command_group && option.name == name) {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -534,9 +534,10 @@ message& message::set_file_content(const std::string &fc)
 	return *this;
 }
 
-message& message::add_file(const std::string &fn, const std::string &fc) {
-	filecontent.push_back(fc);
+message& message::add_file(const std::string &fn, const std::string &fc, const std::string &fm) {
 	filename.push_back(fn);
+	filecontent.push_back(fc);
+	filemimetype.push_back(fm);
 	return *this;
 }
 

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -23,18 +23,6 @@
 
 namespace dpp {
 
-permission::permission(const uint64_t &value) : value(value) {}
-
-permission::permission() : permission(0) {}
-
-permission::operator uint64_t() const {
-	return value;
-}
-
-permission::operator uint64_t &() {
-	return value;
-}
-
 permission::operator nlohmann::json() const {
 	return std::to_string(value);
 }

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -35,18 +35,22 @@ namespace dpp {
 static std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, " + std::to_string(DPP_VERSION_MAJOR) + "." + std::to_string(DPP_VERSION_MINOR) + "." + std::to_string(DPP_VERSION_PATCH) + ")";
 static const char* DISCORD_HOST = "https://discord.com";
 
-http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method _method, const std::string &audit_reason, const std::string &filename, const std::string &filecontent)
+http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method _method, const std::string &audit_reason, const std::string &filename, const std::string &filecontent, const std::string &filemimetype)
  : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(_method), reason(audit_reason), mimetype("application/json"), waiting(false)
 {
 		if (!filename.empty())
 			file_name.push_back(filename);
 		if (!filecontent.empty())
 			file_content.push_back(filecontent);
+	if (!filemimetype.empty())
+		file_mimetypes.push_back(filemimetype);
 }
 
-http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method method, const std::string &audit_reason, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent)
- : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(method), reason(audit_reason), file_name(filename), file_content(filecontent), mimetype("application/json"), waiting(false)
+http_request::http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata, http_method method, const std::string &audit_reason, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent, const std::vector<std::string> &filemimetypes)
+ : complete_handler(completion), completed(false), non_discord(false), endpoint(_endpoint), parameters(_parameters), postdata(_postdata),  method(method), reason(audit_reason), file_name(filename), file_content(filecontent), file_mimetypes(filemimetypes), mimetype("application/json"), waiting(false)
 {
+	if (filecontent.size() && !filemimetypes.size())
+		std::cout << "hi" << std::endl;
 }
 
 
@@ -167,7 +171,7 @@ http_request_completion_t http_request::run(cluster* owner) {
 		multipart = { postdata, "" };
 	} else {
 
-		multipart = https_client::build_multipart(postdata, file_name, file_content);
+		multipart = https_client::build_multipart(postdata, file_name, file_content, file_mimetypes);
 		if (!multipart.mimetype.empty()) {
 			headers.emplace("Content-Type", multipart.mimetype);
 		}

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -311,6 +311,14 @@ bool role::has_moderate_members() const {
 	return has_administrator() || permissions.has(p_moderate_members);
 }
 
+bool role::has_view_creator_monetization_analytics() const {
+	return has_administrator() || permissions.has(p_view_creator_monetization_analytics);
+}
+
+bool role::has_use_soundboard() const {
+	return has_administrator() || permissions.has(p_use_soundboard);
+}
+
 role& role::set_name(const std::string& n) {
 	name = utility::validate(n, 1, 100, "Role name too short");
 	return *this;

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -595,6 +595,11 @@ void from_json(const nlohmann::json& j, interaction& i) {
 	i.guild_id = snowflake_not_null(&j, "guild_id");
 	i.app_permissions = snowflake_not_null(&j, "app_permissions");
 
+	if (j.contains("channel") && !j.at("channel").is_null()) {
+		const json& c = j["channel"];
+		i.channel = channel().fill_from_json((json*)&c);
+	}
+
 	if (j.contains("message") && !j.at("message").is_null()) {
 		const json& m = j["message"];
 		i.msg = message().fill_from_json((json*)&m, i.cache_policy);
@@ -891,7 +896,7 @@ const dpp::role& interaction::get_resolved_role(snowflake id) const {
 }
 
 const dpp::channel& interaction::get_resolved_channel(snowflake id) const {
-	return get_resolved<channel, std::map<snowflake, channel>>(id, resolved.channels);
+	return get_resolved<dpp::channel, std::map<snowflake, dpp::channel>>(id, resolved.channels);
 }
 
 const dpp::guild_member& interaction::get_resolved_member(snowflake id) const {

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -219,14 +219,15 @@ void to_json(json& j, const slashcommand& p) {
 			j["name_localizations"][loc.first] = loc.second;
 		}
 	}
-	if (p.description_localizations.size()) {
-		j["description_localizations"] = json::object();
-		for(auto& loc : p.description_localizations) {
-			j["description_localizations"][loc.first] = loc.second;
-		}
-	}
 
 	if (p.type != ctxm_user && p.type != ctxm_message) {
+		if (p.description_localizations.size()) {
+			j["description_localizations"] = json::object();
+			for(auto& loc : p.description_localizations) {
+				j["description_localizations"][loc.first] = loc.second;
+			}
+		}
+
 		if (p.options.size()) {
 			j["options"] = json();
 
@@ -491,7 +492,9 @@ std::string interaction::build_json(bool with_id) const {
 
 slashcommand& slashcommand::add_localization(const std::string& language, const std::string& _name, const std::string& _description) {
 	name_localizations[language] = _name;
-	description_localizations[language] = _description;
+	if (! _description.empty()) {
+		description_localizations[language] = _description;
+	}
 	return *this;
 }
 
@@ -502,7 +505,9 @@ command_option_choice& command_option_choice::add_localization(const std::string
 
 command_option& command_option::add_localization(const std::string& language, const std::string& _name, const std::string& _description) {
 	name_localizations[language] = _name;
-	description_localizations[language] = _description;
+	if (! _description.empty()) {
+		description_localizations[language] = _description;
+	}
 	return *this;
 }
 

--- a/src/dpp/webhook.cpp
+++ b/src/dpp/webhook.cpp
@@ -35,9 +35,14 @@ webhook::webhook() : managed(), type(w_incoming), guild_id(0), channel_id(0), us
 
 webhook::webhook(const std::string& webhook_url) : webhook()
 {
-	token = webhook_url.substr(webhook_url.find_last_of("/") + 1);
+	auto pos = webhook_url.find_last_of('/');
+	if (pos == std::string::npos) { // throw when the url doesn't contain a slash at all
+		throw dpp::logic_exception(std::string("Failed to parse webhook URL: No '/' found in the webhook url"));
+	}
 	try {
-		id = std::stoull(webhook_url.substr(strlen("https://discord.com/api/webhooks/"), webhook_url.find_last_of("/")));
+		token = webhook_url.substr(pos + 1);
+		std::string endpoint = "https://discord.com/api/webhooks/";
+		id = std::stoull(webhook_url.substr(endpoint.size(), pos));
 	}
 	catch (const std::exception& e) {
 		throw dpp::logic_exception(std::string("Failed to parse webhook URL: ") + e.what());

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -182,6 +182,66 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		set_test("WEBHOOK", false);
 	}
 
+	{ // test interaction_create_t::get_parameter
+		// create a fake interaction
+		dpp::cluster cluster("");
+		dpp::discord_client client(&cluster, 1, 1, "");
+		dpp::interaction_create_t interaction(&client, "");
+
+		/* Check the method with subcommands */
+		set_test("GET_PARAMETER_WITH_SUBCOMMANDS", false);
+
+		dpp::command_interaction cmd_data; // command
+		cmd_data.type = dpp::ctxm_chat_input;
+		cmd_data.name = "command";
+
+		dpp::command_data_option subcommandgroup; // subcommand group
+		subcommandgroup.name = "group";
+		subcommandgroup.type = dpp::co_sub_command_group;
+
+		dpp::command_data_option subcommand; // subcommand
+		subcommand.name = "add";
+		subcommand.type = dpp::co_sub_command;
+
+		dpp::command_data_option option1; // slashcommand option
+		option1.name = "user";
+		option1.type = dpp::co_user;
+		option1.value = dpp::snowflake(189759562910400512);
+
+		dpp::command_data_option option2; // slashcommand option
+		option2.name = "checked";
+		option2.type = dpp::co_boolean;
+		option2.value = true;
+
+		// add them
+		subcommand.options.push_back(option1);
+		subcommand.options.push_back(option2);
+		subcommandgroup.options.push_back(subcommand);
+		cmd_data.options.push_back(subcommandgroup);
+		interaction.command.data = cmd_data;
+
+		dpp::snowflake value1 = std::get<dpp::snowflake>(interaction.get_parameter("user"));
+		set_test("GET_PARAMETER_WITH_SUBCOMMANDS", value1 == dpp::snowflake(189759562910400512));
+
+		/* Check the method without subcommands */
+		set_test("GET_PARAMETER_WITHOUT_SUBCOMMANDS", false);
+
+		dpp::command_interaction cmd_data2; // command
+		cmd_data2.type = dpp::ctxm_chat_input;
+		cmd_data2.name = "command";
+
+		dpp::command_data_option option3; // slashcommand option
+		option3.name = "number";
+		option3.type = dpp::co_integer;
+		option3.value = int64_t(123456);
+
+		cmd_data2.options.push_back(option3);
+		interaction.command.data = cmd_data2;
+
+		int64_t value2 = std::get<int64_t>(interaction.get_parameter("number"));
+		set_test("GET_PARAMETER_WITHOUT_SUBCOMMANDS", value2 == 123456);
+	}
+
 	{ // test dpp::command_option_choice::fill_from_json
 		set_test("OPTCHOICE_DOUBLE", false);
 		set_test("OPTCHOICE_INT", false);

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -106,7 +106,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 	set_test("HTTPS", false);
 	if (!offline) {
 		dpp::multipart_content multipart = dpp::https_client::build_multipart(
-			"{\"content\":\"test\"}", {"test.txt", "blob.blob"}, {"ABCDEFGHI", "BLOB!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"}
+			"{\"content\":\"test\"}", {"test.txt", "blob.blob"}, {"ABCDEFGHI", "BLOB!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"}, {"text/plain", "application/octet-stream"}
 		);
 		try {
 			dpp::https_client c("discord.com", 443, "/api/channels/" + std::to_string(TEST_TEXT_CHANNEL_ID) + "/messages", "POST", multipart.body,

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -293,15 +293,29 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 #ifndef _WIN32
 		success = dpp::snowflake_not_null(&j, "value") == 5120 && success;
 #endif
-		p.set(dpp::p_administrator, dpp::p_ban_members);
-		success = p.has(dpp::p_administrator) && success;
-		success = p.has(dpp::p_administrator) && p.has(dpp::p_ban_members) && success;
-		success = p.has(dpp::p_administrator, dpp::p_ban_members) && success;
-		success = p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+		p.set(0).add(~uint64_t{0}).remove(dpp::p_speak).set(dpp::p_administrator);
+		success = !p.has(dpp::p_administrator, dpp::p_ban_members) && success; // must return false because they're not both set
+		success = !p.has(dpp::p_administrator | dpp::p_ban_members) && success;
 
-		p.set(dpp::p_administrator);
-		success = ! p.has(dpp::p_administrator, dpp::p_ban_members) && success; // must return false because they're not both set
-		success = ! p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+		constexpr auto constexpr_test = [](dpp::permission p) constexpr noexcept {
+			bool success{true};
+
+			p.set(0).add(~uint64_t{0}).remove(dpp::p_speak).set(dpp::p_connect);
+			p.set(dpp::p_administrator, dpp::p_ban_members);
+			success = p.has(dpp::p_administrator) && success;
+			success = p.has(dpp::p_administrator) && p.has(dpp::p_ban_members) && success;
+			success = p.has(dpp::p_administrator, dpp::p_ban_members) && success;
+			success = p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+			success = p.add(dpp::p_speak).has(dpp::p_administrator, dpp::p_speak) && success;
+			success = !p.remove(dpp::p_speak).has(dpp::p_administrator, dpp::p_speak) && success;
+			return success;
+		};
+		constexpr auto constexpr_success = constexpr_test({~uint64_t{0}});
+
+		static_assert(constexpr_success, "dpp::permission constexpr test failed");
+		static_assert(noexcept(dpp::permission{}) && noexcept(dpp::permission(dpp::p_speak)));
+		static_assert(noexcept(p = 0) && noexcept(p = dpp::permission{}));
+
 		set_test("PERMISSION_CLASS", success);
 	}
 

--- a/src/unittest/unittest.cpp
+++ b/src/unittest/unittest.cpp
@@ -113,6 +113,8 @@ std::map<std::string, test_t> tests = {
 	{"JSON_PARSE_ERROR", {tt_online, "JSON parse error for post_rest", false, false}},
 	{"USER_GET_CACHED_PRESENT", {tt_online, "cluster::user_get_cached_sync() with present member", false, false}},
 	{"USER_GET_CACHED_ABSENT", {tt_online, "cluster::user_get_cached_sync() with not present member", false, false}},
+	{"GET_PARAMETER_WITH_SUBCOMMANDS", {tt_offline, "interaction_create_t::get_parameter() with subcommands", false, false}},
+	{"GET_PARAMETER_WITHOUT_SUBCOMMANDS", {tt_offline, "interaction_create_t::get_parameter() without subcommands", false, false}},
 };
 
 double start = dpp::utility::time_f();


### PR DESCRIPTION
This PR modernizes dpp::permission by making it constexpr-compatible, making use of C++17 features and common practices.

Notable changes :
- Made value data member public, changed class to struct
- Made member functions constexpr and noexcept (except for conversion to json)
- Added unit tests for it

This effectively allows for a user to declare constexpr variables with the type `dpp::permission`, allowing to make use of the class's convenience member functions. As the type is effectively a convenience wrapper around the enum `dpp::permissions`, it allows to be used as an extension of it in a constexpr context, this is useful for example if a user wants to make a constexpr command table with default permissions, it allows them to use the dpp::permission convenience methods instead of raw enum values, while still retaining the performance benefits of constexpr variables, as the compiler is able to inline the calls very easily in a constant context. The data member was made public to make the struct a literal type to be able to be used in a constexpr context. It was directly modifiable through the implicit reference conversion anyways, so there is no reason to keep it private.

The PR also applies some modern C++14 and C++17 practices, such as applying noexcept, using `std::enable_if_t` instead of `std::enable_if`, `std::is_convertible_v` instead of `std::is_convertible`, which slightly speeds up compilation time.