### PR TITLE
feat(build): add off-by-default DPP_USE_PCH option in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(DPP_BUILD_TEST "Build the test program" ON)
 option(DPP_NO_VCPKG "No VCPKG" OFF)
 option(DPP_CORO "Experimental support for C++20 coroutines" OFF)
 option(DPP_USE_EXTERNAL_JSON "Use an external installation of nlohmann::json" OFF)
+option(DPP_USE_PCH "Use precompiled headers to speed up compilation" OFF)
 
 include(CheckCXXSymbolExists)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -230,6 +230,15 @@ foreach (fullmodname ${subdirlist})
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp>
 	)
 
+	if (DPP_USE_PCH)
+		target_precompile_headers(${modname} PRIVATE
+			"${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp/cluster.h"
+			"${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp/json.h"
+			"${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp/utility.h"
+			"${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp/restresults.h"
+		)
+	endif()
+
 	if (WIN32 AND NOT MINGW)
 		if (NOT WINDOWS_32_BIT)
 			target_link_libraries(${modname} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../win32/lib/libssl.lib"


### PR DESCRIPTION
Adds an option to use private PCH when building DPP from source.
Mostly useful on MSVC, makes the build take 30 seconds instead of 5 minutes.
Useful for contributors mostly 👀 as this only affects DPP itself due to being private, and does not propagate to dependents.

This does not affect vcpkg.

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.

