### PR TITLE
fix: force dpp::to_hex to use std::locale::classic for formatting

### DIFF
--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -190,6 +190,7 @@ template <int> int from_string(const std::string &s)
 template <typename T> std::string to_hex(T i)
 {
   std::stringstream stream;
+	stream.imbue(std::locale::classic());
   stream << std::setfill('0') << std::setw(sizeof(T)*2) << std::hex << i;
   return stream.str();
 }
@@ -205,6 +206,7 @@ template <typename T> std::string to_hex(T i)
 template <typename T> std::string leading_zeroes(T i, size_t width)
 {
   std::stringstream stream;
+	stream.imbue(std::locale::classic());
   stream << std::setfill('0') << std::setw((int)width) << std::dec << i;
   return stream.str();
 }


### PR DESCRIPTION
Title. This notably fixes HTTP multipart requests failing if locale is set to something else globally, due to form hex boundaries having for example commas in them, making them ill-formed. (see [src/dpp/httpsclient.cpp:86](https://github.com/brainboxdotcc/DPP/blob/a822694ed6b1a103a3fc09bcf495059d60997796/src/dpp/httpsclient.cpp#L86))