### PR TITLE
build: improve changelog parsing and order

### DIFF
--- a/buildtools/changelog.php
+++ b/buildtools/changelog.php
@@ -94,10 +94,9 @@ function add_change(string $change, string $category, string $scope = null) {
             $catgroup[$category][$scope] = [];
         }
         $catgroup[$category][$scope][] = $change;
+        return;
     }
-    else {
-        $catgroup[$category][] = $change;
-    }
+    $catgroup[$category][] = $change;
 }
 
 foreach ($changelog as $change) {

--- a/buildtools/changelog.php
+++ b/buildtools/changelog.php
@@ -2,6 +2,20 @@
 
 // D++ changelog generator, saves 15 minutes for each release :-)
 
+// Categories, in display order
+$catgroup = [
+    '💣 Breaking Changes' => [],
+    '✨ New Features' => [],
+    '🐞 Bug Fixes' => [],
+    '🚀 Performance Improvements' => [],
+    '♻️ Refactoring' => [],
+    '🚨 Testing' => [],
+    '📚 Documentation' => [],
+    '💎 Style Changes' => [],
+    '🔧 Chore' => [],
+    '📜 Miscellaneous Changes' => []
+];
+
 // Pattern list
 $categories = [
     'break' => '💣 Breaking Changes',
@@ -42,22 +56,15 @@ $categories = [
     'updated' => '📜 Miscellaneous Changes',
 ];
 
-$catgroup = [];
 $changelog = [];
 $githubstyle = true;
 if (count($argv) > 2 && $argv[1] == '--discord') {
     $githubstyle = false;
 }
+$errors = [];
 
 // Magic sauce
 exec("git log --format=\"%s\" $(git log --no-walk --tags | head -n1 | cut -d ' ' -f 2)..HEAD | grep -v '^Merge '", $changelog);
-
-// Leadin
-if ($githubstyle) {
-    echo "The changelog is listed below:\n\nRelease Changelog\n===========\n";
-} else {
-    echo "The changelog is listed below:\n\n__**Release Changelog**__\n";
-}
 
 // Case insensitive removal of duplicates
 $changelog = array_intersect_key($changelog, array_unique(array_map("strtolower", $changelog)));
@@ -78,6 +85,21 @@ foreach ($changelog as $item) {
     }
 }
 
+function add_change(string $change, string $category, string $scope = null) {
+    global $catgroup;
+
+    if (isset($scope) && !empty($scope)) {
+        // Group by feature inside the section
+        if (!isset($catgroup[$category][$scope])) {
+            $catgroup[$category][$scope] = [];
+        }
+        $catgroup[$category][$scope][] = $change;
+    }
+    else {
+        $catgroup[$category][] = $change;
+    }
+}
+
 foreach ($changelog as $change) {
 
     // Wrap anything that looks like a symbol name in backticks
@@ -92,41 +114,111 @@ foreach ($changelog as $change) {
     $change = preg_replace("/\b(was|is|wo)nt\b/i", '$1n\'t', $change);
     $change = preg_replace("/\bfreebsd\b/", 'FreeBSD', $change);
     $change = preg_replace("/``/", "`", $change);
+    $change = trim($change);
 
-    // Match keywords against categories
     $matched = false;
-    foreach ($categories as $cat => $header) {
-        // Purposefully ignored: comments that are one word, merge commits, and version bumps
-        if (strpos($change, ' ') === false || preg_match("/^Merge (branch|pull request|remote-tracking branch) /", $change) || preg_match("/version bump/i", $change)) {
-            $matched = true;
-            continue;
-        }
-        // Groupings
-        if ((preg_match("/^" . $cat . ":/i", $change)) || (preg_match("/^\[" . $cat . "\//i", $change)) || (preg_match("/^\[" . $cat . "\]/i", $change)) || (preg_match("/^\[" . $cat . ":/i", $change)) || (preg_match("/^" . $cat . "\//i", $change)) || (preg_match("/^" . $cat . ":/i", $change))) {
+    $matches = [];
+    // Extract leading category section
+    if (preg_match("/^((?:(?:[\w_]+(?:\([\w_]+\))?+)(?:[\s]*[,\/][\s]*)?)+):/i", $change, $matches) || preg_match("/^\[((?:(?:[\w_]+(?:\([\w_]+\))?+)(?:[\s]*[,\/][\s]*)?)+)\](?:\s*:)?/i", $change, $matches)) {
+        $categorysection = $matches[0];
+        $changecategories = $matches[1];
+        $matchflags = PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL;
+        // Extract each category and scope
+        if (preg_match_all("/(?:[\s]*)([\w_]+)(?:\(([\w_]+)\))?(?:[\s]*)(?:[,\/]+)?/i", $changecategories, $matches, $matchflags) !== false) {
+            /**
+             * Given a commit "foo, bar(foobar): add many foos and bars" :
+             * $matches is [
+             *     0 => [[0] => 'foo,', [1] => 'foo', [2] => null],
+             *     1 => [[0] => ' bar(foobar)', [1] => 'bar', [2] => 'foobar'],
+             * ]
+             * In other words, for a matched category N, matches[N][1] is the category, matches[N][2] is the scope
+             */
+            $header = $matches[0][1];
+            $scope = $matches[0][2];
+            $change = trim(substr($change, strlen($categorysection)));
+            // List in breaking if present
+            foreach ($matches as $nb => $match) {
+                if ($nb == 0) // Skip the first category which will be added anyways
+                    continue;
+                $category = $match[1];
+                if (isset($categories[$category]) && $categories[$category] === '💣 Breaking Changes')
+                    add_change($change, $categories[$category], $scope);
+            }
+            if (!isset($categories[$header])) {
+                $errors[] = "could not find category \"" . $header . "\" for commit \"" . $change . "\", adding it to misc";
+                $header = $categories['misc'];
+            }
+            else {
+                $header = $categories[$header];
+            }
             if (!isset($catgroup[$header])) {
                 $catgroup[$header] = [];
             }
             $matched = true;
-            $catgroup[$header][] = preg_replace("/^\S+\s+/", "", $change);
-            break;
-        } else if (preg_match("/^" . $cat . " /i", $change)) {
-            if (!isset($catgroup[$header])) {
-                $catgroup[$header] = [];
+            // Ignore version bumps
+            if (!preg_match("/^(version )?bump/i", $change)) {
+                add_change($change, $header, $scope);
             }
-            $matched = true;
-            $catgroup[$header][] = $change;
-            break;
         }
+    }
+    if (!$matched) { // Could not parse category section, try keywords
+        // Match keywords against categories
+        foreach ($categories as $cat => $header) {
+            // Purposefully ignored: comments that are one word, merge commits, and version bumps
+            if (strpos($change, ' ') === false || preg_match("/^Merge (branch|pull request|remote-tracking branch) /", $change) || preg_match("/^(version )?bump/i", $change)) {
+                $matched = true;
+                break;
+            }
+            if (preg_match("/^" . $cat . " /i", $change)) {
+                if (!isset($catgroup[$header])) {
+                    $catgroup[$header] = [];
+                }
+                $matched = true;
+                $catgroup[$header][] = $change;
+                break;
+            }
+        }
+    }
+    if (!$matched) {
+        $errors[] = "could not guess category for commit \"" . $change . "\", adding it to misc";
+        $header = $categories['misc'];
+        if (!isset($catgroup[$header])) {
+            $catgroup[$header] = [];
+        }
+        $matched = true;
+        $catgroup[$header][] = $change;
+    }
+}
+
+// Leadin
+if ($githubstyle) {
+    echo "The changelog is listed below:\n\nRelease Changelog\n===========\n";
+} else {
+    echo "The changelog is listed below:\n\n__**Release Changelog**__\n";
+}
+
+function print_change(string $change) {
+    global $githubstyle;
+
+    // Exclude bad commit messages like 'typo fix', 'test push' etc by pattern
+    if (!preg_match("/^(typo|test|fix)\s\w+$/", $change) && strpos($change, ' ') !== false) {
+        echo ($githubstyle ? '-' : '•') . ' ' . ucfirst(str_replace('@', '', $change)) . "\n";
     }
 }
 
 // Output tidy formatting
 foreach ($catgroup as $cat => $list) {
-    echo "\n" . ($githubstyle ? '## ' : '__**') . $cat . ($githubstyle ? '' : '**__') . "\n";
-    foreach ($list as $item) {
-        // Exclude bad commit messages like 'typo fix', 'test push' etc by pattern
-        if (!preg_match("/^(typo|test|fix)\s\w+$/", $item) && strpos($item, ' ') !== false) {
-            echo ($githubstyle ? '-' : '•') . ' ' . ucfirst(str_replace('@', '', $item)) . "\n";
+    if (!empty($list)) {
+        echo "\n" . ($githubstyle ? '## ' : '__**') . $cat . ($githubstyle ? '' : '**__') . "\n";
+        foreach ($list as $key => $item) {
+            if (is_array($item)) {
+                foreach ($item as $change) {
+                    print_change("$key: $change");
+                }
+            }
+            else {
+                print_change($item);
+            }
         }
     }
 }
@@ -137,4 +229,8 @@ if (!$githubstyle) {
     $version = $argv[2];
     echo 'The ' . $version . ' download can be found here: <https://dl.dpp.dev/' . $version . '>';
     echo "\n";
+}
+
+foreach ($errors as $err) {
+    trigger_error($err, E_USER_WARNING);
 }


### PR DESCRIPTION
- Added the ability for the parser to parse more patterns :
  - A commit with several categories, e.g. `foo, bar: many foos, many bars`. Only the first category is taken into account, but all of them are split and parsed with a regex, so they can easily be used if needed. ❗ Commits marked as breaking will always be listed at the top the changelog in the breaking section (alongside their own category if the breaking was a secondary category)
  - A commit with a scope, e.g. `feat(scope): some changes`, all commits with the same scope will be grouped together in the changelog, listed as `Scope: some changes`
- Fixed the order of the categories, which are now listed in declaration order, as opposed to in the order of the first commit that references them
- The script will warn if a commit has failed to parse a category, and now add them to `misc`. Warnings are generated on stderr and can be silenced using shell redirection

All other behavior was left intact.

Changelog after this commit:
```md
The changelog is listed below:

Release Changelog
===========

## ✨ New Features
- Add SPDX-License-Identifier to headers in files
- Introduce the media channel type (#746)
- Adding AVX implementation for mixing audio. (#745)
- Add STDCORO to cspell
- Add `dpp::snowflake::str()` that returns string form of snowflake value
- Added functionality for guild onboarding and welcome screen (#734)

## 🐞 Bug Fixes
- Fix dodgy search and replace, vscode inserting newlines
- Fix spelling error
- `default` empty destructors
- Delete copy and move assignment operators for cluster
- Workaround gcc-12 bug #105329 (#748)
- Coroutines: better support for clang, remove experimental if unneeded, add missing headers (#743)
- Warning for [=] copy without explkit , rerun coro builder for onboarding
- Add /bigobj to non-VCPKG MSVC CMake flags, fixing ninja build, and fix `CMakeSettings.json` (#740)

## ♻️ Refactoring
- Change `interaction_response.msg` from message* to message, fixing double free on copy (#762)
- Json parsing helper functions added to unify the way arrays are parsed (#744)
- Use nullptr instead of NULL
- Use structured bindings
- Change `std::for_each` to ranged for loops

## 📚 Documentation
- Add openssf scorecard to readme
- Add spelling
- Fix typo (#741)
- Some tweaks in code examples (#742)
- Documentation for `unicode_emoji` namespace (#739)

## 📜 Miscellaneous Changes
- Create `pull_request_template.md`
- Update `scorecard.yml`
- Update `dependabot.yml`
- OpenSSF best practices badge (#766)
- Update `README.md`
- D++ == CHAD++ // true (#747)
- Clang-tidy namespace comment autofix
- Update `codeql.yml`
- Update `SECURITY.md`
- Create `scorecard.yml`
- Enable CORO on g++11, g++12, osx
- Dont enable AVX when compiling on GHA
- Update `CONTRIBUTING.md`
- Update `CONTRIBUTING.md` - add rules about not just using automated tools to generate bad prs

## 👷 Build/CI
- Improve changelog parsing and order
- Add signing shell script to auto sign releases with gpg and upload .asc alongside artifacts
- Apply security best practices (#749)


**Thank you for using D++!**
```
STDERR output :
```php
PHP Warning:  could not guess category for commit "Create `pull_request_template.md`", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
PHP Warning:  could not guess category for commit "OpenSSF best practices badge (#766)", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
PHP Warning:  could not guess category for commit "D++ == CHAD++ // true (#747)", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
PHP Warning:  could not guess category for commit "Create `scorecard.yml`", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
PHP Warning:  could not guess category for commit "enable CORO on g++11, g++12, osx", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
PHP Warning:  could not guess category for commit "dont enable AVX when compiling on GHA", adding it to misc in /home/miuna/dev/DPP/buildtools/changelog.php on line 234
```
