### PR TITLE
refactor: modernize dpp::permission

### DIFF
--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -82,38 +82,41 @@ enum permissions : uint64_t {
 using role_permissions = permissions;
 
 /**
- * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are hold in an uint64_t
+ * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are held in an uint64_t
  */
-class DPP_EXPORT permission {
-protected:
+struct DPP_EXPORT permission {
+
 	/**
 	 * @brief The permission bitmask value
 	 */
-	uint64_t value;
+	uint64_t value{0};
 
-public:
 	/**
-	 * @brief Construct a permission object
-	 * @param value A permission bitmask
+	 * @brief Default constructor, initializes permission to 0
 	 */
-	permission(const uint64_t& value);
+	constexpr permission() = default;
 
 	/**
- 	 * @brief Construct a permission object
- 	 */
-	permission();
+	 * @brief Bitmask constructor, initializes permission to the argument
+	 * @param value The bitmask to initialize the permission to
+	 */
+	constexpr permission(uint64_t value) noexcept : value{value} {}
 
 	/**
 	 * @brief For acting like an integer
 	 * @return The permission bitmask value
 	 */
-	operator uint64_t() const;
+	constexpr operator uint64_t() const noexcept {
+		return value;
+	}
 
 	/**
 	 * @brief For acting like an integer
 	 * @return A reference to the permission bitmask value
 	 */
-	operator uint64_t &();
+	constexpr operator uint64_t &() noexcept {
+		return value;
+	}
 
 	/**
 	 * @brief For building json
@@ -136,7 +139,7 @@ public:
 	 * @return bool True if it has all the given permissions
 	 */
 	template <typename... T>
-	bool has(T... values) const {
+	constexpr bool has(T... values) const noexcept {
 		return (value & (0 | ... | values)) == (0 | ... | values);
 	}
 
@@ -155,8 +158,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	add(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr add(T... values) noexcept {
 		value |= (0 | ... | values);
 		return *this;
 	}
@@ -175,8 +178,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	set(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr set(T... values) noexcept {
 		value = (0 | ... | values);
 		return *this;
 	}
@@ -196,8 +199,8 @@ public:
 	 * @return permission& reference to self for chaining
 	 */
 	template <typename... T>
-	typename std::enable_if<(std::is_convertible<T, uint64_t>::value && ...), permission&>::type
-	remove(T... values) {
+	std::enable_if_t<(std::is_convertible_v<T, uint64_t> && ...), permission&>
+	constexpr remove(T... values) noexcept {
 		value &= ~(0 | ... | values);
 		return *this;
 	}

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -84,13 +84,14 @@ using role_permissions = permissions;
 /**
  * @brief Represents a permission bitmask (refer to enum dpp::permissions) which are held in an uint64_t
  */
-struct DPP_EXPORT permission {
-
+class DPP_EXPORT permission {
+protected:
 	/**
 	 * @brief The permission bitmask value
 	 */
 	uint64_t value{0};
 
+public:
 	/**
 	 * @brief Default constructor, initializes permission to 0
 	 */

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -23,18 +23,6 @@
 
 namespace dpp {
 
-permission::permission(const uint64_t &value) : value(value) {}
-
-permission::permission() : permission(0) {}
-
-permission::operator uint64_t() const {
-	return value;
-}
-
-permission::operator uint64_t &() {
-	return value;
-}
-
 permission::operator nlohmann::json() const {
 	return std::to_string(value);
 }

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -293,15 +293,29 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 #ifndef _WIN32
 		success = dpp::snowflake_not_null(&j, "value") == 5120 && success;
 #endif
-		p.set(dpp::p_administrator, dpp::p_ban_members);
-		success = p.has(dpp::p_administrator) && success;
-		success = p.has(dpp::p_administrator) && p.has(dpp::p_ban_members) && success;
-		success = p.has(dpp::p_administrator, dpp::p_ban_members) && success;
-		success = p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+		p.set(0).add(~uint64_t{0}).remove(dpp::p_speak).set(dpp::p_administrator);
+		success = !p.has(dpp::p_administrator, dpp::p_ban_members) && success; // must return false because they're not both set
+		success = !p.has(dpp::p_administrator | dpp::p_ban_members) && success;
 
-		p.set(dpp::p_administrator);
-		success = ! p.has(dpp::p_administrator, dpp::p_ban_members) && success; // must return false because they're not both set
-		success = ! p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+		constexpr auto constexpr_test = [](dpp::permission p) constexpr noexcept {
+			bool success{true};
+
+			p.set(0).add(~uint64_t{0}).remove(dpp::p_speak).set(dpp::p_connect);
+			p.set(dpp::p_administrator, dpp::p_ban_members);
+			success = p.has(dpp::p_administrator) && success;
+			success = p.has(dpp::p_administrator) && p.has(dpp::p_ban_members) && success;
+			success = p.has(dpp::p_administrator, dpp::p_ban_members) && success;
+			success = p.has(dpp::p_administrator | dpp::p_ban_members) && success;
+			success = p.add(dpp::p_speak).has(dpp::p_administrator, dpp::p_speak) && success;
+			success = !p.remove(dpp::p_speak).has(dpp::p_administrator, dpp::p_speak) && success;
+			return success;
+		};
+		constexpr auto constexpr_success = constexpr_test({~uint64_t{0}});
+
+		static_assert(constexpr_success, "dpp::permission constexpr test failed");
+		static_assert(noexcept(dpp::permission{}) && noexcept(dpp::permission(dpp::p_speak)));
+		static_assert(noexcept(p = 0) && noexcept(p = dpp::permission{}));
+
 		set_test("PERMISSION_CLASS", success);
 	}
 

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -297,7 +297,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		success = !p.has(dpp::p_administrator, dpp::p_ban_members) && success; // must return false because they're not both set
 		success = !p.has(dpp::p_administrator | dpp::p_ban_members) && success;
 
-		constexpr auto constexpr_test = [](dpp::permission p) constexpr noexcept {
+		constexpr auto permission_test = [](dpp::permission p) constexpr noexcept {
 			bool success{true};
 
 			p.set(0).add(~uint64_t{0}).remove(dpp::p_speak).set(dpp::p_connect);
@@ -310,12 +310,8 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			success = !p.remove(dpp::p_speak).has(dpp::p_administrator, dpp::p_speak) && success;
 			return success;
 		};
-		constexpr auto constexpr_success = constexpr_test({~uint64_t{0}});
-
-		static_assert(constexpr_success, "dpp::permission constexpr test failed");
-		static_assert(noexcept(dpp::permission{}) && noexcept(dpp::permission(dpp::p_speak)));
-		static_assert(noexcept(p = 0) && noexcept(p = dpp::permission{}));
-
+		constexpr auto constexpr_success = permission_test({~uint64_t{0}}); // test in constant evaluated
+		success = permission_test({~uint64_t{0}}) && constexpr_success && success; // test at runtime
 		set_test("PERMISSION_CLASS", success);
 	}
 


### PR DESCRIPTION
This PR modernizes dpp::permission by making it constexpr-compatible, making use of C++17 features and common practices.

Notable changes :
- Made value data member public, changed class to struct
- Made member functions constexpr and noexcept (except for conversion to json which may throw)
- Added unit tests for it

This effectively allows for a user to declare constexpr variables with the type `dpp::permission`, allowing to make use of the class's convenience member functions. As the type is effectively a convenience wrapper around the enum `dpp::permissions`, it allows to be used as an extension of it in a constexpr context, this is useful for example if a user wants to make a constexpr command table with default permissions, it allows them to use the dpp::permission convenience methods instead of raw enum values, while still retaining the performance benefits of constexpr variables, as the compiler is able to inline the calls very easily in a constant context. The data member was made public to make the struct a literal type to be able to be used in a constexpr context. It was directly modifiable through the implicit reference conversion anyways, so there is no reason to keep it private.

The PR also applies some modern C++14 and C++17 practices, such as applying noexcept, using `std::enable_if_t` instead of `std::enable_if`, `std::is_convertible_v` instead of `std::is_convertible`, which slightly speeds up compilation time.

If this PR is accepted I will start a series of PRs updating other parts of the library to make use of C++17 features in a similar way.