### PR TITLE
test: add extended unit tests mode

### DIFF
--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -40,6 +40,8 @@ enum test_type_t {
 	tt_offline,
 	/* A test that requires discord connectivity */
 	tt_online,
+	/* A test that requires both online and full tests to be enabled */
+	tt_extended
 };
 
 /* Represents a test case */
@@ -75,6 +77,7 @@ extern dpp::snowflake TEST_EVENT_ID;
 
 /* True if we skip tt_online tests */
 extern bool offline;
+extern bool extended;
 
 /**
  * @brief Perform a test of a REST base API call with one parameter
@@ -314,8 +317,3 @@ inline constexpr user_project_id_t get_user_snowflake;
 inline constexpr auto is_owner = [](auto &&user) noexcept {
 	return get_user_snowflake(user) == TEST_USER_ID;
 };
-
-/**
- * @brief Thread emoji - https://www.compart.com/en/unicode/U+1F9F5
- */
-inline const std::string THREAD_EMOJI = "\xF0\x9F\xA7\xB5";

--- a/src/unittest/unittest.cpp
+++ b/src/unittest/unittest.cpp
@@ -33,8 +33,6 @@ std::map<std::string, test_t> tests = {
 	{"MESSAGECREATE", {tt_online, "Creation of a channel message", false, false}},
 	{"MESSAGEEDIT", {tt_online, "Editing a channel message", false, false}},
 	{"EDITEVENT", {tt_online, "Message edit event", false, false}},
-	{"MESSAGEPIN", {tt_online, "Pinning a channel message", false, false}},
-	{"MESSAGEUNPIN", {tt_online, "Unpinning a channel message", false, false}},
 	{"MESSAGEDELETE", {tt_online, "Deletion of a channel message", false, false}},
 	{"MESSAGERECEIVE", {tt_online, "Receipt of a created message", false, false}},
 	{"MESSAGEFILE", {tt_online, "Message attachment send and check", false, false}},
@@ -103,21 +101,7 @@ std::map<std::string, test_t> tests = {
 	{"THREAD_DELETE_EVENT", {tt_online, "cluster::on_thread_delete event", false, false}},
 	{"THREAD_EDIT", {tt_online, "cluster::thread_edit", false, false}},
 	{"THREAD_UPDATE_EVENT", {tt_online, "cluster::on_thread_update event", false, false}},
-	{"THREAD_MEMBER_ADD", {tt_online, "cluster::thread_member_add", false, false}},
-	{"THREAD_MEMBER_GET", {tt_online, "cluster::thread_member_get", false, false}},
-	{"THREAD_MEMBERS_GET", {tt_online, "cluster::thread_members_get", false, false}},
-	{"THREAD_MEMBER_REMOVE", {tt_online, "cluster::thread_member_remove", false, false}},
-	{"THREAD_MEMBERS_ADD_EVENT", {tt_online, "cluster::on_thread_members_update event with member addition", false, false}},
-	{"THREAD_MEMBERS_REMOVE_EVENT", {tt_online, "cluster::on_thread_members_update event with member removal", false, false}},
-	{"THREAD_CREATE_MESSAGE", {tt_online, "cluster::thread_create_with_message", false, false}},
 	{"THREAD_GET_ACTIVE", {tt_online, "cluster::threads_get_active", false, false}},
-
-	{"THREAD_MESSAGE", {tt_online, "message manipulation in thread", false, false}},
-	{"THREAD_MESSAGE_CREATE_EVENT", {tt_online, "cluster::on_message_create in thread", false, false}},
-	{"THREAD_MESSAGE_EDIT_EVENT", {tt_online, "cluster::on_message_edit in thread", false, false}},
-	{"THREAD_MESSAGE_DELETE_EVENT", {tt_online, "cluster::on_message_delete in thread", false, false}},
-	{"THREAD_MESSAGE_REACT_ADD_EVENT", {tt_online, "cluster::on_reaction_add in thread", false, false}},
-	{"THREAD_MESSAGE_REACT_REMOVE_EVENT", {tt_online, "cluster::on_reaction_remove in thread", false, false}},
 
 	{"VOICE_CHANNEL_CREATE", {tt_online, "creating a voice channel", false, false}},
 	{"VOICE_CHANNEL_EDIT", {tt_online, "editing the created voice channel", false, false}},
@@ -169,10 +153,31 @@ std::map<std::string, test_t> tests = {
 	{"INVITE_CREATE", {tt_online, "cluster::channel_invite_create", false, false}},
 	{"INVITE_GET", {tt_online, "cluster::invite_get", false, false}},
 	{"INVITE_DELETE", {tt_online, "cluster::invite_delete", false, false}},
+
+	/* Extended set -- Less important, skipped on the master branch due to rate limits and GitHub actions limitations*/
+	/* To execute, run unittests with "full" command line argument */
+	{"MESSAGEPIN", {tt_extended, "Pinning a channel message", false, false}},
+	{"MESSAGEUNPIN", {tt_extended, "Unpinning a channel message", false, false}},
+
+	{"THREAD_MEMBER_ADD", {tt_extended, "cluster::thread_member_add", false, false}},
+	{"THREAD_MEMBER_GET", {tt_extended, "cluster::thread_member_get", false, false}},
+	{"THREAD_MEMBERS_GET", {tt_extended, "cluster::thread_members_get", false, false}},
+	{"THREAD_MEMBER_REMOVE", {tt_extended, "cluster::thread_member_remove", false, false}},
+	{"THREAD_MEMBERS_ADD_EVENT", {tt_extended, "cluster::on_thread_members_update event with member addition", false, false}},
+	{"THREAD_MEMBERS_REMOVE_EVENT", {tt_extended, "cluster::on_thread_members_update event with member removal", false, false}},
+	{"THREAD_CREATE_MESSAGE", {tt_extended, "cluster::thread_create_with_message", false, false}},
+
+	{"THREAD_MESSAGE", {tt_extended, "message manipulation in thread", false, false}},
+	{"THREAD_MESSAGE_CREATE_EVENT", {tt_extended, "cluster::on_message_create in thread", false, false}},
+	{"THREAD_MESSAGE_EDIT_EVENT", {tt_extended, "cluster::on_message_edit in thread", false, false}},
+	{"THREAD_MESSAGE_DELETE_EVENT", {tt_extended, "cluster::on_message_delete in thread", false, false}},
+	{"THREAD_MESSAGE_REACT_ADD_EVENT", {tt_extended, "cluster::on_reaction_add in thread", false, false}},
+	{"THREAD_MESSAGE_REACT_REMOVE_EVENT", {tt_extended, "cluster::on_reaction_remove in thread", false, false}},
 };
 
 double start = dpp::utility::time_f();
 bool offline = false;
+bool extended = false;
 
 dpp::snowflake TEST_GUILD_ID = std::stoull(SAFE_GETENV("TEST_GUILD_ID"));
 dpp::snowflake TEST_TEXT_CHANNEL_ID = std::stoull(SAFE_GETENV("TEST_TEXT_CHANNEL_ID"));
@@ -216,7 +221,7 @@ int test_summary() {
 	std::cout << "\u001b[37;1m\n\nUNIT TEST SUMMARY\n==================\n\u001b[0m";
 	for (auto & t : tests) {
 		bool test_skipped = false;
-		if (t.second.type == tt_online && offline) {
+		if (t.second.executed == false && ((t.second.type == tt_online && offline) || (t.second.type == tt_extended && !extended))) {
 			skipped++;
 			test_skipped = true;
 		} else {
@@ -232,9 +237,18 @@ int test_summary() {
 	return failed;
 }
 
+namespace {
+	std::string get_testdata_dir() {
+		char *env_var = getenv("TEST_DATA_DIR");
+
+		return (env_var ? env_var : "../../testdata/");
+	}
+}
+
 std::vector<uint8_t> load_test_audio() {
 	std::vector<uint8_t> testaudio;
-	std::ifstream input ("../../testdata/Robot.pcm", std::ios::in|std::ios::binary|std::ios::ate);
+	std::string dir = get_testdata_dir();
+	std::ifstream input (dir + "Robot.pcm", std::ios::in|std::ios::binary|std::ios::ate);
 	if (input.is_open()) {
 		size_t testaudio_size = input.tellg();
 		testaudio.resize(testaudio_size);
@@ -243,7 +257,7 @@ std::vector<uint8_t> load_test_audio() {
 		input.close();
 	}
 	else {
-		std::cout << "ERROR: Can't load ../../testdata/Robot.pcm\n";
+		std::cout << "ERROR: Can't load " + dir + "Robot.pcm\n";
 		exit(1);
 	}
 	return testaudio;
@@ -251,7 +265,8 @@ std::vector<uint8_t> load_test_audio() {
 
 std::vector<uint8_t> load_test_image() {
 	std::vector<uint8_t> testimage;
-	std::ifstream input ("../../testdata/DPP-Logo.png", std::ios::in|std::ios::binary|std::ios::ate);
+	std::string dir = get_testdata_dir();
+	std::ifstream input (dir + "DPP-Logo.png", std::ios::in|std::ios::binary|std::ios::ate);
 	if (input.is_open()) {
 		size_t testimage_size = input.tellg();
 		testimage.resize(testimage_size);
@@ -260,7 +275,7 @@ std::vector<uint8_t> load_test_image() {
 		input.close();
 	}
 	else {
-		std::cout << "ERROR: Can't load ../../testdata/DPP-Logo.png\n";
+		std::cout << "ERROR: Can't load " + dir + "DPP-Logo.png\n";
 		exit(1);
 	}
 	return testimage;
@@ -287,7 +302,7 @@ void wait_for_tests() {
 		for (auto & t : tests) {
 			if (t.second.executed == true) {
 				executed++;
-			} else if (offline && t.second.type == tt_online && !t.second.executed) {
+			} else if (!t.second.executed && ((offline && t.second.type == tt_online) || (!extended && t.second.type == tt_extended))) {
 				executed++;
 				t.second.success = true;
 				std::cout << "[" << std::fixed << std::setprecision(3)  << get_time() << "]: " << "[\u001b[33mSKIPPED\u001b[0m] " << t.second.description << "\n";

--- a/src/unittest/unittest.cpp
+++ b/src/unittest/unittest.cpp
@@ -221,7 +221,7 @@ int test_summary() {
 	std::cout << "\u001b[37;1m\n\nUNIT TEST SUMMARY\n==================\n\u001b[0m";
 	for (auto & t : tests) {
 		bool test_skipped = false;
-		if (t.second.executed == false && ((t.second.type == tt_online && offline) || (t.second.type == tt_extended && !extended))) {
+		if ((t.second.type == tt_online && offline) || (t.second.type == tt_extended && !extended)) {
 			skipped++;
 			test_skipped = true;
 		} else {
@@ -304,7 +304,7 @@ void wait_for_tests() {
 				executed++;
 			} else if (!t.second.executed && ((offline && t.second.type == tt_online) || (!extended && t.second.type == tt_extended))) {
 				executed++;
-				t.second.success = true;
+				t.second.executed = true;
 				std::cout << "[" << std::fixed << std::setprecision(3)  << get_time() << "]: " << "[\u001b[33mSKIPPED\u001b[0m] " << t.second.description << "\n";
 			}
 		}
@@ -314,5 +314,9 @@ void wait_for_tests() {
 		}
 		std::this_thread::sleep_for(std::chrono::seconds(1));
 		ticks++;
+	}
+	for (auto &t : tests) {
+		if (!t.second.executed)
+			std::cout << "[" << std::fixed << std::setprecision(3)  << get_time() << "]: " << "[\u001b[31mTIMEOUT\u001b[0m] " << t.second.description << "\n";
 	}
 }


### PR DESCRIPTION
Title. Moved some online tests into an optional, off by default set. Run with "full" command argument to run the full online set.

Also added a "TIMEOUT" notification for any remaining tests when the tests are killed and changed INVITE_GET to not rely on permanent invites, as [Discord has disabled permanent invites for non-community servers](https://support.discord.com/hc/en-us/articles/208866998-Invites-101#h_01H2DMMG355MV7GJDQ9F65SDVG).