### PR TITLE
docs: refactored code examples to comply with code standard

### DIFF
--- a/docpages/example_code/attachments1.cpp
+++ b/docpages/example_code/attachments1.cpp
@@ -1,34 +1,32 @@
 #include <dpp/dpp.h>
 
 int main() {
-    dpp::cluster bot("token");
+	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
-    
-    /* The event is fired when someone issues your commands */
+	bot.on_log(dpp::utility::cout_logger());
+
+	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "file") {
+			dpp::message msg(event.command.channel_id, "Hey there, I've got a new file!");
 
-            dpp::message msg(event.command.channel_id, "Hey there, I've got a new file!");
-
-            /* attach the file to the message */
-            msg.add_file("foobar.txt", dpp::utility::read_file("path_to_your_file.txt"));
+			/* attach the file to the message */
+			msg.add_file("foobar.txt", dpp::utility::read_file("path_to_your_file.txt"));
 
 			/* Reply to the user with the message, with our file attached. */
 			event.reply(msg);
 		}
 	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("file", "Send a message with a file attached!", bot.me.id));
+		}
+	});
 
-            /* Create and register a command when the bot is ready */
-            bot.global_command_create(dpp::slashcommand("file", "Send a message with a file attached!", bot.me.id));
-        }
-    });
+	bot.start(dpp::st_wait);
 
-    bot.start(dpp::st_wait);
-
-    return 0;
+	return 0;
 }

--- a/docpages/example_code/attachments2.cpp
+++ b/docpages/example_code/attachments2.cpp
@@ -1,41 +1,40 @@
 #include <dpp/dpp.h>
 
 int main() {
-    dpp::cluster bot("token");
+	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* The event is fired when someone issues your commands */
+	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "file") {
 
-            /* Request the image from the URL specified and capture the event in a lambda. */
-            bot.request("https://dpp.dev/DPP-Logo.png", dpp::m_get, [event](const dpp::http_request_completion_t & httpRequestCompletion) {
+			/* Request the image from the URL specified and capture the event in a lambda. */
+			bot.request("https://dpp.dev/DPP-Logo.png", dpp::m_get, [event](const dpp::http_request_completion_t & httpRequestCompletion) {
 
-                /* Create a message */
-                dpp::message msg(event.command.channel_id, "This is my new attachment:");
+				/* Create a message */
+				dpp::message msg(event.command.channel_id, "This is my new attachment:");
 
-                /* Attach the image to the message, only on success (Code 200). */
-                if (httpRequestCompletion.status == 200) {
-                    msg.add_file("logo.png", httpRequestCompletion.body);
-                }
+				/* Attach the image to the message, only on success (Code 200). */
+				if (httpRequestCompletion.status == 200) {
+					msg.add_file("logo.png", httpRequestCompletion.body);
+				}
 
-                /* Send the message, with our attachment. */
-                event.reply(msg);
-            });
+				/* Send the message, with our attachment. */
+				event.reply(msg);
+			});
 		}
 	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("file", "Send a message with an image attached from the internet!", bot.me.id));
+		}
+	});
 
-            /* Create and register a command when the bot is ready */
-            bot.global_command_create(dpp::slashcommand("file", "Send a message with an image attached from the internet!", bot.me.id));
-        }
-    });
+	bot.start(dpp::st_wait);
 
-    bot.start(dpp::st_wait);
-
-    return 0;
+	return 0;
 }

--- a/docpages/example_code/attachments3.cpp
+++ b/docpages/example_code/attachments3.cpp
@@ -1,41 +1,39 @@
 #include <dpp/dpp.h>
 
 int main() {
-    dpp::cluster bot("token");
+	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* The event is fired when someone issues your commands */
+	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "file") {
+			/* Create a message. */
+			dpp::message msg(event.command.channel_id, "");
 
-            /* Create a message. */
-            dpp::message msg(event.command.channel_id, "");
+			/* Attach the image to the message we just created. */
+			msg.add_file("image.jpg", dpp::utility::read_file("path_to_your_image.jpg"));
 
-            /* Attach the image to the message we just created. */
-            msg.add_file("image.jpg", dpp::utility::read_file("path_to_your_image.jpg"));
+			/* Create an embed. */
+			dpp::embed embed;
+			embed.set_image("attachment://image.jpg"); /* Set the image of the embed to the attached image. */
 
-            /* Create an embed. */
-            dpp::embed embed;
-            embed.set_image("attachment://image.jpg"); /* Set the image of the embed to the attached image. */
+			/* Add the embed to the message. */
+			msg.add_embed(embed);
 
-            /* Add the embed to the message. */
-            msg.add_embed(embed);
-
-            event.reply(msg);
+			event.reply(msg);
 		}
 	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("file", "Send a local image along with an embed with the image!", bot.me.id));
+		}
+	});
 
-            /* Create and register a command when the bot is ready */
-            bot.global_command_create(dpp::slashcommand("file", "Send a local image along with an embed with the image!", bot.me.id));
-        }
-    });
+	bot.start(dpp::st_wait);
 
-    bot.start(dpp::st_wait);
-
-    return 0;
+	return 0;
 }

--- a/docpages/example_code/autocomplete.cpp
+++ b/docpages/example_code/autocomplete.cpp
@@ -4,21 +4,21 @@ int main()
 {
 	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
-	    if (dpp::run_once<struct register_bot_commands>()) {
+		if (dpp::run_once<struct register_bot_commands>()) {
 
-		    /* Create a new global command once on ready event */
-		    bot.global_command_create(dpp::slashcommand("blep", "Send a random adorable animal photo", bot.me.id)
-		    	.add_option(
-		    		/* If you set the auto complete setting on a command option, it will trigger the on_autocomplete
-		    		 * event whenever discord needs to fill information for the choices. You cannot set any choices
-		    		 * here if you set the auto complete value to true.
-		    		 */
-		    		dpp::command_option(dpp::co_string, "animal", "The type of animal").set_auto_complete(true)
-		    	)
-		    );
+			/* Create a new global command once on ready event */
+			bot.global_command_create(dpp::slashcommand("blep", "Send a random adorable animal photo", bot.me.id)
+				.add_option(
+				/* If you set the auto complete setting on a command option, it will trigger the on_autocomplete
+				* event whenever discord needs to fill information for the choices. You cannot set any choices
+				* here if you set the auto complete value to true.
+				*/
+				dpp::command_option(dpp::co_string, "animal", "The type of animal").set_auto_complete(true)
+				)
+			);
 		}
 	});
 

