### PR TITLE
fix: awful wrong indentation in stringops

### DIFF
--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -186,15 +186,16 @@ template <int> int from_string(const std::string &s)
  * 
  * @tparam T numeric type
  * @param i numeric value
+ * @param leading_zeroes set to false if you don't want the leading zeroes in the output
  * @return std::string value in hex, the length will be 2* the raw size of the type
  */
-template <typename T> std::string to_hex(T i)
+template <typename T> std::string to_hex(T i, bool leading_zeroes = true)
 {
 	char str[26] = { 0 };
 	size_t size = sizeof(T) * 2;
 	std::to_chars(std::begin(str), std::end(str), i, 16);
 	std::string out{str};
-	if (out.length() < size) {
+	if (leading_zeroes && out.length() < size) {
 		out.insert(out.begin(), size - out.length(), '0');
 	}
 	return out;

--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -191,8 +191,13 @@ template <int> int from_string(const std::string &s)
 template <typename T> std::string to_hex(T i)
 {
 	char str[26] = { 0 };
+	size_t size = sizeof(T) * 2;
 	std::to_chars(std::begin(str), std::end(str), i, 16);
-	return std::string{str};
+	std::string out{str};
+	if (out.length() < size) {
+		out.insert(out.begin(), size - out.length(), '0');
+	}
+	return out;
 }
 
 /**

--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -40,9 +40,9 @@ namespace dpp {
  */
 template <typename T> std::basic_string<T> lowercase(const std::basic_string<T>& s)
 {
-    std::basic_string<T> s2 = s;
-    std::transform(s2.begin(), s2.end(), s2.begin(), tolower);
-    return s2;
+	std::basic_string<T> s2 = s;
+	std::transform(s2.begin(), s2.end(), s2.begin(), tolower);
+	return s2;
 }
 
 /**
@@ -54,9 +54,9 @@ template <typename T> std::basic_string<T> lowercase(const std::basic_string<T>&
  */
 template <typename T> std::basic_string<T> uppercase(const std::basic_string<T>& s)
 {
-    std::basic_string<T> s2 = s;
-    std::transform(s2.begin(), s2.end(), s2.begin(), toupper);
-    return s2;
+	std::basic_string<T> s2 = s;
+	std::transform(s2.begin(), s2.end(), s2.begin(), toupper);
+	return s2;
 }
 
 /**
@@ -189,10 +189,10 @@ template <int> int from_string(const std::string &s)
  */
 template <typename T> std::string to_hex(T i)
 {
-  std::stringstream stream;
+	std::stringstream stream;
 	stream.imbue(std::locale::classic());
-  stream << std::setfill('0') << std::setw(sizeof(T)*2) << std::hex << i;
-  return stream.str();
+	stream << std::setfill('0') << std::setw(sizeof(T)*2) << std::hex << i;
+	return stream.str();
 }
 
 /**
@@ -205,10 +205,10 @@ template <typename T> std::string to_hex(T i)
  */
 template <typename T> std::string leading_zeroes(T i, size_t width)
 {
-  std::stringstream stream;
+	std::stringstream stream;
 	stream.imbue(std::locale::classic());
-  stream << std::setfill('0') << std::setw((int)width) << std::dec << i;
-  return stream.str();
+	stream << std::setfill('0') << std::setw((int)width) << std::dec << i;
+	return stream.str();
 }
 
 } // namespace dpp

--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <sstream>
 #include <iostream>
+#include <charconv>
 
 namespace dpp {
 /**
@@ -189,10 +190,9 @@ template <int> int from_string(const std::string &s)
  */
 template <typename T> std::string to_hex(T i)
 {
-	std::stringstream stream;
-	stream.imbue(std::locale::classic());
-	stream << std::setfill('0') << std::setw(sizeof(T)*2) << std::hex << i;
-	return stream.str();
+	char str[26] = { 0 };
+	std::to_chars(std::begin(str), std::end(str), i, 16);
+	return std::string{str};
 }
 
 /**


### PR DESCRIPTION
[ Please outline your change here. Be sure to check the checkboxes below. ]

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
