### PR TITLE
docs: fixed a ref issue and added more info in discordvoiceclient.h

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -685,13 +685,13 @@ public:
 	 * ready to send and know its length it is advisable to call this
 	 * method multiple times to enqueue the entire stream audio so that
 	 * it is all encoded at once (unless you have set use_opus to false).
-	 * Constantly calling this from the dpp::on_voice_buffer_send callback
-	 * can and will eat a TON of cpu!
+	 * **Constantly calling this from dpp::cluster::on_voice_buffer_send
+	 * can, and will, eat a TON of cpu!**
 	 * 
 	 * @param audio_data Raw PCM audio data. Channels are interleaved,
 	 * with each channel's amplitude being a 16 bit value.
 	 * 
-	 * The audio data should be 48000Hz signed 16 bit audio.
+	 * @warning **The audio data needs to be 48000Hz signed 16 bit audio, otherwise, the audio will come through incorrectly!**
 	 * 
 	 * @param length The length of the audio data. The length should
 	 * be a multiple of 4 (2x 16 bit stereo channels) with a maximum


### PR DESCRIPTION
discordvoiceclient.h was not referencing `dpp::cluster::on_voice_buffer_send` correctly, this has been altered. I've also changed the notice of `the audio data needs to be...` to be a warning, to which it also states that the audio will be affected if it isn't at that hz (just to inform people what will happen otherwise).

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
