### PR TITLE
feat: added on_guild_audit_log_entry_create gateway event

### DIFF
--- a/include/dpp/auditlog.h
+++ b/include/dpp/auditlog.h
@@ -177,7 +177,7 @@ struct DPP_EXPORT audit_extra {
 /**
  * @brief An individual audit log entry
  */
-struct DPP_EXPORT audit_entry {
+struct DPP_EXPORT audit_entry : public json_interface<audit_entry> {
 	snowflake			id;		//!< id of the entry
 	/**
 	 * ID of the affected entity (webhook, user, role, etc.) (may be empty)
@@ -189,6 +189,18 @@ struct DPP_EXPORT audit_entry {
 	audit_type			type;		//!< type of action that occurred
 	std::optional<audit_extra>	extra;	//!< Optional: additional info for certain action types
 	std::string			reason;		//!< Optional: the reason for the change (1-512 characters)
+
+	/** Constructor */
+	audit_entry();
+
+	/** Destructor */
+	virtual ~audit_entry() = default;
+
+	/** Read class values from json object
+	 * @param j A json object to read from
+	 * @return A reference to self
+	 */
+	audit_entry& fill_from_json(nlohmann::json* j);
 };
 
 /**

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -947,6 +947,14 @@ public:
 	 */
 	event_router_t<message_create_t> on_message_create;
 
+	/**
+	 * @brief Called when a guild audit log entry is created.
+	 *
+	 * @see https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create
+	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
+	 * The function signature for this event takes a single `const` reference of type guild_audit_log_entry_create_t&, and returns void.
+	 */
+	event_router_t<guild_audit_log_entry_create_t> on_guild_audit_log_entry_create;
 	
 	/**
 	 * @brief Called when a ban is added to a guild.

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -40,6 +40,7 @@
 #include <dpp/scheduled_event.h>
 #include <dpp/stage_instance.h>
 #include <dpp/integration.h>
+#include <dpp/auditlog.h>
 #include <functional>
 #include <variant>
 #include <exception>
@@ -1398,6 +1399,19 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @note confirmation_callback_t::value contains a message object on success. On failure, value is undefined and confirmation_callback_t::is_error() is true.
 	 */
 	void reply(message&& msg, bool mention_replied_user = false, command_completion_event_t callback = utility::log_error()) const;
+};
+
+/** @brief Guild audit log entry create */
+struct DPP_EXPORT guild_audit_log_entry_create_t : public event_dispatch_t {
+	/** Constructor
+	 * @param client The shard the event originated on
+	 * @param raw Raw event text as JSON
+	 */
+	guild_audit_log_entry_create_t(class discord_client* client, const std::string& raw);
+	/**
+	 * @brief created audit log entry
+	 */
+	audit_entry entry;
 };
 
 /** @brief Guild ban add */

--- a/include/dpp/event.h
+++ b/include/dpp/event.h
@@ -148,4 +148,7 @@ event_decl(automod_rule_update, AUTO_MODERATION_RULE_UPDATE);
 event_decl(automod_rule_delete, AUTO_MODERATION_RULE_DELETE);
 event_decl(automod_rule_execute, AUTO_MODERATION_ACTION_EXECUTION);
 
+/* Audit log */
+event_decl(guild_audit_log_entry_create, GUILD_AUDIT_LOG_ENTRY_CREATE);
+
 }};

