### PR TITLE
[vcpkg] Move misplaced compiler definitions to options and make linker option Debug-Mode dependent

### DIFF
--- a/library-vcpkg/CMakeLists.txt
+++ b/library-vcpkg/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(
 
 target_link_options(
 	"${LIB_NAME}" PUBLIC
-	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>/DEBUG>>"
+	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:/DEBUG>>"
 )
 
 add_compile_definitions(HAVE_VOICE)

--- a/library-vcpkg/CMakeLists.txt
+++ b/library-vcpkg/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(
 
 target_link_options(
 	"${LIB_NAME}" PUBLIC
-	"$<$<PLATFORM_ID:Windows>:/DEBUG>"
+	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>/DEBUG>>"
 )
 
 add_compile_definitions(HAVE_VOICE)

--- a/library-vcpkg/CMakeLists.txt
+++ b/library-vcpkg/CMakeLists.txt
@@ -14,13 +14,13 @@ add_library("${PROJECT_NAME}::${LIB_NAME}" ALIAS "${LIB_NAME}")
 target_compile_definitions(
 	"${LIB_NAME}" PUBLIC
 	"DPP_BUILD"
-	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:/sdl;/std:c++17;/Od;/DEBUG;/sdl;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
-	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Release>:/std:c++17;/O2;/Oi;/Oy;/GL;/Gy;/sdl;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
 )
 
 target_compile_options(
 	"${LIB_NAME}" PUBLIC
 	"$<$<PLATFORM_ID:Windows>:/bigobj>"
+ 	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:/sdl;/std:c++17;/Od;/DEBUG;/sdl;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
+	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Release>:/std:c++17;/O2;/Oi;/Oy;/GL;/Gy;/sdl;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
 	"$<$<PLATFORM_ID:Linux>:$<$<CONFIG:Debug>:-std=c++17;-Wall;-Wempty-body;-Wno-psabi;-Wunknown-pragmas;-Wignored-qualifiers;-Wimplicit-fallthrough;-Wmissing-field-initializers;-Wsign-compare;-Wtype-limits;-Wuninitialized;-Wshift-negative-value;-pthread;-g;-Og;-fPIC>>"
 	"$<$<PLATFORM_ID:Linux>:$<$<CONFIG:Release>:-std=c++17;-Wall;-Wempty-body;-Wno-psabi;-Wunknown-pragmas;-Wignored-qualifiers;-Wimplicit-fallthrough;-Wmissing-field-initializers;-Wsign-compare;-Wtype-limits;-Wuninitialized;-Wshift-negative-value;-pthread;-O3;-fPIC>>"
 )


### PR DESCRIPTION
Hello everyone 👋 

Using DPP with vcpkg and CMake on Windows seems to create some trouble when it comes to compiler definitions. They look like they are compiler options, not definitions.
Moving them fixes an annoying intellisense error in Visual Studio (`command-line error: invalid macro definition: /sdl`) - atleast inside the auto-generated cmake-file (share-dir).
Sadly I can't test these changes on my own, I am completly new to vcpkg.

Additionally I thought it would make more sense to remove the /DEBUG-Option for everything but Debug builds, I don't really see a point for this option if we build Release - it will be tested in Debug anyway, right? Feel free to correct me.

Possible fix for #710