### PR TITLE
refactor: changed templates to properly fix changes from #868

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/code_change_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code_change_template.md
@@ -2,7 +2,7 @@
 
 ## Code change checklist
 
-- [ ] I have ensured that all methods and functions are **fully documented** using doxygen style comments
+- [ ] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
 - [ ] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
 - [ ] I tested that my change works before raising the PR.
 - [ ] I have ensured that I did not break any existing API calls.

--- a/.github/PULL_REQUEST_TEMPLATE/docs_change_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs_change_template.md
@@ -3,6 +3,6 @@
 ## Documentation change checklist
 
 - [ ] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
-- [ ] I tested that my change works before raising the PR (via running `oxygen`, and testing examples).
+- [ ] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
 - [ ] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
 - [ ] I have not generated content using AI or a desktop utility such as grammarly.


### PR DESCRIPTION
This PR adds missing punctuation from #868, and fixes a spelling mistake in the second bullet point (changing `oxygen` to `doxygen`, the fix can be seen below).

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
