### PR TITLE
Enhancement: Making AudioMixer a member instead of invoking it statically to cut down CPU usage by roughly 50%

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -55,6 +55,8 @@ struct OpusRepacketizer;
 
 namespace dpp {
 
+class audio_mixer;
+
 // !TODO: change these to constexpr and rename every occurrence across the codebase
 #define AUDIO_TRACK_MARKER (uint16_t)0xFFFF
 
@@ -138,6 +140,11 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @brief Last connect time of voice session
 	 */
 	time_t connect_time;
+
+	/*
+	* @brief For mixing outgoing voice data.
+	*/
+	std::unique_ptr<audio_mixer> mixer;
 
 	/**
 	 * @brief IP of UDP/RTP endpoint


### PR DESCRIPTION
Storing it along with the array of floats that are used as an intermediary for converting to/from avx registers seems to cut down CPU usage while streaming audio in my implementation by roughly 50%. As opposed to reallocating the array for every function call.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
