### PR TITLE
fix: make snowflake formattable again

### DIFF
--- a/include/dpp/snowflake.h
+++ b/include/dpp/snowflake.h
@@ -251,6 +251,18 @@ public:
 	constexpr uint16_t get_increment() const noexcept {
 		return static_cast<uint16_t>(value & 0xFFF);
 	}
+
+	/**
+	 * @brief Helper function for libfmt so that a snowflake can be directly formatted as a uint64_t.
+	 *
+	 * @see https://fmt.dev/latest/api.html#formatting-user-defined-types
+	 * @return uint64_t snowflake ID
+	 */
+	friend constexpr uint64_t format_as(snowflake s) noexcept {
+		/* note: this function must stay as "friend" - this declares it as a free function but makes it invisible unless the argument is snowflake
+		 * this effectively means no implicit conversions are performed to snowflake, for example format_as(0) doesn't call this function */
+		return s.value;
+	}
 };
 
 } // namespace dpp


### PR DESCRIPTION
Updating libfmt to v10 for my bot broke `fmt::format("{}", dpp::snowflake{})`, this makes it work again

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
