### PR TITLE
move the error checks from sslclient.cpp to wsclient.cpp where they belong, so they dont cause excessive data copies or false alarms

### DIFF
--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -508,28 +508,6 @@ void ssl_client::read_loop()
 							case SSL_ERROR_NONE:
 								/* Data received, add it to the buffer */
 								if (r > 0) {
-									const std::string data(server_to_client_buffer, r);
-									/* Split the data into an array for every line. */
-									const std::vector<std::string> data_lines = utility::tokenize(data);
-									/* Get the first line as we always know that's the HTTP response. */
-									const std::string http_reponse(data_lines[0]);
-
-									/* Does the first line begin with a http code? */
-									if (http_reponse.rfind("HTTP/1.1", 0) != std::string::npos) {
-										/* Now let's split the first line by every space, meaning we can check the actual HTTP code. */
-										const std::vector<std::string> line_split_by_space = utility::tokenize(data_lines[0], " ");
-
-										/* We need to make sure there's at least 3 elements in line_split_by_space. */
-										if (line_split_by_space.size() >= 3) {
-											const int http_code = std::stoi(line_split_by_space[1]);
-
-											/* If the http_code isn't 204, 101, or 200, log it. */
-											if (http_code != 204 && http_code != 101 && http_code != 200) {
-												log(ll_warning, "Received unhandled code: " + http_reponse);
-											}
-										}
-									}
-
 									buffer.append(server_to_client_buffer, r);
 									if (!this->handle_buffer(buffer)) {
 										return;

--- a/src/dpp/wsclient.cpp
+++ b/src/dpp/wsclient.cpp
@@ -159,7 +159,7 @@ bool websocket_client::handle_buffer(std::string &buffer)
 					} else if (status.size() < 3) {
 						log(ll_warning, "Malformed HTTP response on websocket");
 						return false;
-					} else {
+					} else if (status[1] != "200" && status[1] != "204") {
 						log(ll_warning, "Received unhandled code: " + status[1]);
 						return false;
 					}

--- a/src/dpp/wsclient.cpp
+++ b/src/dpp/wsclient.cpp
@@ -156,7 +156,11 @@ bool websocket_client::handle_buffer(std::string &buffer)
 						}
 		
 						state = CONNECTED;
+					} else if (status.size() < 3) {
+						log(ll_warning, "Malformed HTTP response on websocket");
+						return false;
 					} else {
+						log(ll_warning, "Received unhandled code: " + status[1]);
 						return false;
 					}
 				}


### PR DESCRIPTION
The code added in a previous PR would cause unceccessary checks of the data every time we did SSL_read, this really belongs in wsclient when looking for the 101 reply, so i moved it.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
