### PR TITLE
feat: added thread_get for threads

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3315,6 +3315,15 @@ public:
 	void threads_get_joined_private_archived(snowflake channel_id, snowflake before_id, uint16_t limit, command_completion_event_t callback);
 
 	/**
+	 * @brief Get the thread specified by thread_id. This uses the same call as dpp::cluster::channel_get but returns a thread object.
+	 * @see https://discord.com/developers/docs/resources/channel#get-channel
+	 * @param thread_id The id of the thread to obtain.
+	 * @param callback Function to call when the API call completes
+	 * On success the callback will contain a dpp::thread object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void thread_get(snowflake thread_id, command_completion_event_t callback);
+
+	/**
 	 * @brief Create a sticker in a guild
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @see https://discord.com/developers/docs/resources/sticker#create-guild-sticker

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -160,4 +160,8 @@ void cluster::thread_member_remove(snowflake thread_id, snowflake user_id, comma
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(thread_id), "/thread-members/" + std::to_string(user_id), m_delete, "", callback);
 }
 
+void cluster::thread_get(snowflake thread_id, command_completion_event_t callback) {
+	rest_request<thread>(this, API_PATH "/channels", std::to_string(thread_id), "", m_get, "", callback);
+}
+
 } // namespace dpp


### PR DESCRIPTION
This PR adds a `thread_get` function to the cluster object, allowing people to get a thread object from an id.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [ ] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR.
- [ ] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
