### PR TITLE
fix: fixed memory leak and potential use-after-free bug with voiceconn

### DIFF
--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -360,7 +360,7 @@ public:
 	/**
 	 * @brief List of voice channels we are connecting to keyed by guild id
 	 */
-	std::unordered_map<snowflake, voiceconn*> connecting_voice_channels;
+	std::unordered_map<snowflake, std::unique_ptr<voiceconn>> connecting_voice_channels;
 
 	/**
 	 * @brief The gateway address we reconnect to when we resume a session

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -610,7 +610,7 @@ discord_client& discord_client::connect_voice(snowflake guild_id, snowflake chan
 #ifdef HAVE_VOICE
 	std::unique_lock lock(voice_mutex);
 	if (connecting_voice_channels.find(guild_id) == connecting_voice_channels.end()) {
-		connecting_voice_channels[guild_id] = new voiceconn(this, channel_id);
+		connecting_voice_channels[guild_id] = std::make_unique<voiceconn>(this, channel_id);
 		/* Once sent, this expects two events (in any order) on the websocket:
 		* VOICE_SERVER_UPDATE and VOICE_STATUS_UPDATE
 		*/
@@ -658,8 +658,6 @@ void discord_client::disconnect_voice_internal(snowflake guild_id, bool emit_jso
 				}
 			})), false);
 		}
-		delete v->second;
-		v->second = nullptr;
 		connecting_voice_channels.erase(v);
 	}
 #endif
@@ -675,7 +673,7 @@ voiceconn* discord_client::get_voice(snowflake guild_id) {
 	std::shared_lock lock(voice_mutex);
 	auto v = connecting_voice_channels.find(guild_id);
 	if (v != connecting_voice_channels.end()) {
-		return v->second;
+		return v->second.get();
 	}
 #endif
 	return nullptr;


### PR DESCRIPTION
dpp::discord_voice_client does not free its active voice connections on destruction. This means that, when the cluster/voice client gets destroyed, any dpp::voiceconn objects as well as threads they have running won't be joined or freed. This causes not only a memory leak, but in the event of the cluster/voice client getting destroyed, and the still alive voiceconn thread trying to for example log a message, a use-after-free will occur and cause undefined behavior (usually a crash). This has happened to me about on about 50% of my executions of the unit tests on Windows.

This PR fixes this bug. However it does make use of std::unique_ptr, that as I understand it the library does not usually use, let me know if you would like me to change it to new/delete instead.