### PR TITLE
added explicit casting to avoid warnings

### DIFF
--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -165,7 +165,7 @@ template <uint64_t> uint64_t from_string(const std::string &s)
  */
 template <uint32_t> uint32_t from_string(const std::string &s)
 {
-	return std::stoul(s, 0, 10);
+	return (uint32_t) std::stoul(s, 0, 10);
 }
 
 /**
@@ -205,7 +205,7 @@ template <typename T> std::string to_hex(T i)
 template <typename T> std::string leading_zeroes(T i, size_t width)
 {
   std::stringstream stream;
-  stream << std::setfill('0') << std::setw(width) << std::dec << i;
+  stream << std::setfill('0') << std::setw((int)width) << std::dec << i;
   return stream.str();
 }
 

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -398,12 +398,12 @@ int discord_voice_client::udp_send(const char* data, size_t length)
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_port = htons(this->port);
 	servaddr.sin_addr.s_addr = inet_addr(this->ip.c_str());
-	return sendto(this->fd, data, (int)length, 0, (const sockaddr*)&servaddr, (int)sizeof(sockaddr_in));
+	return (int) sendto(this->fd, data, (int)length, 0, (const sockaddr*)&servaddr, (int)sizeof(sockaddr_in));
 }
 
 int discord_voice_client::udp_recv(char* data, size_t max_length)
 {
-	return recv(this->fd, data, (int)max_length, 0);
+	return (int) recv(this->fd, data, (int)max_length, 0);
 }
 
 bool discord_voice_client::handle_frame(const std::string &data)

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -480,7 +480,7 @@ void ssl_client::read_loop()
 				if (plaintext) {
 					read_blocked_on_write = false;
 					read_blocked = false;
-					r = ::recv(sfd, server_to_client_buffer, DPP_BUFSIZE, 0);
+					r = (int) ::recv(sfd, server_to_client_buffer, DPP_BUFSIZE, 0);
 					if (r <= 0) {
 						/* error or EOF */
 						return;
@@ -551,7 +551,7 @@ void ssl_client::read_loop()
 				/* Try to write */
 
 				if (plaintext) {
-					r = ::send(sfd, client_to_server_buffer + client_to_server_offset, (int)client_to_server_length, 0);
+					r = (int) ::send(sfd, client_to_server_buffer + client_to_server_offset, (int)client_to_server_length, 0);
 
 					if (r < 0) {
 						/* Write error */


### PR DESCRIPTION
Using a MacOS 13.2 with Xcode 14.2 I received the following warnings. 

Implicit conversion loses integer precision: 'unsigned long' to 'uint32_t' (aka 'unsigned int')
Implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int'

Added casts solved the warnings and is still consistent with the intention of the code.