### PR TITLE
fix: add missing mimetype to external HTTPS requests

### DIFF
--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -168,13 +168,12 @@ http_request_completion_t http_request::run(cluster* owner) {
 
 	multipart_content multipart;
 	if (non_discord) {
-		multipart = { postdata, "" };
+		multipart = { postdata, mimetype };
 	} else {
-
 		multipart = https_client::build_multipart(postdata, file_name, file_content, file_mimetypes);
-		if (!multipart.mimetype.empty()) {
-			headers.emplace("Content-Type", multipart.mimetype);
-		}
+	}
+	if (!multipart.mimetype.empty()) {
+		headers.emplace("Content-Type", multipart.mimetype);
 	}
 	http_connect_info hci = https_client::get_host_info(_host);
 	try {


### PR DESCRIPTION
See context [from the D++ discord server](https://discord.com/channels/825407338755653642/825411707521728512/1095776446196228237)