### PR TITLE
Implement clyde AI permission bits

### DIFF
--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -75,6 +75,7 @@ enum permissions : uint64_t {
 	p_use_soundboard = 0x40000000000, //!< allows for using soundboard in a voice channel
 	p_use_external_sounds = 0x0000200000000000, //!< allows the usage of custom soundboard sounds from other servers
 	p_send_voice_messages = 0x0000400000000000, //!< allows sending voice messages
+	p_use_clyde_ai = 0x0000800000000000, //!< allows use of Clyde AI
 };
 
 /**

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -604,6 +604,13 @@ public:
 	 * @return bool True if user has the send voice messages permission or is administrator.
 	 */
 	bool has_send_voice_messages() const;
+	/**
+	 * @brief True if has permission to use clyde AI.
+	 * @note Having the administrator permission causes this method to always return true
+	 * Channel specific overrides may apply to permissions.
+	 * @return bool True if user has the clyde AI permission or is administrator.
+	 */
+	bool has_use_clyde_ai() const;
 
 	/**
 	 * @brief Get guild members who have this role

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -365,6 +365,10 @@ bool role::has_send_voice_messages() const {
 	return has_administrator() || permissions.has(p_send_voice_messages);
 }
 
+bool role::has_use_clyde_ai() const {
+	return has_administrator() || permissions.has(p_use_clyde_ai);
+}
+
 role& role::set_name(const std::string& n) {
 	name = utility::validate(n, 1, 100, "Role name too short");
 	return *this;


### PR DESCRIPTION
Implements https://github.com/discord/discord-api-docs/pull/6354

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.