--- a/src/dpp/auditlog.cpp
+++ b/src/dpp/auditlog.cpp
@@ -26,45 +26,51 @@ namespace dpp {
 
 using json = nlohmann::json;
 
+audit_entry::audit_entry(): type(aut_guild_update) {
+}
+
+audit_entry &audit_entry::fill_from_json(nlohmann::json *j) {
+	this->id = snowflake_not_null(j, "id");
+	this->type = (audit_type)int8_not_null(j, "action_type");
+	this->user_id = snowflake_not_null(j, "user_id");
+	this->target_id = snowflake_not_null(j, "target_id");
+	this->reason = string_not_null(j, "reason");
+	if (j->contains("changes")) {
+		auto &c = (*j)["changes"];
+		for (auto & change : c) {
+			audit_change ac;
+			ac.key = string_not_null(&change, "key");
+			if (change.find("new_value") != change.end()) {
+				ac.new_value = change["new_value"].dump();
+			}
+			if (change.find("old_value") != change.end()) {
+				ac.old_value = change["old_value"].dump();
+			}
+			this->changes.push_back(ac);
+		}
+	}
+	if (j->contains("options")) {
+		auto &o = (*j)["options"];
+		audit_extra opts;
+		opts.automod_rule_name = string_not_null(&o, "auto_moderation_rule_name");
+		opts.automod_rule_trigger_type = string_not_null(&o, "auto_moderation_rule_trigger_type");
+		opts.channel_id = snowflake_not_null(&o, "channel_id");
+		opts.count = string_not_null(&o, "count");
+		opts.delete_member_days = string_not_null(&o, "delete_member_days");
+		opts.id = snowflake_not_null(&o, "id");
+		opts.members_removed = string_not_null(&o, "members_removed");
+		opts.message_id = snowflake_not_null(&o, "message_id");
+		opts.role_name = string_not_null(&o, "role_name");
+		opts.type = string_not_null(&o, "type");
+		opts.application_id = snowflake_not_null(&o, "application_id");
+		this->extra = opts;
+	}
+	return *this;
+}
+
 auditlog& auditlog::fill_from_json(nlohmann::json* j) {
 	for (auto &ai : (*j)["audit_log_entries"]) {
-		audit_entry ae;
-		ae.id = snowflake_not_null(&ai, "id");
-		ae.type = (audit_type)int8_not_null(&ai, "action_type");
-		ae.user_id = snowflake_not_null(&ai, "user_id");
-		ae.target_id = snowflake_not_null(&ai, "target_id");
-		ae.reason = string_not_null(&ai, "reason");
-		if (ai.contains("changes")) {
-			auto &c = ai["changes"];
-			for (auto & change : c) {
-				audit_change ac;
-				ac.key = string_not_null(&change, "key");
-				if (change.find("new_value") != change.end()) {
-					ac.new_value = change["new_value"].dump();
-				}
-				if (change.find("old_value") != change.end()) {
-					ac.old_value = change["old_value"].dump();
-				}
-				ae.changes.push_back(ac);
-			}
-		}
-		if (ai.contains("options")) {
-			auto &o = ai["options"];
-			audit_extra opts;
-			opts.automod_rule_name = string_not_null(&o, "auto_moderation_rule_name");
-			opts.automod_rule_trigger_type = string_not_null(&o, "auto_moderation_rule_trigger_type");
-			opts.channel_id = snowflake_not_null(&o, "channel_id");
-			opts.count = string_not_null(&o, "count");
-			opts.delete_member_days = string_not_null(&o, "delete_member_days");
-			opts.id = snowflake_not_null(&o, "id");
-			opts.members_removed = string_not_null(&o, "members_removed");
-			opts.message_id = snowflake_not_null(&o, "message_id");
-			opts.role_name = string_not_null(&o, "role_name");
-			opts.type = string_not_null(&o, "type");
-			opts.application_id = snowflake_not_null(&o, "application_id");
-			ae.extra = opts;
-		}
-		this->entries.emplace_back(ae);
+		this->entries.emplace_back(audit_entry().fill_from_json(&ai));
 	}
 	return *this;
 }

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -341,7 +341,7 @@ const std::map<std::string, dpp::events::event*> eventmap = {
 	{ "AUTO_MODERATION_RULE_UPDATE", new dpp::events::automod_rule_update() },
 	{ "AUTO_MODERATION_RULE_DELETE", new dpp::events::automod_rule_delete() },
 	{ "AUTO_MODERATION_ACTION_EXECUTION", new dpp::events::automod_rule_execute() },
-	{ "GUILD_AUDIT_LOG_ENTRY_CREATE", nullptr }, /* TODO: Implement this event */
+	{ "GUILD_AUDIT_LOG_ENTRY_CREATE", new dpp::events::guild_audit_log_entry_create() },
 };
 
 void discord_client::handle_event(const std::string &event, json &j, const std::string &raw)

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -299,6 +299,7 @@ event_ctor(invite_create_t, event_dispatch_t);
 event_ctor(message_update_t, event_dispatch_t);
 event_ctor(user_update_t, event_dispatch_t);
 event_ctor(message_create_t, event_dispatch_t);
+event_ctor(guild_audit_log_entry_create_t, event_dispatch_t);
 event_ctor(guild_ban_add_t, event_dispatch_t);
 event_ctor(guild_ban_remove_t, event_dispatch_t);
 event_ctor(integration_create_t, event_dispatch_t);

--- a/src/dpp/events/guild_audit_log_entry_create.cpp
+++ b/src/dpp/events/guild_audit_log_entry_create.cpp
@@ -20,9 +20,6 @@
  ************************************************************************************/
 #include <dpp/discordevents.h>
 #include <dpp/cluster.h>
-#include <dpp/scheduled_event.h>
-#include <dpp/stringops.h>
-#include <dpp/json.h>
 
 namespace dpp { namespace events {
 

--- a/src/dpp/events/guild_audit_log_entry_create.cpp
+++ b/src/dpp/events/guild_audit_log_entry_create.cpp
@@ -1,0 +1,49 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/discordevents.h>
+#include <dpp/cluster.h>
+#include <dpp/scheduled_event.h>
+#include <dpp/stringops.h>
+#include <dpp/json.h>
+
+namespace dpp { namespace events {
+
+using json = nlohmann::json;
+using namespace dpp;
+
+
+/**
+ * @brief Handle event
+ *
+ * @param client Websocket client (current shard)
+ * @param j JSON data for the event
+ * @param raw Raw JSON string
+ */
+void guild_audit_log_entry_create::handle(discord_client* client, json &j, const std::string &raw) {
+	json& d = j["d"];
+	if (!client->creator->on_guild_audit_log_entry_create.empty()) {
+		dpp::guild_audit_log_entry_create_t ec(client, raw);
+		ec.entry.fill_from_json(&d);
+		client->creator->on_guild_audit_log_entry_create.call(ec);
+	}
+}
+
+}};


### PR DESCRIPTION
This PR implements the missing Guild Audit Log Entry Create gateway event.
Reference: https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create

Tested simply using
```c++
bot.on_guild_audit_log_entry_create([](const dpp::guild_audit_log_entry_create_t &event) {
	std::cout << "audit log entry received; reason: " << event.entry.reason << " , user_id: " << event.entry.user_id << " , type: " << to_string(event.entry.type) << std::endl;
});
```