### PR TITLE
fix: corrected presence.cpp to allow custom statuses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/doxygen_sqlite3.db
 build
 buildtools/composer.phar
 src/build
+cmake-build-debug
 
 # tests
 test

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -73,14 +73,14 @@ presence::presence() : user_id(0), guild_id(0), flags(0)
 presence::presence(presence_status status, activity_type type, const std::string& activity_description) {
 	dpp::activity a;
 
-    /* Even if type is custom, a name is still required.
-     * We'll just set the name as this activity_description as it won't be used if custom either way. */
+	/* Even if type is custom, a name is still required.
+	 * We'll just set the name as this activity_description as it won't be used if custom either way. */
 	a.name = activity_description;
 
-    /* If the type is custom, set the state as "activity_description" */
-    if(type == activity_type::at_custom) {
-        a.state = activity_description;
-    }
+	/* If the type is custom, set the state as "activity_description" */
+	if(type == activity_type::at_custom) {
+	    a.state = activity_description;
+	}
 
 	a.type = type;
 	activities.clear();
@@ -264,11 +264,11 @@ std::string presence::build_json(bool with_id) const {
 			});
 			if (!i.url.empty()) j2["url"] = i.url;
 
-            if(i.type == activity_type::at_custom) {
-                if (!i.state.empty()) j2["state"] = i.state; /* When type is custom, bot needs to use "state" */
-            } else {
-                if (!i.state.empty()) j2["details"] = i.state; /* Otherwise, the bot needs to use "details" */
-            }
+			if(i.type == activity_type::at_custom) {
+			    if (!i.state.empty()) j2["state"] = i.state; /* When type is custom, bot needs to use "state" */
+			} else {
+			    if (!i.state.empty()) j2["details"] = i.state; /* Otherwise, the bot needs to use "details" */
+			}
 
 			j["d"]["activities"].push_back(j2);
 		}

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -79,7 +79,7 @@ presence::presence(presence_status status, activity_type type, const std::string
 
 	/* If the type is custom, set the state as "activity_description" */
 	if(type == activity_type::at_custom) {
-	    a.state = activity_description;
+	    	a.state = activity_description;
 	}
 
 	a.type = type;
@@ -265,9 +265,9 @@ std::string presence::build_json(bool with_id) const {
 			if (!i.url.empty()) j2["url"] = i.url;
 
 			if(i.type == activity_type::at_custom) {
-			    if (!i.state.empty()) j2["state"] = i.state; /* When type is custom, bot needs to use "state" */
+			    	if (!i.state.empty()) j2["state"] = i.state; /* When type is custom, bot needs to use "state" */
 			} else {
-			    if (!i.state.empty()) j2["details"] = i.state; /* Otherwise, the bot needs to use "details" */
+			    	if (!i.state.empty()) j2["details"] = i.state; /* Otherwise, the bot needs to use "details" */
 			}
 
 			j["d"]["activities"].push_back(j2);

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -72,7 +72,16 @@ presence::presence() : user_id(0), guild_id(0), flags(0)
 
 presence::presence(presence_status status, activity_type type, const std::string& activity_description) {
 	dpp::activity a;
+
+    /* Even if type is custom, a name is still required.
+     * We'll just set the name as this activity_description as it won't be used if custom either way. */
 	a.name = activity_description;
+
+    /* If the type is custom, set the state as "activity_description" */
+    if(type == activity_type::at_custom) {
+        a.state = activity_description;
+    }
+
 	a.type = type;
 	activities.clear();
 	activities.emplace_back(a);
@@ -254,7 +263,12 @@ std::string presence::build_json(bool with_id) const {
 				{ "type", i.type }
 			});
 			if (!i.url.empty()) j2["url"] = i.url;
-			if (!i.state.empty()) j2["details"] = i.state; // bot activity is details, not state
+
+            if(i.type == activity_type::at_custom) {
+                if (!i.state.empty()) j2["state"] = i.state; /* When type is custom, bot needs to use "state" */
+            } else {
+                if (!i.state.empty()) j2["details"] = i.state; /* Otherwise, the bot needs to use "details" */
+            }
 
 			j["d"]["activities"].push_back(j2);
 		}


### PR DESCRIPTION
This PR changes presence.cpp to allow custom statuses. The way discord asks for a presence means we need to set the "state" in the json object, however, we don't do this (hence this PR!). This now means you can do the following:

```
bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_custom, "Testing 123!"));
```
![image](https://github.com/brainboxdotcc/DPP/assets/46899449/a2844881-3efd-4dbc-93c8-734c56c298e2)

This PR also adds "cmake-build-debug" to the `.gitignore`.

I also have no idea why the indentation is weird, I simply added the code in CLion and it looks great on my end, but on GitHub and a text editor it does that. If it's okay to leave then that's great, otherwise, I'm happy for someone to give me a fix for it!

- [x] My pull request is made against the `dev` branch.
- [x] I have ensured that the changed library can be built on your target system. I did not introduce any platform-specific code.
- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] I tested my commits, by adding a test case to the unit tests if needed
- [x] I have ensured that I did not break any existing API calls.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html) (if you are not sure, match the code style of existing files including indent style etc).
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight. Where I have generated this pull request using a tool, I have justified why this is needed.