### PR TITLE
fix: threads now send correctly to discord.

### DIFF
--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -484,7 +484,7 @@ std::string thread::build_json(bool with_id) const {
 	j["auto_archive_duration"] = this->metadata.auto_archive_duration;
 	j["locked"] = this->metadata.locked;
 	
-	if(this->get_type() == dpp::channel_type::CHANNEL_PRIVATE_THREAD) {
+	if(is_private_thread()) {
 		j["invitable"] = this->metadata.invitable;
 	}
 

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -478,14 +478,34 @@ channel& channel::fill_from_json(json* j) {
 }
 
 std::string thread::build_json(bool with_id) const {
-	json j = json::parse(channel::build_json(with_id));
-	j["type"] = (flags & CHANNEL_TYPE_MASK);
-	j["thread_metadata"] = this->metadata;
-	if (!this->applied_tags.empty()) {
-		j["applied_tags"] = json::array();
-		for (auto &tag_id: this->applied_tags) {
-			if (tag_id) {
-				j["applied_tags"].push_back(tag_id);
+	json j;
+	j["name"] = this->name;
+	j["archived"] = this->metadata.archived;
+	j["auto_archive_duration"] = this->metadata.auto_archive_duration;
+	j["locked"] = this->metadata.locked;
+	
+	if(this->get_type() == dpp::channel_type::CHANNEL_PRIVATE_THREAD) {
+		j["invitable"] = this->metadata.invitable;
+	}
+
+	j["rate_limit_per_user"] = this->rate_limit_per_user;
+
+	if (is_forum() || is_media_channel()) {
+
+		uint32_t _flags = (flags & dpp::c_require_tag) ? dc_require_tag : 0;
+		if (is_media_channel()) {
+			_flags |= (flags & dpp::c_hide_media_download_options) ? dc_hide_media_download_options : 0;
+		}
+		if (_flags) {
+			j["flags"] = _flags;
+		}
+
+		if (!this->applied_tags.empty()) {
+			j["applied_tags"] = json::array();
+			for (auto &tag_id: this->applied_tags) {
+				if (tag_id) {
+					j["applied_tags"].push_back(tag_id);
+				}
 			}
 		}
 	}

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -478,34 +478,21 @@ channel& channel::fill_from_json(json* j) {
 }
 
 std::string thread::build_json(bool with_id) const {
-	json j;
-	j["name"] = this->name;
+	json j = json::parse(channel::build_json(with_id));
+	j["type"] = (flags & CHANNEL_TYPE_MASK);
 	j["archived"] = this->metadata.archived;
 	j["auto_archive_duration"] = this->metadata.auto_archive_duration;
 	j["locked"] = this->metadata.locked;
 	
-	if(is_private_thread()) {
+	if(this->get_type() == dpp::channel_type::CHANNEL_PRIVATE_THREAD) {
 		j["invitable"] = this->metadata.invitable;
 	}
 
-	j["rate_limit_per_user"] = this->rate_limit_per_user;
-
-	if (is_forum() || is_media_channel()) {
-
-		uint32_t _flags = (flags & dpp::c_require_tag) ? dc_require_tag : 0;
-		if (is_media_channel()) {
-			_flags |= (flags & dpp::c_hide_media_download_options) ? dc_hide_media_download_options : 0;
-		}
-		if (_flags) {
-			j["flags"] = _flags;
-		}
-
-		if (!this->applied_tags.empty()) {
-			j["applied_tags"] = json::array();
-			for (auto &tag_id: this->applied_tags) {
-				if (tag_id) {
-					j["applied_tags"].push_back(tag_id);
-				}
+	if (!this->applied_tags.empty()) {
+		j["applied_tags"] = json::array();
+		for (auto &tag_id: this->applied_tags) {
+			if (tag_id) {
+				j["applied_tags"].push_back(tag_id);
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue with threads, as they weren't sending correctly to discord [according to this part of the documentation](https://discord.com/developers/docs/resources/channel#:~:text=json%20params%20(thread)). This means threads can now be locked and archived correctly.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