--- a/docpages/example_code/callbacks.cpp
+++ b/docpages/example_code/callbacks.cpp
@@ -1,88 +1,89 @@
 #include <dpp/dpp.h>
 
 int main() {
-    dpp::cluster bot("Token Was Here", dpp::i_default_intents | dpp::i_message_content);
-    /* the second argument is a bitmask of intents - i_message_content is needed to get messages */
+	dpp::cluster bot("Token Was Here", dpp::i_default_intents | dpp::i_message_content);
+	/* the second argument is a bitmask of intents - i_message_content is needed to get messages */
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* The event is fired when someone issues your commands */
-    bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) -> void {
-        if (event.command.get_command_name() == "msgs-get") {
-            int64_t limit = std::get<int64_t>(event.get_parameter("quantity"));
+	/* The event is fired when someone issues your commands */
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+		if (event.command.get_command_name() == "msgs-get") {
+			int64_t limit = std::get<int64_t>(event.get_parameter("quantity"));
 
-            /* get messages using ID of the channel the command was issued in */
-            bot.messages_get(event.command.channel_id, 0, 0, 0, limit, [event](const dpp::confirmation_callback_t& callback) -> void {
-                if (callback.is_error()) { /* catching an error to log it */
-                    std::cout << callback.get_error().message << std::endl;
-                    return;
-                }
+			/* get messages using ID of the channel the command was issued in */
+			bot.messages_get(event.command.channel_id, 0, 0, 0, limit, [event](const dpp::confirmation_callback_t& callback) {
+				if (callback.is_error()) { /* catching an error to log it */
+					std::cout << callback.get_error().message << std::endl;
+					return;
+				}
 
-                auto messages = callback.get<dpp::message_map>();
-                /* std::get<dpp::message_map>(callback.value) would give the same result */
-                
-                std::string contents;
-                for (const auto& x : messages) { /* here we iterate through the dpp::message_map we got from callback... */
-                    contents += x.second.content + '\n'; /* ...where x.first is ID of the current message and x.second is the message itself. */
-                }
+				auto messages = callback.get<dpp::message_map>();
+				/* std::get<dpp::message_map>(callback.value) would give the same result */
 
-                event.reply(contents); /* we will see all those messages we got, united as one! */
-            });
-        } else if (event.command.get_command_name() == "channel-create") {
-            /* create a text channel */
-            dpp::channel channel = dpp::channel()
-                .set_name("test")
-                .set_guild_id(event.command.guild_id);
+				std::string contents;
+				for (const auto& x : messages) { /* here we iterate through the dpp::message_map we got from callback... */
+					contents += x.second.content + '\n'; /* ...where x.first is ID of the current message and x.second is the message itself. */
+				}
 
-            bot.channel_create(channel, [&bot, event](const dpp::confirmation_callback_t& callback) -> void {
-                if (callback.is_error()) { /* catching an error to log it */
-                    bot.log(dpp::loglevel::ll_error, callback.get_error().message);
-                    return;
-                }
+				event.reply(contents); /* we will see all those messages we got, united as one! */
+			});
+		} else if (event.command.get_command_name() == "channel-create") {
+			/* create a text channel */
+			dpp::channel channel = dpp::channel()
+				.set_name("test")
+				.set_guild_id(event.command.guild_id);
 
-                auto channel = callback.get<dpp::channel>();
-                /* std::get<dpp::channel>(callback.value) would give the same result */
+			bot.channel_create(channel, [&bot, event](const dpp::confirmation_callback_t& callback) -> void {
+				if (callback.is_error()) { /* catching an error to log it */
+					bot.log(dpp::loglevel::ll_error, callback.get_error().message);
+					return;
+				}
 
-                /* reply with the created channel information */
-                dpp::message message = dpp::message("The channel's name is `" + channel.name + "`, ID is `" + std::to_string(channel.id) + " and type is `" + std::to_string(channel.get_type()) + "`.");
-                /* note that channel types are represented as numbers */
-                event.reply(message);
-            });
-        } else if (event.command.get_command_name() == "msg-error") {
-            bot.message_get(0, 0, [event](const dpp::confirmation_callback_t& callback) -> void {
-                /* the error will occur since there is no message with ID '0' that is in a channel with ID '0' (I'm not explaining why) */
-                if (callback.is_error()) {
-                    event.reply(callback.get_error().message);
-                    return;
-                }
+				auto channel = callback.get<dpp::channel>();
+				/* std::get<dpp::channel>(callback.value) would give the same result */
 
-                /* we won't be able to get here because of the return; statement */
-                auto message = callback.get<dpp::message>();
-                event.reply(message);
-            });
-        }
-    });
+				/* reply with the created channel information */
+				dpp::message message = dpp::message("The channel's name is `" + channel.name + "`, ID is `" + std::to_string(channel.id) + " and type is `" + std::to_string(channel.get_type()) + "`.");
+				/* note that channel types are represented as numbers */
+				event.reply(message);
+			});
+		} else if (event.command.get_command_name() == "msg-error") {
+			bot.message_get(0, 0, [event](const dpp::confirmation_callback_t& callback) -> void {
+				/* the error will occur since there is no message with ID '0' that is in a channel with ID '0' (I'm not explaining why) */
+				if (callback.is_error()) {
+					event.reply(callback.get_error().message);
+					return;
+				}
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once <struct register_global_commands>()) {
-            dpp::slashcommand msgs_get("msgs-get", "Get messages", bot.me.id);
+				/* we won't be able to get here because of the return; statement */
+				auto message = callback.get<dpp::message>();
+				event.reply(message);
+			});
+		}
+	});
 
-            constexpr int64_t min_val{1};
-            constexpr int64_t max_val{100};
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once <struct register_global_commands>()) {
+			dpp::slashcommand msgs_get("msgs-get", "Get messages", bot.me.id);
 
-            msgs_get.add_option(
-                dpp::command_option(dpp::co_integer, "quantity", "Quantity of messages to get. Max - 100.")
-                .set_min_value(min_val)
-                .set_max_value(max_val)
-            );
+			constexpr int64_t min_val{1};
+			constexpr int64_t max_val{100};
 
-            dpp::slashcommand channel_create("channel-create", "Create a channel", bot.me.id);
-            dpp::slashcommand msg_error("msg-error", "Get an error instead of message :)", bot.me.id);
+			msgs_get.add_option(
+				dpp::command_option(dpp::co_integer, "quantity", "Quantity of messages to get. Max - 100.")
+					.set_min_value(min_val)
+					.set_max_value(max_val)
+			);
 
-            bot.global_bulk_command_create({ msgs_get, channel_create, msg_error });
-        }
-    });
+			dpp::slashcommand channel_create("channel-create", "Create a channel", bot.me.id);
+			dpp::slashcommand msg_error("msg-error", "Get an error instead of message :)", bot.me.id);
 
-    bot.start(dpp::st_wait);
-    return 0;
+			bot.global_bulk_command_create({ msgs_get, channel_create, msg_error });
+		}
+	});
+
+	bot.start(dpp::st_wait);
+	
+	return 0;
 }

--- a/docpages/example_code/commandhandler.cpp
+++ b/docpages/example_code/commandhandler.cpp
@@ -1,16 +1,16 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* If your bot only uses the "/" prefix, you can remove the intents here. */
 	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
 
-	bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger()); 
 
 	/* Create command handler, and specify prefixes */
 	dpp::commandhandler command_handler(&bot);
 	/* Specifying a prefix of "/" tells the command handler it should also expect slash commands. Remove the .add_prefix(".") if you wish to only make it a slash command */
