### PR TITLE
feat: added an error for caps in command_option.

### DIFF
--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -333,6 +333,9 @@ command_option_choice &command_option_choice::fill_from_json(nlohmann::json *j) 
 command_option::command_option(command_option_type t, const std::string &n, const std::string &d, bool r) :
 	type(t), name(n), description(d), required(r), autocomplete(false)
 {
+	if (std::any_of(n.begin(), n.end(), [](unsigned char c){ return std::isupper(c); })) {
+		throw dpp::logic_exception("Command options can not contain capital letters in the name of the option.");
+	}
 }
 
 command_option& command_option::add_choice(const command_option_choice &o)


### PR DESCRIPTION
This PR adds an error message into the constructor of `command_option`. This is just to make it more user-friendly for people, rather than discord just returning an error.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
