### PR TITLE
docs: Made collect_reactions page more explicit.

### DIFF
--- a/docpages/example_programs/misc/collect_reactions.md
+++ b/docpages/example_programs/misc/collect_reactions.md
@@ -15,8 +15,8 @@ public:
 	/* Collector will run for 20 seconds */
 	react_collector(dpp::cluster* cl, snowflake id) : dpp::message_collector(cl, 20, id) { }
 
-	/* On completion just output number of collected reactions to as a message. */
-	virtual void completed(const std::vector<dpp::collected_reaction>& list) {
+	/* Override the "completed" event and then output the number of collected reactions as a message. */
+	virtual void completed(const std::vector<dpp::collected_reaction>& list) override {
 		if (list.size()) {
 			owner->message_create(dpp::message(list[0].channel_id, "I collected " + std::to_string(list.size()) + " reactions!"));
 		} else {
@@ -33,10 +33,10 @@ int main() {
 	/* Pointer to reaction collector */
 	react_collector* r = nullptr;
 
-        bot.on_log(dpp::utility::cout_logger());
+    bot.on_log(dpp::utility::cout_logger());
 
 	/* Message handler */
-	bot.on_message_create([&](const dpp::message_create_t &event) {
+	bot.on_message_create([&](const dpp::message_create_t& event) {
 
 		/* If someone sends a message that has the text 'collect reactions!' start a reaction collector */
 		if (event.msg.content == "collect reactions!" && r == nullptr) {


### PR DESCRIPTION
collect_reactions never used "override" with virtual void completed(), this changes that. Whilst it's not needed, it's better to be explicit.

This also clears the random indentation on line 36 (prev. line 29).

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.
- [x] I agree to the terms of the [DCO (Developer Certificate of Origin)]((https://dpp.dev/coding-standards.html))
