### PR TITLE
feat: added guild member flags

### DIFF
--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -158,19 +158,27 @@ enum guild_flags_extra : uint16_t {
 
 /**
  * @brief Various flags that can be used to indicate the status of a guild member.
- * @note Use set_mute and set_deaf member functions and do not toggle the bits yourself.
+ * @note Use the setter functions in dpp::guild_member and do not toggle the bits yourself.
  */
-enum guild_member_flags : uint8_t {
+enum guild_member_flags : uint16_t {
 	/** Member deafened in voice channels */
-	gm_deaf =		0b00000001,
+	gm_deaf =		0b0000000000000001,
 	/** Member muted in voice channels */
-	gm_mute =		0b00000010,
+	gm_mute =		0b0000000000000010,
 	/** Member pending verification by membership screening */
-	gm_pending =		0b00000100,
+	gm_pending =		0b0000000000000100,
 	/** Member has animated guild-specific avatar */
-	gm_animated_avatar = 	0b00001000,
+	gm_animated_avatar = 	0b0000000000001000,
 	/** gm_deaf or gm_mute has been toggled */
-	gm_voice_action = 		0b00010000,
+	gm_voice_action = 		0b0000000000010000,
+	/** Member has left and rejoined the guild */
+	gm_did_rejoin = 0b0000000000100000,
+	/** Member has completed onboarding */
+	gm_completed_onboarding = 0b0000000001000000,
+	/** Member is exempt from guild verification requirements */
+	gm_bypasses_verification = 0b0000000010000000,
+	/** Member has started onboarding */
+	gm_started_onboarding = 0b0000000100000000,
 };
 
 /**
@@ -196,7 +204,7 @@ public:
 	/** Boosting since */
 	time_t premium_since;
 	/** A set of flags built from the bitmask defined by dpp::guild_member_flags */
-	uint8_t flags;
+	uint16_t flags;
 
 	/** Default constructor */
 	guild_member();
@@ -250,6 +258,38 @@ public:
 	bool is_pending() const;
 
 	/**
+	 * @brief Returns true if the user has left and rejoined the guild
+	 *
+	 * @return true user has left and rejoined the guild
+	 * @return false user has not rejoined
+	 */
+	bool has_rejoined() const;
+
+	/**
+	 * @brief Returns true if the user has completed onboarding
+	 *
+	 * @return true user has completed onboarding
+	 * @return false user has not completed onboarding
+	 */
+	bool has_completed_onboarding() const;
+
+	/**
+	 * @brief Returns true if the user has started onboarding
+	 *
+	 * @return true user has started onboarding
+	 * @return false user has not started onboarding yet
+	 */
+	bool has_started_onboarding() const;
+
+	/**
+	 * @brief Returns true if the user is exempt from guild verification requirements
+	 *
+	 * @return true user bypasses verification
+	 * @return false user doesn't bypass verification
+	 */
+	bool has_bypasses_verification() const;
+
+	/**
 	 * @brief Returns true if the user's per-guild custom avatar is animated
 	 * 
 	 * @return true user's custom avatar is animated
@@ -294,6 +334,15 @@ public:
 	 */
 	
 	bool operator == (guild_member const& other_member) const;
+
+	/**
+	 * @brief Set whether the user is exempt from guild verification requirements
+	 *
+	 * @param is_bypassing_verification value to set
+	 *
+	 * @return guild_member& reference to self
+	 */
+	guild_member& set_bypasses_verification(const bool is_bypassing_verification);
 
 	/**
 	 * @brief Set whether the user is muted in voice channels

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -107,6 +107,11 @@ guild_member& guild_member::set_nickname(const std::string& nick) {
 	return *this;
 }
 
+guild_member& guild_member::set_bypasses_verification(const bool is_bypassing_verification) {
+	this->flags = (is_bypassing_verification) ? flags | gm_bypasses_verification : flags & ~gm_bypasses_verification;
+	return *this;
+}
+
 guild_member& guild_member::set_mute(const bool is_muted) {
 	this->flags = (is_muted) ? flags | gm_mute : flags & ~gm_mute;
 	this->flags |= gm_voice_action;
@@ -147,6 +152,20 @@ void from_json(const nlohmann::json& j, guild_member& gm) {
 	set_ts_not_null(&j, "joined_at", gm.joined_at);
 	set_ts_not_null(&j, "premium_since", gm.premium_since);
 	set_ts_not_null(&j, "communication_disabled_until", gm.communication_disabled_until);
+
+	uint16_t flags = int16_not_null(&j, "flags");
+	if (flags & 1 << 0) {
+		gm.flags |= dpp::gm_did_rejoin;
+	}
+	if (flags & 1 << 1) {
+		gm.flags |= dpp::gm_completed_onboarding;
+	}
+	if (flags & 1 << 2) {
+		gm.flags |= dpp::gm_bypasses_verification;
+	}
+	if (flags & 1 << 3) {
+		gm.flags |= dpp::gm_started_onboarding;
+	}
 
 	gm.roles.clear();
 	if (j.contains("roles") && !j.at("roles").is_null()) {
@@ -213,15 +232,21 @@ std::string guild_member::build_json(bool with_id) const {
 		j["nick"] = this->nickname;
 	if (!this->roles.empty()) {
 		j["roles"] = {};
-		for (auto & role : roles) {
+		for (auto & role : this->roles) {
 			j["roles"].push_back(std::to_string(role));
 		}
 	}
 
-	if (flags & gm_voice_action) {
+	if (this->flags & gm_voice_action) {
 		j["mute"] = is_muted();
 		j["deaf"] = is_deaf();
 	}
+
+	uint16_t out_flags = 0;
+	if (this->flags & gm_bypasses_verification) {
+		out_flags |= 1 << 2;
+	}
+	j["flags"] = out_flags;
 
 	return j.dump();
 }
@@ -245,6 +270,22 @@ bool guild_member::is_muted() const {
 
 bool guild_member::is_pending() const {
 	return flags & dpp::gm_pending;
+}
+
+bool guild_member::has_rejoined() const {
+	return flags & dpp::gm_did_rejoin;
+}
+
+bool guild_member::has_completed_onboarding() const {
+	return flags & dpp::gm_completed_onboarding;
+}
+
+bool guild_member::has_started_onboarding() const {
+	return flags & dpp::gm_started_onboarding;
+}
+
+bool guild_member::has_bypasses_verification() const {
+	return flags & dpp::gm_bypasses_verification;
 }
 
 bool guild::is_large() const {


### PR DESCRIPTION
Reference: https://github.com/discord/discord-api-docs/commit/c38ca4d817cde888c1a3d601aed98ffcea2a154a

**This PR bumps the guild member flags from `uint8_t` to `uint16_t`**!

Added The 4 missing guild member flags. Added a setter for the BYPASSES_VERIFICATION flag and getter for all 4. Haven't tested to edit a guild member with the new flags btw.