### PR TITLE
docs: corrected freebsd.md and openbsd.md

### DIFF
--- a/docpages/building/freebsd.md
+++ b/docpages/building/freebsd.md
@@ -3,6 +3,7 @@
 \note This page assumes you are the root user. If you are not, start the package install commands with `sudo`, along with `make install`. You will need `sudo` installed if you are not the root user.
 
 ## 1. Toolchain
+
 Since the project uses `CMake`, you'll need to install it! If you don't have it, you can do the following:
 
 ```bash
@@ -10,6 +11,7 @@ pkg install cmake
 ```
 
 ## 2. Install Voice Dependencies (Optional)
+
 If you wish to use voice support, you'll need to install opus and libsodium:
 
 First, you need to install opus.
@@ -34,14 +36,15 @@ cmake --build ./build -j8
     
 Replace the number after `-j` with a number suitable for your setup, usually the same as the number of cores on your machine. `cmake` will fetch any dependencies that are required for you and ensure they are compiled alongside the library.
 
-## 4. Install globally
+## 4. Install Globally
 
 ```bash
 cd build
 make install
 ```
 
-## 5. Installation to a different directory (Optional)
+## 5. Installation to a D0ifferent Directory (Optional)
+
 If you want to install the library, its dependencies and header files to a different directory, specify this directory when running `cmake`:
 
 ```bash
@@ -50,7 +53,8 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
 
 Then once the build is complete, run `sudo make install` to install to the location you specified.
 
-## 6. Using the library
+## 6. Using the Library
+
 Once installed, you can make use of the library in standalone programs simply by including it and linking to it:
 
 ```bash
@@ -59,12 +63,12 @@ clang++ -std=c++17 -L/usr/local/lib -I/usr/local/include -ldpp bot.cpp -o dppbot
 
 The important flags in this command-line are:
 
- * `-std=c++17` - Required to compile the headers
- * `-L/usr/local/lib` - Required to tell the linker where libdpp is located.
- * `-I/usr/local/include` - Required to tell the linker where dpp headers are located.
- * `-ldpp` - Link to `libdpp.so`.
- * `bot.cpp` - Your source code.
- * `-o dppbot` - The name of the executable to make.
+* `-std=c++17` - Required to compile the headers
+* `-L/usr/local/lib` - Required to tell the linker where libdpp is located.
+* `-I/usr/local/include` - Required to tell the linker where dpp headers are located.
+* `-ldpp` - Link to `libdpp.so`.
+* `bot.cpp` - Your source code.
+* `-o dppbot` - The name of the executable to make.
 
 \include{doc} install_prebuilt_footer.dox
 

--- a/docpages/building/freebsd.md
+++ b/docpages/building/freebsd.md
@@ -1,46 +1,70 @@
 \page buildfreebsd Building on FreeBSD
 
+\note This page assumes you are the root user. If you are not, start the package install commands with `sudo`, along with `make install`. You will need `sudo` installed if you are not the root user.
+
 ## 1. Toolchain
-This project uses CMake. Install it with `pkg install cmake`
+Since the project uses `CMake`, you'll need to install it! If you don't have it, you can do the following:
 
-## 2. Install External Dependencies
-Your FreeBSD base system should have all the required dependencies installed by default.
+```bash
+pkg install cmake
+```
 
-For voice support, additional dependencies are required
+## 2. Install Voice Dependencies (Optional)
+If you wish to use voice support, you'll need to install opus and libsodium:
 
-    pkg install libsodium opus pkgconf
+First, you need to install opus.
+```bash
+cd /usr/ports/audio/opus
+make && make install
+```
+
+Then, you need to install libsodium.
+
+```bash
+cd /usr/ports/security/libsodium
+make && make install
+```
 
 ## 3. Build Source Code
 
-    cmake -B ./build
-    cmake --build ./build -j8
+```bash
+cmake -B ./build
+cmake --build ./build -j8
+```
     
 Replace the number after `-j` with a number suitable for your setup, usually the same as the number of cores on your machine. `cmake` will fetch any dependencies that are required for you and ensure they are compiled alongside the library.
 
 ## 4. Install globally
 
-    cd build; make install
+```bash
+cd build
+make install
+```
 
-## 5. Installation to a different directory
-
+## 5. Installation to a different directory (Optional)
 If you want to install the library, its dependencies and header files to a different directory, specify this directory when running `cmake`:
 
-    cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
+```bash
+cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
+```
 
-Then once the build is complete, run `make install` to install to the location you specified.
+Then once the build is complete, run `sudo make install` to install to the location you specified.
 
 ## 6. Using the library
-
 Once installed, you can make use of the library in standalone programs simply by including it and linking to it:
 
-    clang++ -std=c++17 -ldpp mydppbot.cpp -o dppbot
+```bash
+clang++ -std=c++17 -L/usr/local/lib -I/usr/local/include -ldpp bot.cpp -o dppbot
+```
 
 The important flags in this command-line are:
 
  * `-std=c++17` - Required to compile the headers