-	command_handler.add_prefix(".").add_prefix("/");
+	command_handler.add_prefix(".")
+		.add_prefix("/");
 
 	bot.on_ready([&command_handler](const dpp::ready_t &event) {
 

--- a/docpages/example_code/components.cpp
+++ b/docpages/example_code/components.cpp
@@ -2,29 +2,26 @@
 #include <dpp/unicode_emoji.h>
 
 int main() {
-
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
-		
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "button") {
-
 			/* Create a message */
 			dpp::message msg(event.command.channel_id, "this text has a button");
 			
 			/* Add an action row, and then a button within the action row. */
 			msg.add_component(
 				dpp::component().add_component(
-					dpp::component().
-					set_label("Click me!").
-					set_type(dpp::cot_button).
-					set_emoji(dpp::unicode_emoji::smile).
-					set_style(dpp::cos_danger).
-					set_id("myid")
+					dpp::component()
+						.set_label("Click me!")
+						.set_type(dpp::cot_button)
+						.set_emoji(dpp::unicode_emoji::smile)
+						.set_style(dpp::cos_danger)
+						.set_id("myid")
 				)
 			);
 
@@ -45,7 +42,6 @@ int main() {
 
 	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create and register a command when the bot is ready */
 			bot.global_command_create(dpp::slashcommand("button", "Send a message with a button!", bot.me.id));
 		}

--- a/docpages/example_code/components2.cpp
+++ b/docpages/example_code/components2.cpp
@@ -1,14 +1,12 @@
 #include <dpp/dpp.h>
 
 int main() {
-
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
-		
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "math") {
 
@@ -18,20 +16,22 @@ int main() {
 			/* Add an action row, and then 3 buttons within the action row. */
 			msg.add_component(
 				dpp::component().add_component(
-					dpp::component().
-					set_label("9").
-					set_style(dpp::cos_primary).
-					set_id("9")
-				).add_component(
-					dpp::component().
-					set_label("10").
-					set_style(dpp::cos_primary).
-					set_id("10")
-				).add_component(
-					dpp::component().
-					set_label("11").
-					set_style(dpp::cos_primary).
-					set_id("11")
+					dpp::component()
+						.set_label("9")
+						.set_style(dpp::cos_primary)
+						.set_id("9")
+				)
+				.add_component(
+					dpp::component()
+						.set_label("10")
+						.set_style(dpp::cos_primary)
+						.set_id("10")
+				)
+				.add_component(
+					dpp::component()
+						.set_label("11")
+						.set_style(dpp::cos_primary)
+						.set_id("11")
 				)
 			);
 
@@ -50,7 +50,6 @@ int main() {
 
 	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create and register a command when the bot is ready */
 			bot.global_command_create(dpp::slashcommand("math", "A quick maths question!", bot.me.id));
 		}

--- a/docpages/example_code/components3.cpp
+++ b/docpages/example_code/components3.cpp
@@ -2,29 +2,26 @@
 #include <dpp/unicode_emoji.h>
 
 int main() {
-
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
-		
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "select") {
-
 			/* Create a message */
 			dpp::message msg(event.command.channel_id, "This text has a select menu!");
 			
 			/* Add an action row, and a select menu within the action row. */
 			msg.add_component(
 				dpp::component().add_component(
-					dpp::component().
-					set_type(dpp::cot_selectmenu).
-					set_placeholder("Pick something").
-					add_select_option(dpp::select_option("label1","value1","description1").set_emoji(dpp::unicode_emoji::smile)).
-					add_select_option(dpp::select_option("label2","value2","description2").set_emoji(dpp::unicode_emoji::slight_smile)).
-					set_id("myselectid")
+					dpp::component()
+						.set_type(dpp::cot_selectmenu)
+						.set_placeholder("Pick something")
+						.add_select_option(dpp::select_option("label1","value1","description1").set_emoji(dpp::unicode_emoji::smile))
+						.add_select_option(dpp::select_option("label2","value2","description2").set_emoji(dpp::unicode_emoji::slight_smile))
+						.set_id("myselectid")
 				)
 			);
 
@@ -45,7 +42,6 @@ int main() {
 
 	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create and register a command when the bot is ready */
 			bot.global_command_create(dpp::slashcommand("select", "Select something at random!", bot.me.id));
 		}

--- a/docpages/example_code/context_menus.cpp
+++ b/docpages/example_code/context_menus.cpp
@@ -22,8 +22,8 @@ int main()
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create the command */
 			dpp::slashcommand command;
-			command.set_name("High Five");
-				.set_application_id(bot.me.id);
+			command.set_name("High Five")
+				.set_application_id(bot.me.id)
 				.set_type(dpp::ctxm_user);
 
 			/* Register the command */

--- a/docpages/example_code/context_menus.cpp
+++ b/docpages/example_code/context_menus.cpp
@@ -10,22 +10,21 @@ int main()
 	/* Use the on_user_context_menu event to look for user context menu actions */
 	bot.on_user_context_menu([](const dpp::user_context_menu_t& event) {
 
-		 /* check if the context menu name is High Five */
-		 if (event.command.get_command_name() == "high five") {
-			 dpp::user user = event.get_user(); // the user who the command has been issued on
-			 dpp::user author = event.command.get_issuing_user(); // the user who clicked on the context menu
-			 event.reply(author.get_mention() + " slapped " + user.get_mention());
-		 }
+		/* check if the context menu name is High Five */
+		if (event.command.get_command_name() == "high five") {
+			dpp::user user = event.get_user(); // the user who the command has been issued on
+			dpp::user author = event.command.get_issuing_user(); // the user who clicked on the context menu
+			event.reply(author.get_mention() + " slapped " + user.get_mention());
+		}
 	});
 
 	bot.on_ready([&bot](const dpp::ready_t &event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create the command */
 			dpp::slashcommand command;
 			command.set_name("High Five");
-			command.set_application_id(bot.me.id); 
-			command.set_type(dpp::ctxm_user);
+				.set_application_id(bot.me.id);
+				.set_type(dpp::ctxm_user);
 
 			/* Register the command */
 			bot.guild_command_create(command, 857692897221033129); /* Replace this with the guild id you want */

--- a/docpages/example_code/coro_awaiting_events.cpp
+++ b/docpages/example_code/coro_awaiting_events.cpp
@@ -11,7 +11,12 @@ int main() {
 			dpp::message m{"Test"};
 			std::string id{event.command.id.str()};
 			m.add_component(
-				dpp::component{}.add_component(dpp::component{}.set_type(dpp::cot_button).set_label("Click me!").set_id(id))
+				dpp::component{}.add_component(
+					dpp::component{}
+						.set_type(dpp::cot_button)
+						.set_label("Click me!")
+						.set_id(id)
+				)
 			);
 			co_await event.co_reply(m);
 
@@ -36,4 +41,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+
+	return 0;
 }

--- a/docpages/example_code/coro_expiring_buttons.cpp
+++ b/docpages/example_code/coro_expiring_buttons.cpp
@@ -11,12 +11,19 @@ int main() {
 			dpp::message m{"Test"};
 			std::string id{event.command.id.str()};
 			m.add_component(
-				dpp::component{}.add_component(dpp::component{}.set_type(dpp::cot_button).set_label("Click me!").set_id(id))
+				dpp::component{}.add_component(
+					dpp::component{}
+						.set_type(dpp::cot_button)
+						.set_label("Click me!")
+						.set_id(id)
+				)
 			);
 			co_await event.co_reply(m);
 
 			auto result = co_await dpp::when_any{ // Whichever completes first...
-				event.from->creator->on_button_click.when([&id](const dpp::button_click_t &b) { return b.custom_id == id; }), // Button clicked
+				event.from->creator->on_button_click.when([&id](const dpp::button_click_t &b) { // Button clicked
+					return b.custom_id == id;
+				}),
 				event.from->creator->co_sleep(5) // Or sleep 5 seconds
 			};
 			// Note!! Due to a bug in g++11 and g++12, id must be captured as a reference above or the compiler will destroy it twice. This is fixed in g++13
@@ -40,4 +47,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+
+	return 0;
 }

--- a/docpages/example_code/coro_intro.cpp
+++ b/docpages/example_code/coro_intro.cpp
@@ -31,5 +31,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+	
 	return 0;
 }

--- a/docpages/example_code/coro_simple_commands1.cpp
+++ b/docpages/example_code/coro_simple_commands1.cpp
@@ -1,7 +1,7 @@
 #include <dpp/dpp.h>
 
 int main() {
-	dpp::cluster bot("token");
+	dpp::cluster bot{"token"};
 
 	bot.on_log(dpp::utility::cout_logger());
 
@@ -60,4 +60,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+
+	return 0;
 }

--- a/docpages/example_code/coro_simple_commands2.cpp
+++ b/docpages/example_code/coro_simple_commands2.cpp
@@ -1,7 +1,7 @@
 #include <dpp/dpp.h>
 
 int main() {
-	dpp::cluster bot("token");
+	dpp::cluster bot{"token"};
 
 	bot.on_log(dpp::utility::cout_logger());
 
@@ -80,4 +80,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+
+	return 0;
 }

--- a/docpages/example_code/detecting_messages.cpp
+++ b/docpages/example_code/detecting_messages.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot, but with our intents so we can use messages. */
 	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
 
@@ -9,7 +8,6 @@ int main()
 
 	/* The event is fired when the bot detects a message in any server and any channel it has access to. */
 	bot.on_message_create([&bot](const dpp::message_create_t& event) {
-
 		/* See if the message contains the phrase we want to check for.
 		 * If there's at least a single match, we reply and say it's not allowed.
 		 */

--- a/docpages/example_code/editing_messages.cpp
+++ b/docpages/example_code/editing_messages.cpp
@@ -1,73 +1,77 @@
 #include <dpp/dpp.h>
 
 int main() {
-    dpp::cluster bot("Token", dpp::i_default_intents | dpp::i_message_content);
-    /* the second argument is a bitmask of intents - i_message_content is needed to get messages */
+	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
+	/* the second argument is a bitmask of intents - i_message_content is needed to get messages */
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* The event is fired when someone issues your commands */
-    bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
-        if (event.command.get_command_name() == "msg-send") {
-            event.reply("That's a message");
-        } else if (event.command.get_command_name() == "msg-edit") {
-            const auto content = std::get<std::string>(event.get_parameter("content"));
+	/* The event is fired when someone issues your commands */
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+		if (event.command.get_command_name() == "msg-send") {
+			event.reply("That's a message");
+		} else if (event.command.get_command_name() == "msg-edit") {
+			const auto content = std::get<std::string>(event.get_parameter("content"));
 
-            /* get message to edit it after */
-            const dpp::snowflake msg_id = std::get<std::string>(event.get_parameter("msg-id"));
-            /* here string will automatically be converted to snowflake */
+			/* get message to edit it after */
+			const dpp::snowflake msg_id = std::get<std::string>(event.get_parameter("msg-id"));
+			/* here string will automatically be converted to snowflake */
 
-            bot.message_get(msg_id, event.command.channel_id, [&bot, content, event](const dpp::confirmation_callback_t& callback) {
-                if (callback.is_error()) {
-                    event.reply("error");
-                    return;
-                }
-                auto message = callback.get<dpp::message>();
+			bot.message_get(msg_id, event.command.channel_id, [&bot, content, event](const dpp::confirmation_callback_t& callback) {
+				if (callback.is_error()) {
+					event.reply("error");
+					return;
+				}
+				auto message = callback.get<dpp::message>();
 
-                /* change the message content and edit the message itself */
-                message.set_content(content);
-                bot.message_edit(message);
-                event.reply("Message content is now `" + content + "`.");
-            });
-        } else if (event.command.get_command_name() == "channel-edit") {
-            const auto name = std::get<std::string>(event.get_parameter("name"));
+				/* change the message content and edit the message itself */
+				message.set_content(content);
+				bot.message_edit(message);
 
-            /* get the channel to edit it after */
-            const auto channel_id = std::get<dpp::snowflake>(event.get_parameter("channel"));
-            bot.channel_get(channel_id, [&bot, name, event](const dpp::confirmation_callback_t& callback) {
-                if (callback.is_error()) {
-                    event.reply("error");
-                    return;
-                }
-                auto channel = callback.get<dpp::channel>();
+				event.reply("Message content is now `" + content + "`.");
+			});
+		} else if (event.command.get_command_name() == "channel-edit") {
+			const auto name = std::get<std::string>(event.get_parameter("name"));
 
-                /* change the channel name and edit the channel itself */
-                channel.set_name(name);
-                bot.channel_edit(channel);
-                event.reply("Channel name is now `" + name + "`.");
-            });
-        }
-    });
+			/* get the channel to edit it after */
+			const auto channel_id = std::get<dpp::snowflake>(event.get_parameter("channel"));
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
+			bot.channel_get(channel_id, [&bot, name, event](const dpp::confirmation_callback_t& callback) {
+				if (callback.is_error()) {
+					event.reply("error");
+					return;
+				}
+				auto channel = callback.get<dpp::channel>();
 
-        if (dpp::run_once <struct register_global_commands>()) {
-            dpp::slashcommand msg_edit("msg-edit", "Edit a message sent by the bot", bot.me.id);
+				/* change the channel name and edit the channel itself */
+				channel.set_name(name);
+				bot.channel_edit(channel);
 
-            msg_edit.add_option(dpp::command_option(dpp::co_string, "msg-id", "ID of the message to edit", true)); /* true for required option */
-            msg_edit.add_option(dpp::command_option(dpp::co_string, "content", "New content for the message", true)); /* same here */
+				event.reply("Channel name is now `" + name + "`.");
+			});
+		}
+	});
 
-            dpp::slashcommand channel_edit("channel-edit", "Edit the name of channel specified", bot.me.id);
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 
-            channel_edit.add_option(dpp::command_option(dpp::co_channel, "channel", "Channel to edit", true));
-            channel_edit.add_option(dpp::command_option(dpp::co_string, "name", "New name for the channel", true));
+		if (dpp::run_once <struct register_global_commands>()) {
+			dpp::slashcommand msg_edit("msg-edit", "Edit a message sent by the bot", bot.me.id);
 
-            dpp::slashcommand msg_send("msg-send", "Send my message", bot.me.id);
+			msg_edit.add_option(dpp::command_option(dpp::co_string, "msg-id", "ID of the message to edit", true)); /* true for required option */
+			msg_edit.add_option(dpp::command_option(dpp::co_string, "content", "New content for the message", true)); /* same here */
 
-            bot.global_bulk_command_create({ msg_edit, channel_edit, msg_send });
-        }
-    });
+			dpp::slashcommand channel_edit("channel-edit", "Edit the name of channel specified", bot.me.id);
 
-    bot.start(dpp::st_wait);
-    return 0;
+			channel_edit.add_option(dpp::command_option(dpp::co_channel, "channel", "Channel to edit", true));
+			channel_edit.add_option(dpp::command_option(dpp::co_string, "name", "New name for the channel", true));
+
+			dpp::slashcommand msg_send("msg-send", "Send my message", bot.me.id);
+
+			bot.global_bulk_command_create({ msg_edit, channel_edit, msg_send });
+		}
+	});
+
+	bot.start(dpp::st_wait);
+	
+	return 0;
 }

--- a/docpages/example_code/embeds.cpp
+++ b/docpages/example_code/embeds.cpp
@@ -1,39 +1,42 @@
 #include <dpp/dpp.h>
 
 int main() {
-    /* Setup the bot */
-    dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
+	/* Setup the bot */
+	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
 
-    /* The event is fired when someone issues your commands */
+	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "embed") {
-
-            /* Create an embed */
-            dpp::embed embed = dpp::embed().
-                set_color(dpp::colors::sti_blue).
-                set_title("Some name").
-                set_url("https://dpp.dev/").
-                set_author("Some name", "https://dpp.dev/", "https://dpp.dev/DPP-Logo.png").
-                set_description("Some description here").
-                set_thumbnail("https://dpp.dev/DPP-Logo.png").
-                add_field(
-                        "Regular field title",
-                        "Some value here"
-                ).
-                add_field(
-                        "Inline field title",
-                        "Some value here",
-                        true
-                ).
-                add_field(
-                        "Inline field title",
-                        "Some value here",
-                        true
-                ).
-                set_image("https://dpp.dev/DPP-Logo.png").
-                set_footer(dpp::embed_footer().set_text("Some footer text here").set_icon("https://dpp.dev/DPP-Logo.png")).
-                set_timestamp(time(0));
+			/* Create an embed */
+			dpp::embed embed = dpp::embed()
+				.set_color(dpp::colors::sti_blue)
+				.set_title("Some name")
+				.set_url("https://dpp.dev/")
+				.set_author("Some name", "https://dpp.dev/", "https://dpp.dev/DPP-Logo.png")
+				.set_description("Some description here")
+				.set_thumbnail("https://dpp.dev/DPP-Logo.png")
+				.add_field(
+					"Regular field title",
+					"Some value here"
+				)
+				.add_field(
+					"Inline field title",
+					"Some value here",
+					true
+				)
+				.add_field(
+					"Inline field title",
+					"Some value here",
+					true
+				)
+				.set_image("https://dpp.dev/DPP-Logo.png")
+				.set_footer(
+					dpp::embed_footer()
+					.set_text("Some footer text here")
+					.set_icon("https://dpp.dev/DPP-Logo.png")
+				)
+				.set_timestamp(time(0));
 
 			/* Create a message with the content as our new embed. */
 			dpp::message msg(event.command.channel_id, embed);
@@ -43,14 +46,14 @@ int main() {
 		}
 	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("embed", "Send a test embed!", bot.me.id));
+		}
+	});
 
