### PR TITLE
feat: added an auto-labeller for documentation PRs.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+documentation:
+- '**Doxyfile'
+- '**docpages/**'
+- '**/*.h'
+- '**/documentation.yml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the [labeler action](https://github.com/marketplace/actions/labeler) (spelling is different due to US) to PRs, automatically assigning the documentation label when any files listed in `.github/labeler.yml` are changes. I included any header file in this as, if people are adding new content, they should be documenting it. Of course, we could always alter this if wanted or just remove the label if it's not applicable (but this will cover most bases).

[This was tested on my fork and works perfectly.](https://github.com/Jaskowicz1/DPP/pull/6)

Neither checklist applies here, this is why the changelist does not include a checklist.
