### PR TITLE
refactor, fix: change interaction_response.msg from message* to message, fixing double free on copy

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -315,31 +315,22 @@ struct DPP_EXPORT interaction_response : public json_interface<interaction_respo
 	 * Should be one of ir_pong, ir_channel_message_with_source,
 	 * or ir_deferred_channel_message_with_source.
 	 */
-	interaction_response_type type;
+	interaction_response_type type{};
 
 	/**
-	 * @brief A message object. This pointer is always valid
-	 * while the containing interaction_response exists.
+	 * @brief Message tied to this response.
 	 */
-	struct message* msg;
+	message msg{};
 
 	/**
 	 * @brief Array of up to 25 autocomplete choices
 	 */
-	std::vector<command_option_choice> autocomplete_choices;
+	std::vector<command_option_choice> autocomplete_choices{};
 
 	/**
 	 * @brief Construct a new interaction response object
 	 */
-	interaction_response();
-
-	/**
-	 * @brief Construct a new interaction response object
-	 *
-	 * @param t Type of reply
-	 * @param m Message to reply with
-	 */
-	interaction_response(interaction_response_type t, const struct message& m);
+	interaction_response() = default;
 
 	/**
 	 * @brief Construct a new interaction response object
@@ -347,6 +338,22 @@ struct DPP_EXPORT interaction_response : public json_interface<interaction_respo
 	 * @param t Type of reply
 	 */
 	interaction_response(interaction_response_type t);
+
+	/**
+	 * @brief Construct a new interaction response object
+	 *
+	 * @param t Type of reply
+	 * @param m Message to reply with
+	 */
+	interaction_response(interaction_response_type t, const message& m);
+
+	/**
+	 * @brief Construct a new interaction response object
+	 *
+	 * @param t Type of reply
+	 * @param m Message to reply with
+	 */
+	interaction_response(interaction_response_type t, message&& m);
 
 	/**
 	 * @brief Fill object properties from JSON
@@ -374,7 +381,7 @@ struct DPP_EXPORT interaction_response : public json_interface<interaction_respo
 	/**
 	 * @brief Destroy the interaction response object
 	 */
-	virtual ~interaction_response();
+	virtual ~interaction_response() = default;
 
 };
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -132,7 +132,7 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, r.msg->filename, r.msg->filecontent, r.msg->filemimetype);
+	}, r.msg.filename, r.msg.filecontent, r.msg.filemimetype);
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {


### PR DESCRIPTION
Fixes double free on copy of interaction_response, for example capturing it by copy in a lambda.

All full suite of tests passed on g++12.
> Failed: 0 Passed: 140 Percentage: 100.00%