### PR TITLE
ci: prevent ci runs being cancelled by github incorrectly (backwards)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
   linux-with-unit-test:
     permissions:
       contents: write
-    concurrency: 
-      group: linux-build-unit-test
-      cancel-in-progress: false
     name: Linux ${{matrix.cfg.arch}} (${{matrix.cfg.cpp-version}})
     runs-on: ${{matrix.cfg.os}}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
   linux-with-unit-test:
     permissions:
       contents: write
+    concurrency:
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     name: Linux ${{matrix.cfg.arch}} (${{matrix.cfg.cpp-version}})
     runs-on: ${{matrix.cfg.os}}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     name: Linux ${{matrix.cfg.arch}} (${{matrix.cfg.cpp-version}})
     runs-on: ${{matrix.cfg.os}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,10 @@ jobs:
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true	
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
 
     concurrency: 
       group: docs-deployment
-      cancel-in-progress: false
+      cancel-in-progress: true
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -9,6 +9,9 @@ jobs:
   scanning:
     name: GitGuardian scan
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true	
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1


### PR DESCRIPTION
https://github.com/orgs/community/discussions/53506
https://www.polpiella.dev/cancelling-unnecessary-github-actions-automatically/

Values for cancel concurrent swapped over, so that PRs dont all stack up crazy-like.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