-            /* Create and register a command when the bot is ready */
-            bot.global_command_create(dpp::slashcommand("embed", "Send a test embed!", bot.me.id));
-        }
-    });
+	bot.start(dpp::st_wait);
 
-    bot.start(dpp::st_wait);
-    return 0;
+	return 0;
 }

--- a/docpages/example_code/ephemeral.cpp
+++ b/docpages/example_code/ephemeral.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 
@@ -9,10 +8,8 @@ int main()
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "hello") {
-
 			/* Reply to the user, but only let them see the response. */
 			event.reply(dpp::message("Hello! How are you today?").set_flags(dpp::m_ephemeral));
 		}
@@ -20,7 +17,6 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create and Register the command */
 			bot.global_command_create(dpp::slashcommand("hello", "Hello there!", bot.me.id));
 		}

--- a/docpages/example_code/eval.cpp
+++ b/docpages/example_code/eval.cpp
@@ -25,8 +25,7 @@ int test_function() {
  * Note for OSX you'll probably have to change all references
  * from .so to .dylib.
  */
-int main()
-{
+int main() {
 	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
 
         bot.on_log(dpp::utility::cout_logger());
@@ -60,7 +59,7 @@ int main()
 				#include <unordered_map>\n\
 				#include <stdint.h>\n\
 				#include <dpp/dpp.h>\n\
-				#include <nlohmann/json.hpp>\n\
+				#include <dpp/nlohmann/json.hpp>\n\
 				#include <fmt/format.h>\n\
 				#include \"eval.h\"\n\
 				extern \"C\" void so_exec(dpp::cluster& bot, dpp::message_create_t event) {\n\
@@ -171,5 +170,6 @@ int main()
 	});
 
 	bot.start(dpp::st_wait);
+	
 	return 0;
 }

