### PR TITLE
CI: add clang builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,15 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
-          - { arch: 'amd64', os: ubuntu-20.04, cpp-version: clang++-10, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-12, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-13, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-14, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-15, cmake-flags: '-DDPP_CORO=ON' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-12, cmake-flags: '-DDPP_CORO=ON' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-11, cmake-flags: '-DDPP_CORO=ON' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-10, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-20.04, cpp-version: g++-9, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-20.04, package: clang-10, cpp-version: clang++-10, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: clang-12, cpp-version: clang++-12, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: clang-13, cpp-version: clang++-13, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: clang-14, cpp-version: clang++-14, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: clang-15, cpp-version: clang++-15, cmake-flags: '-DDPP_CORO=ON' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: g++-12, cpp-version: g++-12, cmake-flags: '-DDPP_CORO=ON' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: g++-11, cpp-version: g++-11, cmake-flags: '-DDPP_CORO=ON' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: g++-10, cpp-version: g++-10, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-20.04, package: g++-9, cpp-version: g++-9, cmake-flags: '' }
 
     steps:
       - name: Harden Runner
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Install apt packages
-        run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install  ${{ matrix.cfg.cpp-version }} libsodium-dev libopus-dev zlib1g-dev rpm
+        run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt install  ${{ matrix.cfg.package }} libsodium-dev libopus-dev zlib1g-dev rpm
 
       - name: Generate CMake
         run: mkdir build && cd build && cmake -DDPP_NO_VCPKG=ON -DAVX_TYPE=AVX0 -DCMAKE_BUILD_TYPE=Release ${{matrix.cfg.cmake-flags}} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
+          - { arch: 'amd64', os: ubuntu-20.04, cpp-version: clang-10, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-12, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-13, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-14, cmake-flags: '' }
@@ -130,6 +131,33 @@ jobs:
       contents: write
     name: macOS x64
     runs-on: macos-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout D++
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Install homebrew packages
+        run: brew install cmake make libsodium opus openssl
+
+      - name: Generate CMake
+        run: mkdir build && cd build && cmake -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Release -DDPP_CORO=ON -DAVX_TYPE=AVX0 ..
+        env:
+          DONT_RUN_VCPKG: true
+
+      - name: Build Project
+        run: cd build && make -j2
+        env:
+          DONT_RUN_VCPKG: true
+
+  macos-arm:
+    permissions:
+      contents: write
+    name: macOS 13 ARM64
+    runs-on: macos-13-arm64
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       matrix:
         cfg:
           - { arch: 'amd64', os: ubuntu-20.04, package: clang-10, cpp-version: clang++-10, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, package: clang-11, cpp-version: clang++-11, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, package: clang-12, cpp-version: clang++-12, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, package: clang-13, cpp-version: clang++-13, cmake-flags: '' }
           - { arch: 'amd64', os: ubuntu-22.04, package: clang-14, cpp-version: clang++-14, cmake-flags: '' }
@@ -149,34 +150,7 @@ jobs:
           DONT_RUN_VCPKG: true
 
       - name: Build Project
-        run: cd build && make -j2
-        env:
-          DONT_RUN_VCPKG: true
-
-  macos-arm:
-    permissions:
-      contents: write
-    name: macOS 13 ARM64
-    runs-on: macos-13-arm64
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout D++
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
-      - name: Install homebrew packages
-        run: brew install cmake make libsodium opus openssl
-
-      - name: Generate CMake
-        run: mkdir build && cd build && cmake -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Release -DDPP_CORO=ON -DAVX_TYPE=AVX0 ..
-        env:
-          DONT_RUN_VCPKG: true
-
-      - name: Build Project
-        run: cd build && make -j2
+        run: cd build && make -j3
         env:
           DONT_RUN_VCPKG: true
 
@@ -293,30 +267,3 @@ jobs:
         with:
           name: "libdpp - RPM Package ${{matrix.cfg.name}}"
           path: "${{github.workspace}}/build/*.rpm"
-
-#  testfreebsd:
-#   runs-on: macos-10.15
-#   name: FreeBSD (g++-10)
-#   steps:
-#   - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-#   - name: FreeBSD Build and Package
-#     id: freebsdtest
-#     uses: vmactions/freebsd-vm@v0.1.5
-#     with:
-#        usesh: true
-#       prepare: pkg install -y openssl-devel gcc gmake cmake git
-#       run: |
-#         pwd
-#         ls -lah
-#          mkdir build
-#          cd build
-#          cmake -DAVX_TYPE=AVX0 -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Release ..
-#          make -j2
-#          make install
-#          cpack --verbose
-#
-#    - name: Upload Binaries (BZ2)
-#      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-#      with:
-#        name: "libdpp - FreeBSD x64"
-#        path: "${{github.workspace}}/build/*.tar.bz2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
-          - { arch: 'amd64', os: ubuntu-20.04, cpp-version: clang-10, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-12, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-13, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-14, cmake-flags: '' }
-          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-15, cmake-flags: '-DDPP_CORO=ON' }
+          - { arch: 'amd64', os: ubuntu-20.04, cpp-version: clang++-10, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-12, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-13, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-14, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang++-15, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-12, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-11, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-10, cmake-flags: '' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-12, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-13, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-14, cmake-flags: '' }
+          - { arch: 'amd64', os: ubuntu-22.04, cpp-version: clang-15, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-12, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-11, cmake-flags: '-DDPP_CORO=ON' }
           - { arch: 'amd64', os: ubuntu-22.04, cpp-version: g++-10, cmake-flags: '' }


### PR DESCRIPTION
Adds clang 10-15 to CI and bumps up concurrency on macos from 2 to 3.
clang++ 15 has CORO, 10-14 do not, to test a wide range of configurations.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
