### PR TITLE
docs: fixed typo in documentation example

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -273,6 +273,7 @@ public:
 	 * 
 	 * @param mode websocket protocol to use, either ws_json or ws_etf.
 	 * @return cluster& Reference to self for chaining.
+	 * @throw dpp::logic_exception If called after the cluster is started (this is not supported)
 	 */
 	cluster& set_websocket_protocol(websocket_protocol_t mode);
 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -119,6 +119,9 @@ request_queue* cluster::get_raw_rest() {
 }
 
 cluster& cluster::set_websocket_protocol(websocket_protocol_t mode) {
+	if (start_time > 0) {
+		throw dpp::logic_exception("Cannot change websocket protocol on a started cluster!");
+	}
 	ws_mode = mode;
 	return *this;
 }


### PR DESCRIPTION
Default PR checklist doesn't apply, changes made to documentation.