### PR TITLE
docs: improve build speed of codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Install apt packages
-        run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install g++-12 ninja-build libsodium-dev libopus-dev zlib1g-dev rpm
-
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3
@@ -56,22 +53,12 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      #- name: Autobuild
-      #  uses: github/codeql-action/autobuild@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
       - name: Build
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Debug ..
-          ninja
+          cmake -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Debug ..
+          make -j2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,7 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          make -j4
+          make -j2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
+      #- name: Autobuild
       #  uses: github/codeql-action/autobuild@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3
 
       # ℹ️ Command-line programs to run using the OS shell.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -43,6 +43,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Install apt packages
+        run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install g++-12 ninja-build libsodium-dev libopus-dev zlib1g-dev rpm
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -67,8 +70,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
-          make -j2
+          cmake -G Ninja -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Debug ..
+          ninja
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,11 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
-
 on:
+  push:
+  pull_request:
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read
@@ -55,17 +56,19 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3
+      #  uses: github/codeql-action/autobuild@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
       #   If the Autobuild fails above, remove it and uncomment the following three lines.
       #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5b6282e01c62d02e720b81eb8a51204f527c3624 # v2.21.3


### PR DESCRIPTION
Improved codeql speed, remove autobuild

Tested four different approaches to compiling D++ for analysis by codeql:

* CodeQL `Autobuild` (default): 1 hour, 11 mins, 30 secs
* `ninja` Build: 45 mins (including 1 minute apt install step to install `ninja-build`)
* `make -j4`: 41 mins, 1 sec
* `make -j2`: 30 mins 30 secs

I selected `make -j2`, this should ensure that codeql completes in under an hour including its analysis step and is a bit more tolerable.