### PR TITLE
docs: changed the notes on read_file.

### DIFF
--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -448,8 +448,8 @@ namespace dpp {
 
 		/**
 		 * @brief Read a whole file into a std::string.
-		 * Be sure you have enough memory to read the file, if you are reading a large file.
-		 * @note Be aware this function can block! If you are regularly reading large files, consider caching them.
+		 * @note This function can take a while if this is a large file, causing events to not reply and also taking up a lot of memory. Make sure you have enough memory, and use dpp::interaction_create_t::thinking in events where you call this function on big files.
+		 * @warning Be aware this function can block! If you are regularly reading large files, consider caching them.
 		 * @param filename The path to the file to read
 		 * @return std::string The file contents
 		 * @throw dpp::file_exception on failure to read the entire file


### PR DESCRIPTION
This PR alters the notes on `dpp::utility::read_file`. After experimenting in DPP-UE, I realised that there was no note as to what happens if the file is big and causes the event to timeout, causing a crash in DPP-UE and an error log in DPP. I made the note to give more information to users about this, making sure they know to use `thinking` if the file is big.

The PR also renames the previous note to be a warning. I feel that the warning is very much required so people know that the function can, and will, block the thread, if the file is big.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