--- a/docpages/example_code/firstbot.cpp
+++ b/docpages/example_code/firstbot.cpp
@@ -1,25 +1,23 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    bot.on_slashcommand([](const dpp::slashcommand_t& event) {
-         if (event.command.get_command_name() == "ping") {
-            event.reply("Pong!");
-        }
-    });
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+		if (event.command.get_command_name() == "ping") {
+			event.reply("Pong!");
+		}
+	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
-            bot.global_command_create(
-                dpp::slashcommand("ping", "Ping pong!", bot.me.id)
-            );
-        }
-    });
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
+		}
+	});
 
-    bot.start(dpp::st_wait);
+	bot.start(dpp::st_wait);
 }

--- a/docpages/example_code/firstbot2.cpp
+++ b/docpages/example_code/firstbot2.cpp
@@ -1,7 +1,7 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 }

--- a/docpages/example_code/firstbot3.cpp
+++ b/docpages/example_code/firstbot3.cpp
@@ -1,13 +1,13 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
-            bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
-        }
-    });
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
+		}
+	});
 }

--- a/docpages/example_code/firstbot4.cpp
+++ b/docpages/example_code/firstbot4.cpp
@@ -1,16 +1,16 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 
-    bot.on_slashcommand([](const dpp::slashcommand_t& event) {
-    });
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
-            bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
-        }
-    });
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
+		}
+	});
 }

--- a/docpages/example_code/firstbot5.cpp
+++ b/docpages/example_code/firstbot5.cpp
@@ -1,20 +1,19 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 
-    bot.on_slashcommand([](const dpp::slashcommand_t& event) {
-         if (event.command.get_command_name() == "ping") {
-            event.reply("Pong!");
-        }
-    });
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+		if (event.command.get_command_name() == "ping") {
+			event.reply("Pong!");
+		}
+	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
-            bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
-        }
-    });
-
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
+		}
+	});
 }

--- a/docpages/example_code/firstbot6.cpp
+++ b/docpages/example_code/firstbot6.cpp
@@ -1,23 +1,23 @@
 #include <dpp/dpp.h>
 
-const std::string    BOT_TOKEN    = "add your token here";
+const std::string BOT_TOKEN = "add your token here";
 
 int main() {
-    dpp::cluster bot(BOT_TOKEN);
+	dpp::cluster bot(BOT_TOKEN);
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    bot.on_slashcommand([](const dpp::slashcommand_t& event) {
-         if (event.command.get_command_name() == "ping") {
-            event.reply("Pong!");
-        }
-    });
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+		if (event.command.get_command_name() == "ping") {
+			event.reply("Pong!");
+		}
+	});
 
-    bot.on_ready([&bot](const dpp::ready_t& event) {
-        if (dpp::run_once<struct register_bot_commands>()) {
-            bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
-        }
-    });
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
+		}
+	});
 
-    bot.start(dpp::st_wait);
+	bot.start(dpp::st_wait);
 }

--- a/docpages/example_code/http_request.cpp
+++ b/docpages/example_code/http_request.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 int main() {
-	dpp::cluster bot("TOKEN GOES HERE");
+	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
@@ -25,4 +25,6 @@ int main() {
 	});
 
 	bot.start(dpp::st_wait);
+
+	return 0;
 }

--- a/docpages/example_code/join_voice.cpp
+++ b/docpages/example_code/join_voice.cpp
@@ -2,12 +2,11 @@
 #include <iomanip>
 #include <sstream>
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	/* Setup the bot */
 	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
@@ -74,7 +73,6 @@ int main(int argc, char const *argv[])
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			bot.global_command_create(dpp::slashcommand("join", "Joins your voice channel.", bot.me.id));
 		}

