### PR TITLE
docs: added a page for clearing slashcommands

### DIFF
--- a/docpages/example_code/clearing_slashcommands.cpp
+++ b/docpages/example_code/clearing_slashcommands.cpp
@@ -1,0 +1,25 @@
+#include <dpp/dpp.h>
+
+int main()
+{
+	dpp::cluster bot("token");
+
+	bot.on_log(dpp::utility::cout_logger());
+
+	/* We won't be performing any commands, so we don't need to add the event here! */
+
+	bot.on_ready([&bot](const dpp::ready_t & event) {
+		if (dpp::run_once<struct clear_bot_commands>()) {
+			/* Now, we're going to wipe our commands */
+			bot.global_bulk_command_delete();
+			/* This one requires a guild id, otherwise it won't what guild's commands it needs to wipe! */
+			bot.guild_bulk_command_delete(857692897221033129);
+		}
+
+		/* Because the run_once above uses a 'clear_bot_commands' struct, you can continue to register commands below! */
+	});
+
+	bot.start(dpp::st_wait);
+
+	return 0;
+}

--- a/docpages/example_programs/interactions_and_components.md
+++ b/docpages/example_programs/interactions_and_components.md
@@ -3,6 +3,7 @@
 The example programs listed here demonstrate lots of things to do with interactions, application commands (slash commands) and message components. If you're looking to make your bot **modern and user friendly** these examples are what you need.
 
 * \subpage slashcommands "Using Slash Commands and Interactions"
+* \subpage clearing_slashcommands
 * \subpage subcommands "Slash command sub-commands"
 * \subpage user-only-messages "Ephemeral replies ('Only you can see this' replies)"
 * \subpage components "Using button components"

--- a/docpages/example_programs/interactions_and_components/clearing_slashcommands.md
+++ b/docpages/example_programs/interactions_and_components/clearing_slashcommands.md
@@ -2,6 +2,6 @@
 
 After a while of creating commands, you may start to wonder "hm, how can I clear these?". Well, this tutorial covers it! All you have to do is simply call dpp::cluster::global_bulk_command_delete or dpp::cluster::guild_bulk_command_delete.
 
-\note Clearing global commands will only clear commands that were **made globally**, same goes for the opposite way round. The example will demonstrate using both functions.
+\note Clearing **global commands** will only clear commands that were **made globally**, same goes for the opposite way round. The example will demonstrate using both functions.
 
 \include{cpp} clearing_slashcommands.cpp

--- a/docpages/example_programs/interactions_and_components/clearing_slashcommands.md
+++ b/docpages/example_programs/interactions_and_components/clearing_slashcommands.md
@@ -1,0 +1,7 @@
+\page clearing_slashcommands Clearing registered commands
+
+After a while of creating commands, you may start to wonder "hm, how can I clear these?". Well, this tutorial covers it! All you have to do is simply call dpp::cluster::global_bulk_command_delete or dpp::cluster::guild_bulk_command_delete.
+
+\note Clearing global commands will only clear commands that were **made globally**, same goes for the opposite way round. The example will demonstrate using both functions.
+
+\include{cpp} clearing_slashcommands.cpp


### PR DESCRIPTION
This PR adds a page about clearing commands, which is added by #938 .

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
