### PR TITLE
feat: Added global_name to dpp::user

### DIFF
--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -89,13 +89,19 @@ class DPP_EXPORT user : public managed, public json_interface<user>  {
 public:
 	/** Discord username */
 	std::string username;
+	/** Global display name
+	 * 
+	 * @note Only present for users that have migrated to the new username format.
+	 */
+	std::string global_name;
 	/** Avatar hash */
 	utility::iconhash avatar;
 	/** Flags built from a bitmask of values in dpp::user_flags */
 	uint32_t flags;
 	/** Discriminator (aka tag), 4 digits usually displayed with leading zeroes.
 	 *
-	 * @note To print the discriminator with leading zeroes, use format_username()
+	 * @note To print the discriminator with leading zeroes, use format_username(). 
+	 * 0 for users that have migrated to the new username format.
 	 */
 	uint16_t discriminator;
 	/** Reference count of how many guilds this user is in */

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -89,10 +89,7 @@ class DPP_EXPORT user : public managed, public json_interface<user>  {
 public:
 	/** Discord username */
 	std::string username;
-	/** Global display name
-	 * 
-	 * @note Only present for users that have migrated to the new username format.
-	 */
+	/** Global display name */
 	std::string global_name;
 	/** Avatar hash */
 	utility::iconhash avatar;

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -67,6 +67,7 @@ std::string user::build_json(bool with_id) const {
 
 	j["id"] = id;
 	j["username"] = username;
+	j["global_name"] = global_name; 
 	j["avatar"] = avatar.to_string();
 	j["discriminator"] = discriminator;
 	j["bot"] = is_bot();
@@ -265,6 +266,7 @@ void from_json(const nlohmann::json& j, user_identified& u) {
 void from_json(const nlohmann::json& j, user& u) {
 	u.id = snowflake_not_null(&j, "id");
 	u.username = string_not_null(&j, "username");
+	u.global_name = string_not_null(&j, "global_name");
 
 	std::string av = string_not_null(&j, "avatar");
 	if (av.length() > 2 && av.substr(0, 2) == "a_") {


### PR DESCRIPTION
https://discord.com/developers/docs/resources/user#users-resource 
Users can now set a global_name, and since the Dev docs now tell us we can expect it in the user object we should add it to dpp::user