### PR TITLE
Updating to the correct AVX2 instruction.

### DIFF
--- a/cmake/DetectArchitecture.cmake
+++ b/cmake/DetectArchitecture.cmake
@@ -27,13 +27,13 @@ endfunction()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(INSTRUCTION_SETS
         "T_AVX?/arch:AVX?auto result = _mm_testz_ps(__m128{}, __m128{})"
-        "T_AVX2?/arch:AVX2?auto result = _mm256_extract_epi64(__m256i{}, 0)"
+        "T_AVX2?/arch:AVX2?auto result = _mm256_add_epi32(__m256i{}, __m256i{})"
         "T_AVX512?/arch:AVX512?auto result = _mm512_add_ps(__m512i{}, __m512i{}).auto result2 = _mm512_cmplt_epu8_mask(__m512i{}, __m512i{})"
     )
 else()
     set(INSTRUCTION_SETS
         "T_AVX?-mavx.-mpclmul.-mbmi?auto result = _mm_testz_ps(__m128{}, __m128{})"
-        "T_AVX2?-mavx2.-mavx.-mpclmul.-mbmi?auto result = _mm256_extract_epi64(__m256i{}, 0)"
+        "T_AVX2?-mavx2.-mavx.-mpclmul.-mbmi?auto result = _mm256_add_epi32(__m256i{}, __m256i{})"
         "T_AVX512?-mavx512bw.-mavx512f.-mavx2.-mavx.-mpclmul.-mbmi?auto result = _mm512_add_ps(__m512i{}, __m512i{}).auto result2 = _mm512_cmplt_epu8_mask(__m512i{}, __m512i{})"
     )
 endif()


### PR DESCRIPTION
Accidentally set this to the wrong intrinsic - which would have only identified that it was AVX1 enabled instead of AVX2.

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.
- [x] I agree to the terms of the [DCO (Developer Certificate of Origin)]((https://dpp.dev/coding-standards.html))
