### PR TITLE
ci: fixed an issue with labeler failing

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 permissions:


### PR DESCRIPTION
Fixed an issue where labeler was failing due to a permissions issue. This was caused by #913.

The checklist does not apply.
