### PR TITLE
fix: fixed discord_voice_client::send_audio_raw blocking thread when provided with invalid size

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -60,7 +60,7 @@ inline constexpr uint16_t AUDIO_TRACK_MARKER = 0xFFFF;
 
 inline constexpr int AUDIO_OVERLAP_SLEEP_SAMPLES = 30;
 
-inline constexpr size_t SEND_AUDIO_RAW_MAX_LENGTH = 11520;
+inline constexpr size_t send_audio_raw_max_length = 11520;
 
 using json = nlohmann::json;
 
@@ -676,7 +676,7 @@ public:
 	/**
 	 * @brief Send raw audio to the voice channel.
 	 * 
-	 * You should send an audio packet of `SEND_AUDIO_RAW_MAX_LENGTH` (11520) bytes.
+	 * You should send an audio packet of `send_audio_raw_max_length` (11520) bytes.
 	 * Note that this function can be costly as it has to opus encode
 	 * the PCM audio on the fly, and also encrypt it with libsodium.
 	 * 
@@ -695,15 +695,15 @@ public:
 	 * 
 	 * @param length The length of the audio data. The length should
 	 * be a multiple of 4 (2x 16 bit stereo channels) with a maximum
-	 * length of `SEND_AUDIO_RAW_MAX_LENGTH`, which is a complete opus
+	 * length of `send_audio_raw_max_length`, which is a complete opus
 	 * frame at highest quality. `dpp::voice_exception` will be thrown
 	 * if length is less than 4 or not divisible by 4.
 	 *
 	 * Generally when you're streaming and you know there will be
 	 * more packet to come you should always provide packet data with
-	 * length of `SEND_AUDIO_RAW_MAX_LENGTH`.
+	 * length of `send_audio_raw_max_length`.
 	 * Silence packet will be appended if length is less than
-	 * `SEND_AUDIO_RAW_MAX_LENGTH` as discord expects to receive such
+	 * `send_audio_raw_max_length` as discord expects to receive such
 	 * specific packet size. This can cause gaps in your stream resulting
 	 * in distorted audio if you have more packet to send later on.
 	 * 

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -56,7 +56,7 @@ struct OpusRepacketizer;
 
 namespace dpp {
 
-// !TODO: change these to constexpr and rename every occurence across the codebase
+// !TODO: change these to constexpr and rename every occurrence across the codebase
 #define AUDIO_TRACK_MARKER (uint16_t)0xFFFF
 
 #define AUDIO_OVERLAP_SLEEP_SAMPLES 30

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -56,9 +56,10 @@ struct OpusRepacketizer;
 
 namespace dpp {
 
-inline constexpr uint16_t AUDIO_TRACK_MARKER = 0xFFFF;
+// !TODO: change these to constexpr and rename every occurence across the codebase
+#define AUDIO_TRACK_MARKER (uint16_t)0xFFFF
 
-inline constexpr int AUDIO_OVERLAP_SLEEP_SAMPLES = 30;
+#define AUDIO_OVERLAP_SLEEP_SAMPLES 30
 
 inline constexpr size_t send_audio_raw_max_length = 11520;
 
@@ -696,8 +697,7 @@ public:
 	 * @param length The length of the audio data. The length should
 	 * be a multiple of 4 (2x 16 bit stereo channels) with a maximum
 	 * length of `send_audio_raw_max_length`, which is a complete opus
-	 * frame at highest quality. `dpp::voice_exception` will be thrown
-	 * if length is less than 4 or not divisible by 4.
+	 * frame at highest quality.
 	 *
 	 * Generally when you're streaming and you know there will be
 	 * more packet to come you should always provide packet data with

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -50,7 +50,7 @@
 #include <functional>
 #include <chrono>
 
-
+#define SEND_AUDIO_RAW_MAX_LENGTH 11520
 
 struct OpusDecoder;
 struct OpusEncoder;
@@ -676,7 +676,7 @@ public:
 	/**
 	 * @brief Send raw audio to the voice channel.
 	 * 
-	 * You should send an audio packet of 11520 bytes.
+	 * You should send an audio packet of `SEND_AUDIO_RAW_MAX_LENGTH` (11520) bytes.
 	 * Note that this function can be costly as it has to opus encode
 	 * the PCM audio on the fly, and also encrypt it with libsodium.
 	 * 
@@ -695,8 +695,18 @@ public:
 	 * 
 	 * @param length The length of the audio data. The length should
 	 * be a multiple of 4 (2x 16 bit stereo channels) with a maximum
-	 * length of 11520, which is a complete opus frame at highest
-	 * quality.
+	 * length of `SEND_AUDIO_RAW_MAX_LENGTH`, which is a complete opus
+	 * frame at highest quality. Packet with length less than 4 will be
+	 * dropped and `dpp::voice_exception` will be thrown if length is
+	 * not divisible by 4.
+	 *
+	 * Generally when you're streaming and you know there will be
+	 * more packet to come you should always provide packet data with
+	 * length of `SEND_AUDIO_RAW_MAX_LENGTH`.
+	 * Silence packet will be appended if length is less than
+	 * `SEND_AUDIO_RAW_MAX_LENGTH` as discord expects to receive such
+	 * specific packet size. This can cause gaps in your stream resulting
+	 * in distorted audio if you have more packet to send later on.
 	 * 
 	 * @return discord_voice_client& Reference to self
 	 * 

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -50,13 +50,17 @@
 #include <functional>
 #include <chrono>
 
-#define SEND_AUDIO_RAW_MAX_LENGTH 11520
-
 struct OpusDecoder;
 struct OpusEncoder;
 struct OpusRepacketizer;
 
 namespace dpp {
+
+inline constexpr uint16_t AUDIO_TRACK_MARKER = 0xFFFF;
+
+inline constexpr int AUDIO_OVERLAP_SLEEP_SAMPLES = 30;
+
+inline constexpr size_t SEND_AUDIO_RAW_MAX_LENGTH = 11520;
 
 using json = nlohmann::json;
 
@@ -94,10 +98,6 @@ struct DPP_EXPORT voice_out_packet {
 	 */
 	uint64_t duration;
 };
