### PR TITLE
Fix: Fixing a typod type in avx.h

### DIFF
--- a/cmake/DetectArchitecture.cmake
+++ b/cmake/DetectArchitecture.cmake
@@ -25,13 +25,13 @@ endfunction()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(INSTRUCTION_SETS
         "AVX1?/arch:AVX?__m128i value{}#auto result = _mm_extract_epi32(value, 0)"
-        "AVX2?/arch:AVX2?__m256i value{}#auto result = _mm256_extract_epi32(value, 0)"
+        "AVX2?/arch:AVX2?__m256i value{}#auto result = _mm256_add_epi32(__m256i{}, __m256i{})"
         "AVX512?/arch:AVX512?int32_t result[16]#const _mm512i& value{}#_mm512_store_si512(result, value)"
     )
 else()
     set(INSTRUCTION_SETS
         "AVX1?-mavx?__m128i value{}#auto result = _mm_extract_epi32(value, 0)"
-        "AVX2?-mavx2?__m256i value{}#auto result = _mm256_extract_epi32(value, 0)"
+        "AVX2?-mavx2?__m256i value{}#auto result = _mm256_add_epi32(__m256i{}, __m256i{})"
         "AVX512?-mavx512f?int32_t result[16]#const _mm512i& value{}#_mm512_store_si512(result, value)"
 )
 endif()

--- a/include/dpp/isa/avx.h
+++ b/include/dpp/isa/avx.h
@@ -97,7 +97,7 @@ namespace dpp {
 			for (uint64_t x = 0; x < byte_blocks_per_register; ++x) {
 				new_array[x] = static_cast<float>(values[x]);
 			}
-			return _mm256_load_ps(new_array);
+			return _mm_load_ps(new_array);
 		}
 
 		/**


### PR DESCRIPTION
Fixing a typod type in avx.h

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
