### PR TITLE
fix: dont require guild cache to fill member roles in message

### DIFF
--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1053,7 +1053,7 @@ message& message::fill_from_json(json* d, cache_policy_t cp) {
 	/* Fill in member record, cache uncached ones */
 	guild* g = find_guild(this->guild_id);
 	this->member = {};
-	if (g && d->find("member") != d->end()) {
+	if (guild_id && d->find("member") != d->end()) {
 		json& mi = (*d)["member"];
 		snowflake uid = snowflake_not_null(&(mi["user"]), "id");
 		if (!uid && author.id) {
@@ -1061,14 +1061,14 @@ message& message::fill_from_json(json* d, cache_policy_t cp) {
 		}
 		if (cp.user_policy == dpp::cp_none) {
 			/* User caching off! Just fill in directly but dont store member to guild */
-			this->member.fill_from_json(&mi, g->id, uid);
-		} else {
+			this->member.fill_from_json(&mi, this->guild_id, uid);
+		} else if (g) {
 			/* User caching on, lazy or aggressive - cache the member information */
 			auto thismember = g->members.find(uid);
 			if (thismember == g->members.end()) {
 				if (!uid.empty() && author.id) {
 					guild_member gm;
-					gm.fill_from_json(&mi, g->id, uid);
+					gm.fill_from_json(&mi, this->guild_id, uid);
 					g->members[author.id] = gm;
 					this->member = gm;
 				}
@@ -1076,7 +1076,7 @@ message& message::fill_from_json(json* d, cache_policy_t cp) {
 				/* Update roles etc */
 				this->member = thismember->second;
 				if (author.id) {
-					this->member.fill_from_json(&mi, g->id, author.id);
+					this->member.fill_from_json(&mi, this->guild_id, author.id);
 					g->members[author.id] = this->member;
 				}
 			}


### PR DESCRIPTION
In the event all caches are disabled, roles list in the member for a message was empty. This was because it was internally using find_guild and skipping this part of the deserialisation. It does not need to do this. This fix ensures that if all caching is off, and we have the guild members intent, the guild member list in the messages member field will be popupated. I'm relying on this in the yeet bot.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