-
-#define AUDIO_TRACK_MARKER (uint16_t)0xFFFF
-
-#define AUDIO_OVERLAP_SLEEP_SAMPLES 30
 
 /** @brief Implements a discord voice connection.
  * Each discord_voice_client connects to one voice channel and derives from a websocket client.

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -696,9 +696,8 @@ public:
 	 * @param length The length of the audio data. The length should
 	 * be a multiple of 4 (2x 16 bit stereo channels) with a maximum
 	 * length of `SEND_AUDIO_RAW_MAX_LENGTH`, which is a complete opus
-	 * frame at highest quality. Packet with length less than 4 will be
-	 * dropped and `dpp::voice_exception` will be thrown if length is
-	 * not divisible by 4.
+	 * frame at highest quality. `dpp::voice_exception` will be thrown
+	 * if length is less than 4 or not divisible by 4.
 	 *
 	 * Generally when you're streaming and you know there will be
 	 * more packet to come you should always provide packet data with

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -1179,7 +1179,7 @@ discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data,
 
 		while (s_audio_data.length() > send_audio_raw_max_length) {
 			std::string packet(s_audio_data.substr(0, send_audio_raw_max_length));
-			const auto packet_size = (long long)packet.size();
+			const auto packet_size = static_cast<ptrdiff_t>(packet.size());
 
 			s_audio_data.erase(s_audio_data.begin(), s_audio_data.begin() + packet_size);
 

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -1174,11 +1174,11 @@ discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data,
 		throw dpp::voice_exception("Raw audio packet size should be divisible by 4");
 	}
 
-	if (length > SEND_AUDIO_RAW_MAX_LENGTH) {
+	if (length > send_audio_raw_max_length) {
 		std::string s_audio_data((const char*)audio_data, length);
 
-		while (s_audio_data.length() > SEND_AUDIO_RAW_MAX_LENGTH) {
-			std::string packet(s_audio_data.substr(0, SEND_AUDIO_RAW_MAX_LENGTH));
+		while (s_audio_data.length() > send_audio_raw_max_length) {
+			std::string packet(s_audio_data.substr(0, send_audio_raw_max_length));
 			const auto packet_size = (long long)packet.size();
 
 			s_audio_data.erase(s_audio_data.begin(), s_audio_data.begin() + packet_size);
@@ -1189,9 +1189,9 @@ discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data,
 		return *this;
 	}
 
-	if (length < SEND_AUDIO_RAW_MAX_LENGTH) {
+	if (length < send_audio_raw_max_length) {
 		std::string packet((const char*)audio_data, length);
-		packet.resize(SEND_AUDIO_RAW_MAX_LENGTH, 0);
+		packet.resize(send_audio_raw_max_length, 0);
 
 		return send_audio_raw((uint16_t*)packet.data(), packet.size());
 	}

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -1166,20 +1166,19 @@ discord_voice_client& discord_voice_client::set_send_audio_type(send_audio_type_
 
 discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data, const size_t length)  {
 #if HAVE_VOICE
-	static const size_t max_frame_bytes = SEND_AUDIO_RAW_MAX_LENGTH;
-
 	if (length < 4) {
-		return *this;
+		throw dpp::voice_exception("Raw audio packet size can't be less than 4");
 	}
 
 	if ((length % 4) != 0) {
-		throw dpp::voice_exception("Raw audio packet size should be left with zero remainder when divided by 4");
+		throw dpp::voice_exception("Raw audio packet size should be divisible by 4");
 	}
 
-	if (length > max_frame_bytes) {
+	if (length > SEND_AUDIO_RAW_MAX_LENGTH) {
 		std::string s_audio_data((const char*)audio_data, length);
-		while (s_audio_data.length() > max_frame_bytes) {
-			std::string packet(s_audio_data.substr(0, max_frame_bytes));
+
+		while (s_audio_data.length() > SEND_AUDIO_RAW_MAX_LENGTH) {
+			std::string packet(s_audio_data.substr(0, SEND_AUDIO_RAW_MAX_LENGTH));
 			const auto packet_size = (long long)packet.size();
 
 			s_audio_data.erase(s_audio_data.begin(), s_audio_data.begin() + packet_size);
@@ -1190,9 +1189,9 @@ discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data,
 		return *this;
 	}
 
-	if (length < max_frame_bytes) {
+	if (length < SEND_AUDIO_RAW_MAX_LENGTH) {
 		std::string packet((const char*)audio_data, length);
-		packet.resize(max_frame_bytes, 0);
+		packet.resize(SEND_AUDIO_RAW_MAX_LENGTH, 0);
 
 		return send_audio_raw((uint16_t*)packet.data(), packet.size());
 	}


### PR DESCRIPTION
## Changes in this PR

- Fix `send_audio_raw` blocking thread when provided with invalid size
- Define `SEND_AUDIO_RAW_MAX_LENGTH` so users can choose not to hardcode the size in their code
- Update comment

## PR Checklist

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.

