### PR TITLE
fix: don't allow user to change ws mode on a connected cluster (this would be bad)

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -273,6 +273,7 @@ public:
 	 * 
 	 * @param mode websocket protocol to use, either ws_json or ws_etf.
 	 * @return cluster& Reference to self for chaining.
+	 * @throw dpp::logic_exception If called after the cluster is started (this is not supported)
 	 */
 	cluster& set_websocket_protocol(websocket_protocol_t mode);
 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -119,6 +119,9 @@ request_queue* cluster::get_raw_rest() {
 }
 
 cluster& cluster::set_websocket_protocol(websocket_protocol_t mode) {
+	if (start_time > 0) {
+		throw dpp::logic_exception("Cannot change websocket protocol on a started cluster!");
+	}
 	ws_mode = mode;
 	return *this;
 }


### PR DESCRIPTION
- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.
- [x] I agree to the terms of the [DCO (Developer Certificate of Origin)]((https://dpp.dev/coding-standards.html))
