### PR TITLE
Remove bad compile defs

### DIFF
--- a/library-vcpkg/CMakeLists.txt
+++ b/library-vcpkg/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 target_compile_definitions(
 	"${LIB_NAME}" PUBLIC
 	"DPP_BUILD"
-	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:/sdl;/std:c++17;/Od;/DEBUG;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
-	"$<$<PLATFORM_ID:Windows>:$<$<CONFIG:Release>:/std:c++17;/O2;/Oi;/Oy;/GL;/Gy;/sdl;/MP;/DFD_SETSIZE=1024;/Zc:preprocessor>>"
 )
 
 add_compile_definitions(OPENSSL_SYS_WIN32)


### PR DESCRIPTION
this fixes warnings when building vcpkg with msvc. I'll submit a more in depth tidy up when I have facility to test it properly without having to wait until a vcpkg pr.

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.

