### PR TITLE
docs: fixed errors on reaction collectors example page

### DIFF
--- a/docpages/example_programs/misc/collect_reactions.md
+++ b/docpages/example_programs/misc/collect_reactions.md
@@ -13,12 +13,12 @@ In the example below we will use it to collect all reactions on a message.
 class react_collector : public dpp::reaction_collector {
 public:
 	/* Collector will run for 20 seconds */
-	react_collector(dpp::cluster* cl, snowflake id) : dpp::message_collector(cl, 20, id) { }
+	react_collector(dpp::cluster* cl, snowflake id) : dpp::reaction_collector(cl, 20, id) { }
 
 	/* On completion just output number of collected reactions to as a message. */
 	virtual void completed(const std::vector<dpp::collected_reaction>& list) {
 		if (list.size()) {
-			owner->message_create(dpp::message(list[0].channel_id, "I collected " + std::to_string(list.size()) + " reactions!"));
+			owner->message_create(dpp::message(list[0].react_channel->id, "I collected " + std::to_string(list.size()) + " reactions!"));
 		} else {
 			owner->message_create(dpp::message("... I got nothin'."));
 		}


### PR DESCRIPTION
Replaced the message_collector template in the constructors with reaction_collector as the previous one was wrong, and would introduce an error.

 I have also replaced list[0].channel_id with list[0].react_channel->id, as channel_id object does not exist.

- [X] My pull request is made against the `dev` branch.
- [X] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] I tested my commits, by adding a test case to the unit tests if needed
- [X] I have ensured that I did not break any existing API calls.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.
- [X] I agree to the terms of the [DCO (Developer Certificate of Origin)]((https://dpp.dev/coding-standards.html))
