### PR TITLE
Fix: Adapt dpp::user::get_default_avatar() to new username system 

### DIFF
--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -116,6 +116,10 @@ std::string user::get_default_avatar_url() const {
 		return utility::cdn_endpoint_url({ i_png },
 										 "embed/avatars/" + std::to_string(this->discriminator % 5),
 										 i_png, 0);
+	} else if (this->id){
+		return utility::cdn_endpoint_url({ i_png },
+										 "embed/avatars/" + std::to_string((this->id >> 22) % 6),
+										 i_png, 0);
 	} else {
 		return std::string();
 	}


### PR DESCRIPTION
Update dpp::user::get_default_avatar() to also work with new username system (see ** under https://discord.com/developers/docs/reference#image-formatting) 
![image](https://github.com/brainboxdotcc/DPP/assets/84308084/5ca68779-1c34-407c-8427-ff3f36ba19b2)