--- a/docpages/example_code/making_threads1.cpp
+++ b/docpages/example_code/making_threads1.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 

--- a/docpages/example_code/making_threads2.cpp
+++ b/docpages/example_code/making_threads2.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 

--- a/docpages/example_code/making_threads3.cpp
+++ b/docpages/example_code/making_threads3.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 	 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 	

--- a/docpages/example_code/modal_dialog_interactions.cpp
+++ b/docpages/example_code/modal_dialog_interactions.cpp
@@ -1,8 +1,7 @@
 #include <dpp/dpp.h>
 #include <iostream>
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
@@ -10,33 +9,32 @@ int main(int argc, char const *argv[])
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check for our /dialog command */
 		if (event.command.get_command_name() == "dialog") {
-
 			/* Instantiate an interaction_modal_response object */
 			dpp::interaction_modal_response modal("my_modal", "Please enter stuff");
 
 			/* Add a text component */
 			modal.add_component(
-				dpp::component().
-				set_label("Short type rammel").
-				set_id("field_id").
-				set_type(dpp::cot_text).
-				set_placeholder("gumd").
-				set_min_length(5).
-				set_max_length(50).
-				set_text_style(dpp::text_short)
+				dpp::component()
+					.set_label("Short type rammel")
+					.set_id("field_id")
+					.set_type(dpp::cot_text)
+					.set_placeholder("gumd")
+					.set_min_length(5)
+					.set_max_length(50)
+					.set_text_style(dpp::text_short)
 			);
 
 			/* Add another text component in the next row, as required by Discord */
 			modal.add_row();
 			modal.add_component(
-				dpp::component().
-				set_label("Type rammel").
-				set_id("field_id2").
-				set_type(dpp::cot_text).
-				set_placeholder("gumf").
-				set_min_length(1).
-				set_max_length(2000).
-				set_text_style(dpp::text_paragraph)
+				dpp::component()
+					.set_label("Type rammel")
+					.set_id("field_id2")
+					.set_type(dpp::cot_text)
+					.set_placeholder("gumf")
+					.set_min_length(1)
+					.set_max_length(2000)
+					.set_text_style(dpp::text_paragraph)
 			);
 
 			/* Trigger the dialog box. All dialog boxes are ephemeral */
@@ -46,7 +44,6 @@ int main(int argc, char const *argv[])
 
 	/* This event handles form submission for the modal dialog we create above */
 	bot.on_form_submit([](const dpp::form_submit_t & event) {
-		
 		/* For this simple example, we know the first element of the first row ([0][0]) is value type string.
 		 * In the real world, it may not be safe to make such assumptions!
 		 */
@@ -67,7 +64,7 @@ int main(int argc, char const *argv[])
 	});
 
 	/* Start bot */
-
 	bot.start(dpp::st_wait);
+
 	return 0;
 }

--- a/docpages/example_code/mp3.cpp
+++ b/docpages/example_code/mp3.cpp
@@ -12,8 +12,7 @@
 /* For an example we will hardcode a path to some awesome music here */
 #define MUSIC_FILE "/media/music/Rick Astley/Whenever You Need Somebody/Never Gonna Give You Up.mp3"
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	/* This will hold the decoded MP3.
 	* The D++ library expects PCM format, which are raw sound
 	* data, 2 channel stereo, 16 bit signed 48000Hz.
@@ -62,10 +61,8 @@ int main(int argc, char const *argv[])
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot, &pcmdata](const dpp::slashcommand_t& event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {
-
 			/* Get the guild */
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
@@ -78,7 +75,6 @@ int main(int argc, char const *argv[])
 			/* Tell the user we joined their channel. */
 			event.reply("Joined your channel!");
 		} else if (event.command.get_command_name() == "mp3") {
-
 			/* Get the voice channel the bot is in, in this current guild. */
 			dpp::voiceconn* v = event.from->get_voice(event.command.guild_id);
 
@@ -97,13 +93,11 @@ int main(int argc, char const *argv[])
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);
-
 			dpp::slashcommand mp3command("mp3", "Plays an mp3 file.", bot.me.id);
 
-			bot.global_bulk_command_create({joincommand, mp3command});
+			bot.global_bulk_command_create({ joincommand, mp3command });
 		}
 	});
 

--- a/docpages/example_code/oggopus.cpp
+++ b/docpages/example_code/oggopus.cpp
@@ -7,8 +7,7 @@
 #include <string.h>
 #include <oggz/oggz.h>
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	/* Load an ogg opus file into memory.
 	 * The bot expects opus packets to be 2 channel stereo, 48000Hz.
 	 * 
@@ -19,14 +18,13 @@ int main(int argc, char const *argv[])
 	/* Setup the bot */
 	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {
-
 			/* Get the guild */
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
@@ -39,7 +37,6 @@ int main(int argc, char const *argv[])
 			/* Tell the user we joined their channel. */
 			event.reply("Joined your channel!");
 		} else if (event.command.get_command_name() == "play") {
-
 			/* Get the voice channel the bot is in, in this current guild. */
 			dpp::voiceconn* v = event.from->get_voice(event.command.guild_id);
 
@@ -101,13 +98,11 @@ int main(int argc, char const *argv[])
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);
-
 			dpp::slashcommand playcommand("play", "Plays an ogg file.", bot.me.id);
 
-			bot.global_bulk_command_create({joincommand, playcommand});
+			bot.global_bulk_command_create({ joincommand, playcommand });
 		}
 	});
 	

--- a/docpages/example_code/private_messaging.cpp
+++ b/docpages/example_code/private_messaging.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 
@@ -9,10 +8,8 @@ int main()
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "pm") {
-
 			dpp::snowflake user;
 
 			/* If there was no specified user, we set the "user" variable to the command author (issuing user). */
@@ -48,7 +45,6 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Register the command */
 			dpp::slashcommand command("pm", "Send a private message.", bot.me.id);
 

--- a/docpages/example_code/record_user.cpp
+++ b/docpages/example_code/record_user.cpp
@@ -2,8 +2,7 @@
 #include <iomanip>
 #include <sstream>
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	/* Example to record a user in a VC
 	* 
 	* Recording is output as './me.pcm' and you can play it via the soundboard example
@@ -19,14 +18,12 @@ int main(int argc, char const *argv[])
 	FILE *fd;
 	fd = fopen("./me.pcm", "wb");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot, &fd](const dpp::slashcommand_t& event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "record") {
-
 			/* Get the guild */
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
@@ -39,7 +36,6 @@ int main(int argc, char const *argv[])
 			/* Tell the user we joined their channel. */
 			event.reply("Joined your channel, now recording!");
 		} else if (event.command.get_command_name() == "stop") {
-
 			event.from->disconnect_voice(event.command.guild_id);
 			fclose(fd);
 
@@ -55,13 +51,11 @@ int main(int argc, char const *argv[])
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			dpp::slashcommand recordcommand("record", "Joins your voice channel and records you.", bot.me.id);
-
 			dpp::slashcommand stopcommand("stop", "Stops recording you.", bot.me.id);
 
-			bot.global_bulk_command_create({recordcommand, stopcommand});
+			bot.global_bulk_command_create({ recordcommand, stopcommand });
 		}
 	});
 