- * `-ldpp` - Link to libdpp.dylib
- * `mydppbot.cpp` - Your source code
- * `dppbot` - The name of the executable to make
+ * `-L/usr/local/lib` - Required to tell the linker where libdpp is located.
+ * `-I/usr/local/include` - Required to tell the linker where dpp headers are located.
+ * `-ldpp` - Link to `libdpp.so`.
+ * `bot.cpp` - Your source code.
+ * `-o dppbot` - The name of the executable to make.
 
 \include{doc} install_prebuilt_footer.dox
 

--- a/docpages/building/freebsd.md
+++ b/docpages/building/freebsd.md
@@ -43,7 +43,7 @@ cd build
 make install
 ```
 
-## 5. Installation to a D0ifferent Directory (Optional)
+## 5. Installation to a Different Directory (Optional)
 
 If you want to install the library, its dependencies and header files to a different directory, specify this directory when running `cmake`:
 

--- a/docpages/building/openbsd.md
+++ b/docpages/building/openbsd.md
@@ -1,5 +1,7 @@
 \page buildopenbsd Building on OpenBSD
 
+\note This page assumes you are the root user. If you are not, start the package install commands with `doas`, along with `make install`.
+
 ## 1. Toolchain
 Since the project uses `CMake`, you'll need to install it! If you don't have it, you can do the following:
 
@@ -23,13 +25,13 @@ cmake --build ./build -j8
     
 Replace the number after `-j` with a number suitable for your setup, usually the same as the number of cores on your machine. `cmake` will fetch any dependencies that are required for you and ensure they are compiled alongside the library.
 
-## 2. Install globally
+## 4. Install globally
 
 ```bash
-cd build; sudo make install
+cd build; make install
 ```
 
-## 3. Installation to a different directory
+## 5. Installation to a different directory
 
 If you want to install the library, its dependencies and header files to a different directory, specify this directory when running `cmake`:
 
@@ -39,21 +41,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
 
 Then once the build is complete, run `make install` to install to the location you specified.
 
-## 4. Using the library
-
-Once installed to the `/usr/local` directory, you can make use of the library in standalone programs simply by including it and linking to it:
-
-```bash
-clang++ -std=c++17 mydppbot.cpp -o dppbot -ldpp
-```
-
-The important flags in this command-line are:
-
- * `-std=c++17` - Required to compile the headers
- * `-ldpp` - Link to libdpp.dylib
- * `mydppbot.cpp` - Your source code
- * `dppbot` - The name of the executable to make
-
-\include{doc} install_prebuilt_footer.dox
+## 6. Using the library
+Once installed to the `/usr/local` directory, you can make use of the library in CMake, without linking to a folder! You can't use this with `clang++`, nor `g++`, as OpenBSD seems to be broken on this end, so your only option from here is to use CMake. This isn't a bad thing, as we recommend people to use CMake anyways!
 
 **Have fun!**

--- a/docpages/building/openbsd.md
+++ b/docpages/building/openbsd.md
@@ -3,6 +3,7 @@
 \note This page assumes you are the root user. If you are not, start the package install commands with `doas`, along with `make install`.
 
 ## 1. Toolchain
+
 Since the project uses `CMake`, you'll need to install it! If you don't have it, you can do the following:
 
 ```bash
@@ -10,6 +11,7 @@ pkg_add cmake
 ```
 
 ## 2. Install Voice Dependencies (Optional)
+
 If you wish to use voice support, you'll need to do the following:
 
 ```bash
@@ -25,13 +27,13 @@ cmake --build ./build -j8
     
 Replace the number after `-j` with a number suitable for your setup, usually the same as the number of cores on your machine. `cmake` will fetch any dependencies that are required for you and ensure they are compiled alongside the library.
 
-## 4. Install globally
+## 4. Install Globally
 
 ```bash
 cd build; make install
 ```
 
-## 5. Installation to a different directory
+## 5. Installation to a Different Directory
 
 If you want to install the library, its dependencies and header files to a different directory, specify this directory when running `cmake`:
 
@@ -41,7 +43,8 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
 
 Then once the build is complete, run `make install` to install to the location you specified.
 
-## 6. Using the library
+## 6. Using the Library
+
 Once installed to the `/usr/local` directory, you can make use of the library in CMake, without linking to a folder! You can't use this with `clang++`, nor `g++`, as OpenBSD seems to be broken on this end, so your only option from here is to use CMake. This isn't a bad thing, as we recommend people to use CMake anyways!
 
 **Have fun!**


### PR DESCRIPTION
This PR corrects the freebsd.md page, so it now works with `clang++` as found from #901. It also corrects openbsd.md, so it no longer states that `clang++` works for OpenBSD, but rather states it can only be used with CMake.

I've also merged changes from #820 into this PR.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
