### PR TITLE
fix: stopped _XOPEN_SOURCE from defining on OpenBSD

### DIFF
--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -18,9 +18,16 @@
  * limitations under the License.
  *
  ************************************************************************************/
-#ifndef _XOPEN_SOURCE
-	#define _XOPEN_SOURCE
+
+/* OpenBSD errors when xopen_source is defined.
+ * We want to make sure that OpenBSD does not define it.
+ */
+#if !defined(__OpenBSD__)
+	#ifndef _XOPEN_SOURCE
+		#define _XOPEN_SOURCE
+	#endif
 #endif
+
 #include <string>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
This PR fixes #765, stopping "_XOPEN_SOURCE" from compiling on OpenBSD. This has been tested and is fully working on OpenBSD. I have tested this fix on Ubuntu 22.04 and WSL and they can still compile and run sucessfully.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