--- a/docpages/example_code/resolved_objects.cpp
+++ b/docpages/example_code/resolved_objects.cpp
@@ -7,35 +7,32 @@ int main() {
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+		/* Check which command they ran */
+		if (event.command.get_command_name() == "addrole") {
+			/* Fetch a parameter value from the command options */
+			dpp::snowflake user_id = std::get<dpp::snowflake>(event.get_parameter("user"));
+			dpp::snowflake role_id = std::get<dpp::snowflake>(event.get_parameter("role"));
 
-	/* Check which command they ran */
-	if (event.command.get_command_name() == "addrole") {
+			/* Get member object from resolved list */
+			dpp::guild_member resolved_member = event.command.get_resolved_member(user_id);
 
-		/* Fetch a parameter value from the command options */
-		dpp::snowflake user_id = std::get<dpp::snowflake>(event.get_parameter("user"));
-		dpp::snowflake role_id = std::get<dpp::snowflake>(event.get_parameter("role"));
+			resolved_member.add_role(role_id);
+			bot.guild_edit_member(resolved_member);
 
-		/* Get member object from resolved list */
-		dpp::guild_member resolved_member = event.command.get_resolved_member(user_id);
-
-		resolved_member.add_role(role_id);
-		bot.guild_edit_member(resolved_member);
-
-		event.reply("Added role");
+			event.reply("Added role");
 		}
 	});
 
 	/* Attach on_ready event */
 	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
+			dpp::slashcommand add_role("addrole", "Give user a role", bot.me.id);
 
-		dpp::slashcommand add_role("addrole", "Give user a role", bot.me.id);
+			/* Add user and role type command options to the slash command */
+			add_role.add_option(dpp::command_option(dpp::co_user, "user", "User to give role to", true));
+			add_role.add_option(dpp::command_option(dpp::co_role, "role", "Role to give", true));
 
-		/* Add user and role type command options to the slash command */
-		add_role.add_option(dpp::command_option(dpp::co_user, "user", "User to give role to", true));
-		add_role.add_option(dpp::command_option(dpp::co_role, "role", "Role to give", true));
-
-		bot.global_command_create(add_role);
+			bot.global_command_create(add_role);
 		}
 	});
 

--- a/docpages/example_code/setting_status1.cpp
+++ b/docpages/example_code/setting_status1.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 

--- a/docpages/example_code/setting_status2.cpp
+++ b/docpages/example_code/setting_status2.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	/* Create the bot */
 	dpp::cluster bot("token");
 

--- a/docpages/example_code/slashcommands1.cpp
+++ b/docpages/example_code/slashcommands1.cpp
@@ -1,17 +1,14 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
-
 			/* Fetch a parameter value from the command parameters */
 			std::string animal = std::get<std::string>(event.get_parameter("animal"));
 
@@ -24,16 +21,13 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new global command on ready event */
 			dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);
 			newcommand.add_option(
-					dpp::command_option(dpp::co_string, "animal", "The type of animal", true).
-						add_choice(dpp::command_option_choice("Dog", std::string("animal_dog"))).
-						add_choice(dpp::command_option_choice("Cat", std::string("animal_cat"))).
-						add_choice(dpp::command_option_choice("Penguin", std::string("animal_penguin")
-					)
-				)
+				dpp::command_option(dpp::co_string, "animal", "The type of animal", true)
+					.add_choice(dpp::command_option_choice("Dog", std::string("animal_dog")))
+					.add_choice(dpp::command_option_choice("Cat", std::string("animal_cat")))
+					.add_choice(dpp::command_option_choice("Penguin", std::string("animal_penguin")))
 			);
 
 			/* Register the command */

--- a/docpages/example_code/slashcommands2.cpp
+++ b/docpages/example_code/slashcommands2.cpp
@@ -1,17 +1,14 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
-
 			/* Fetch a parameter value from the command parameters */
 			std::string animal = std::get<std::string>(event.get_parameter("animal"));
 
@@ -24,16 +21,13 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new global command on ready event */
 			dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);
 			newcommand.add_option(
-					dpp::command_option(dpp::co_string, "animal", "The type of animal", true).
-						add_choice(dpp::command_option_choice("Dog", std::string("animal_dog"))).
-						add_choice(dpp::command_option_choice("Cat", std::string("animal_cat"))).
-						add_choice(dpp::command_option_choice("Penguin", std::string("animal_penguin")
-					)
-				)
+				dpp::command_option(dpp::co_string, "animal", "The type of animal", true).
+					.add_choice(dpp::command_option_choice("Dog", std::string("animal_dog")))
+					.add_choice(dpp::command_option_choice("Cat", std::string("animal_cat")))
+					.add_choice(dpp::command_option_choice("Penguin", std::string("animal_penguin")))
 			);
 
 			/* Register the command */

--- a/docpages/example_code/slashcommands2.cpp
+++ b/docpages/example_code/slashcommands2.cpp
@@ -24,7 +24,7 @@ int main() {
 			/* Create a new global command on ready event */
 			dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);
 			newcommand.add_option(
-				dpp::command_option(dpp::co_string, "animal", "The type of animal", true).
+				dpp::command_option(dpp::co_string, "animal", "The type of animal", true)
 					.add_choice(dpp::command_option_choice("Dog", std::string("animal_dog")))
 					.add_choice(dpp::command_option_choice("Cat", std::string("animal_cat")))
 					.add_choice(dpp::command_option_choice("Penguin", std::string("animal_penguin")))

--- a/docpages/example_code/slashcommands3.cpp
+++ b/docpages/example_code/slashcommands3.cpp
@@ -1,14 +1,12 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");
@@ -23,7 +21,6 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create some commands */
 			dpp::slashcommand pingcommand("ping", "Pong!", bot.me.id);
 			dpp::slashcommand pongcommand("pong", "Ping!", bot.me.id);

--- a/docpages/example_code/slashcommands4.cpp
+++ b/docpages/example_code/slashcommands4.cpp
@@ -1,14 +1,12 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");
@@ -23,7 +21,6 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create some commands */
 			dpp::slashcommand pingcommand("ping", "Pong!", bot.me.id);
 			dpp::slashcommand pongcommand("pong", "Ping!", bot.me.id);
@@ -32,7 +29,6 @@ int main()
 
 			/* Register our commands in a list using bulk */
 			bot.guild_bulk_command_create({ pingcommand, pongcommand, dingcommand, dongcommand }, 857692897221033129);
-			
 		}
 	});
 

--- a/docpages/example_code/soundboard.cpp
+++ b/docpages/example_code/soundboard.cpp
@@ -2,8 +2,7 @@
 #include <iomanip>
 #include <sstream>
 
-int main(int argc, char const *argv[])
-{
+int main() {
 	/* Load a sound file called Robot.pcm into memory.
 	 * The bot expects PCM format, which are raw sound data,
 	 * 2 channel stereo, 16 bit signed 48000Hz.
@@ -29,14 +28,12 @@ int main(int argc, char const *argv[])
 	/* Setup the bot */
 	dpp::cluster bot("token");
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot, robot, robot_size](const dpp::slashcommand_t& event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {
-
 			/* Get the guild */
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
@@ -49,7 +46,6 @@ int main(int argc, char const *argv[])
 			/* Tell the user we joined their channel. */
 			event.reply("Joined your channel!");
 		} else if (event.command.get_command_name() == "robot") {
-
 			/* Get the voice channel the bot is in, in this current guild. */
 			dpp::voiceconn* v = event.from->get_voice(event.command.guild_id);
 
@@ -68,13 +64,12 @@ int main(int argc, char const *argv[])
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);
 
 			dpp::slashcommand robotcommand("robot", "Plays a robot noise in your voice channel.", bot.me.id);
 
-			bot.global_bulk_command_create({joincommand, robotcommand});
+			bot.global_bulk_command_create({ joincommand, robotcommand });
 		}
 	});
 

--- a/docpages/example_code/subcommands.cpp
+++ b/docpages/example_code/subcommands.cpp
@@ -2,10 +2,42 @@
 #include <iostream>
 
 int main() {
-
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
+
+	/* Use the on_slashcommand event to look for commands */
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+		dpp::command_interaction cmd_data = event.command.get_command_interaction();
+
+		/* Check if the command is the image command. */
+		if (event.command.get_command_name() == "image") {
+			/* Get the sub command */
+			auto subcommand = cmd_data.options[0];
+			/* Check if the subcommand is "dog" */
+			if (subcommand.name == "dog") {	
+				/* Checks if the subcommand has any options. */
+				if (!subcommand.options.empty()) {
+					/* Get the user from the parameter */
+					dpp::user user = event.command.get_resolved_user(subcommand.get_value<dpp::snowflake>(0));
+					event.reply(user.get_mention() + " has now been turned into a dog."); 
+				} else {
+					/* Reply if there were no options.. */
+					event.reply("No user specified");
+				}
+			} else if (subcommand.name == "cat") { /* Check if the subcommand is "cat". */
+				/* Checks if the subcommand has any options. */
+				if (!subcommand.options.empty()) {
+					/* Get the user from the parameter */
+					dpp::user user = event.command.get_resolved_user(subcommand.get_value<dpp::snowflake>(0));
+					event.reply(user.get_mention() + " has now been turned into a cat."); 
+				} else {
+					/* Reply if there were no options.. */
+					event.reply("No user specified");
+				}
+			}
+		}
+	});
 
 	/* Executes on ready. */
 	bot.on_ready([&bot](const dpp::ready_t & event) {
@@ -22,47 +54,9 @@ int main() {
 				dpp::command_option(dpp::co_sub_command, "cat", "Send a picture of a cat.")
 					.add_option(dpp::command_option(dpp::co_user, "user", "User to turn into a cat.", false))
 			);
+
 			/* Create command */
 			bot.global_command_create(image);
-		}
-	});
-
-	/* Use the on_slashcommand event to look for commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
-		dpp::interaction interaction = event.command;
-		dpp::command_interaction cmd_data = interaction.get_command_interaction();
-		/* Check if the command is the image command. */
-		if (interaction.get_command_name() == "image") {
-			/* Get the sub command */
-			auto subcommand = cmd_data.options[0];
-			/* Check if the subcommand is "dog" */
-			if (subcommand.name == "dog") {	
-				/* Checks if the subcommand has any options. */
-				if (!subcommand.options.empty()) {
-					/* Get the user from the parameter */
-					dpp::user user = interaction.get_resolved_user(
-						subcommand.get_value<dpp::snowflake>(0)
-					);
-					event.reply(user.get_mention() + " has now been turned into a dog."); 
-				} else {
-					/* Reply if there were no options.. */
-					event.reply("No user specified");
-				}
-			}
-			/* Check if the subcommand is "cat" */
-			if (subcommand.name == "cat") {
-				/* Checks if the subcommand has any options. */
-				if (!subcommand.options.empty()) {
-					/* Get the user from the parameter */
-					dpp::user user = interaction.get_resolved_user(
-						subcommand.get_value<dpp::snowflake>(0)
-					);
-					event.reply(user.get_mention() + " has now been turned into a cat."); 
-				} else {
-					/* Reply if there were no options.. */
-					event.reply("No user specified");
-				}
-			}
 		}
 	});
 

--- a/docpages/example_code/upload_parameter.cpp
+++ b/docpages/example_code/upload_parameter.cpp
@@ -1,17 +1,14 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
-
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "show") {
-
 			/* Get the file id from the parameter attachment. */
 			dpp::snowflake file_id = std::get<dpp::snowflake>(event.get_parameter("file"));
 
@@ -25,7 +22,6 @@ int main()
 
 	bot.on_ready([&bot](const dpp::ready_t & event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
-
 			/* Create a new command. */
 			dpp::slashcommand newcommand("show", "Show an uploaded file", bot.me.id);
 

--- a/docpages/example_code/using_cache.cpp
+++ b/docpages/example_code/using_cache.cpp
@@ -1,26 +1,26 @@
 #include <dpp/dpp.h>
 
 int main() {
-    /* Create bot */
-    dpp::cluster bot("token", dpp::i_default_intents | dpp::i_guild_members);
+	/* Create bot */
+	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_guild_members);
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* This event is fired when someone removes their reaction from a message*/
-    bot.on_message_reaction_remove([&bot](const dpp::message_reaction_remove_t& event) {
+	/* This event is fired when someone removes their reaction from a message */
+	bot.on_message_reaction_remove([&bot](const dpp::message_reaction_remove_t& event) {
+		/* Find the user in the cache using his discord id */
+		dpp::user* reacting_user = dpp::find_user(event.reacting_user_id);
 
-        /* Find the user in the cache using his discord id */
-        dpp::user* reacting_user = dpp::find_user(event.reacting_user_id);
+		/* If user not found in cache, log and return */
+		if (!reacting_user) {
+			bot.log(dpp::ll_info, "User with the id " + std::to_string(event.reacting_user_id) + " was not found.");
+			return;
+		}
 
-        /* If user not found in cache, log and return */
-        if (!reacting_user) {
-            bot.log(dpp::ll_info, "User with the id " + std::to_string(event.reacting_user_id) + " was not found.");
-            return;
-        }
+		bot.log(dpp::ll_info, reacting_user->format_username() + " removed his reaction.");
+	});
 
-        bot.log(dpp::ll_info, reacting_user->format_username() + " removed his reaction.");
-    });
+	bot.start(dpp::st_wait);
 
-    bot.start(dpp::st_wait);
-    return 0;
+	return 0;
 }

--- a/docpages/example_code/webhooks.cpp
+++ b/docpages/example_code/webhooks.cpp
@@ -2,15 +2,15 @@
 
 int main()
 {
-    dpp::cluster bot(""); // normally, you put your bot token in here. But to just run a webhook its not required
+	dpp::cluster bot(""); /* Normally, you put your bot token in here, but its not required for webhooks. */
 
-    bot.on_log(dpp::utility::cout_logger());
+	bot.on_log(dpp::utility::cout_logger());
 
-    /* construct a webhook object using the URL you got from Discord */
-    dpp::webhook wh("https://discord.com/api/webhooks/833047646548133537/ntCHEYYIoHSLy_GOxPx6pmM0sUoLbP101ct-WI6F-S4beAV2vaIcl_Id5loAMyQwxqhE");
+	/* Construct a webhook object using the URL you got from Discord */
+	dpp::webhook wh("https://discord.com/api/webhooks/833047646548133537/ntCHEYYIoHSLy_GOxPx6pmM0sUoLbP101ct-WI6F-S4beAV2vaIcl_Id5loAMyQwxqhE");
 
-    /* send a message with this webhook */
-    bot.execute_webhook_sync(wh, dpp::message("Have a great time here :smile:"));
+	/* Send a message with this webhook */
+	bot.execute_webhook_sync(wh, dpp::message("Have a great time here :smile:"));
 
-    return 0;
+	return 0;
 }


### PR DESCRIPTION
This PR refactors all the code examples in `docpages/example_code/` to comply with our code standards. It's a big PR as I wanted to ship it all as one, breaking it into smaller pieces would have taken longer to get out.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
