### PR TITLE
feat: dpp::application is now updated, added set_iconhash_not_null

### DIFF
--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -26,6 +26,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/user.h>
+#include <dpp/guild.h>
 #include <dpp/permissions.h>
 #include <dpp/json_fwd.h>
 #include <dpp/json_interface.h>
@@ -127,27 +128,48 @@ protected:
 	application& fill_from_json_impl(nlohmann::json* j);
 
 public:
-	std::string		name;			//!< the name of the app
-	utility::iconhash	icon;			//!< the icon hash of the app (may be empty)
-	std::string		description;		//!< the description of the app
-	std::string		rpc_origins;		//!< Optional: an array of rpc origin urls, if rpc is enabled
-	bool			bot_public;		//!< when false only app owner can join the app's bot to guilds
-	bool			bot_require_code_grant;	//!< when true the app's bot will only join upon completion of the full oauth2 code grant flow
-	std::string		terms_of_service_url;	//!< Optional: the url of the app's terms of service
-	std::string		privacy_policy_url;	//!< Optional: the url of the app's privacy policy
-	user			owner;			//!< Optional: partial user object containing info on the owner of the application
-	std::string		summary;		//!< if this application is a game sold on Discord, this field will be the summary field for the store page of its primary sku @deprecated Will be removed in v11
-	std::string		verify_key;		//!< the hex encoded key for verification in interactions and the GameSDK's GetTicket
-	app_team		team;			//!< if the application belongs to a team, this will be a list of the members of that team (may be empty)
-	snowflake		guild_id;		//!< Optional: if this application is a game sold on Discord, this field will be the guild to which it has been linked
-	snowflake		primary_sku_id;		//!< Optional: if this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists
-	std::string		slug;			//!< Optional: if this application is a game sold on Discord, this field will be the URL slug that links to the store page
-	utility::iconhash	cover_image;		//!< Optional: the application's default rich presence invite cover image hash
-	uint32_t		flags;			//!< Optional: the application's public flags
-	std::vector<std::string> tags;	//!< Up to 5 tags describing the content and functionality of the application
-	application_install_params install_params;	//!< Settings for the application's default in-app authorization link, if enabled
-	std::string custom_install_url;	//!< The application's default custom authorization link, if enabled
-	std::string role_connections_verification_url; //!< The application's role connection verification entry point, which when configured will render the app as a verification method in the guild role verification configuration
+	std::string		name;				//!< the name of the app
+	utility::iconhash	icon;				//!< the icon hash of the app (may be empty)
+	std::string		description;			//!< the description of the app
+	std::vector<std::string> rpc_origins;			//!< Optional: an array of rpc origin urls, if rpc is enabled
+	bool			bot_public;			//!< when false only app owner can join the app's bot to guilds
+	bool			bot_require_code_grant;		//!< when true the app's bot will only join upon completion of the full oauth2 code grant flow
+	user			bot;				//!< Optional: Partial user object for the bot user associated with the app.
+	std::string		terms_of_service_url;		//!< Optional: the url of the app's terms of service
+	std::string		privacy_policy_url;		//!< Optional: the url of the app's privacy policy
+	user			owner;				//!< Optional: partial user object containing info on the owner of the application
+	std::string		summary;			//!< if this application is a game sold on Discord, this field will be the summary field for the store page of its primary sku @deprecated Will be removed in v11
+	std::string		verify_key;			//!< the hex encoded key for verification in interactions and the GameSDK's GetTicket
+	app_team		team;				//!< if the application belongs to a team, this will be a list of the members of that team (may be empty)
+	snowflake		guild_id;			//!< Optional: if this application is a game sold on Discord, this field will be the guild to which it has been linked
+	guild			guild_obj;			//!< Optional: Partial object of the associated guild
+	snowflake		primary_sku_id;			//!< Optional: if this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists
+	std::string		slug;				//!< Optional: if this application is a game sold on Discord, this field will be the URL slug that links to the store page
+	utility::iconhash	cover_image;			//!< Optional: the application's default rich presence invite cover image hash
+	uint32_t		flags;				//!< Optional: the application's public flags
+	uint64_t		approximate_guild_count;	//!< Optional: Approximate count of guilds the app has been added to
+	std::vector<std::string> redirect_uris;			//!< Optional: Array of redirect URIs for the app
+	std::string		interactions_endpoint_url;	//!< Optional: Interactions endpoint URL for the app
+	std::string 	role_connections_verification_url;	//!< The application's role connection verification entry point, which when configured will render the app as a verification method in the guild role verification configuration
+	std::vector<std::string> tags;				//!< Up to 5 tags describing the content and functionality of the application
+	application_install_params install_params;		//!< Settings for the application's default in-app authorization link, if enabled
+	std::string 		custom_install_url;		//!< The application's default custom authorization link, if enabled
+
+	uint8_t			discoverability_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint32_t 		discovery_eligibility_flags;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			explicit_content_filter;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			creator_monetization_state;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	bool			integration_public;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	bool			integration_require_code_grant;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	std::vector<std::string> interactions_event_types;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			interactions_version;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	bool			is_monetized;			//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint32_t		monetization_eligibility_flags;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			monetization_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	bool			hook;				//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			rpc_application_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			store_application_state;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	uint8_t			verification_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
 
 	/** Constructor */
 	application();

--- a/include/dpp/discordevents.h
+++ b/include/dpp/discordevents.h
@@ -23,6 +23,7 @@
 #include <dpp/export.h>
 #include <dpp/json_fwd.h>
 #include <dpp/json_interface.h>
+#include <dpp/utility.h>
 #include <string_view>
 #include <functional>
 
@@ -83,6 +84,13 @@ std::string DPP_EXPORT string_not_null(const nlohmann::json* j, const char *keyn
  * @param v Value to change
  */
 void DPP_EXPORT set_string_not_null(const nlohmann::json* j, const char *keyname, std::string &v);
+
+/** @brief This is a repeat of set_string_not_null, but takes in a iconhash.
+ * @param j nlohmann::json instance to retrieve value from
+ * @param keyname key name to check for a value
+ * @param v Value to change
+ */
+void DPP_EXPORT set_iconhash_not_null(const nlohmann::json* j, const char *keyname, utility::iconhash &v);
 
 /** @brief Returns a double from a json field value, if defined, else returns 0.
  * @param j nlohmann::json instance to retrieve value from

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -148,7 +148,7 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 }
 
 std::string application::get_cover_image_url(uint16_t size, const image_type format) const {
-	if (!this->cover_image.to_string().empty()) {
+	if (!this->cover_image.to_string().empty() && this->id) {
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
 	 		"app-icons/" + std::to_string(this->id) + "/" + this->cover_image.to_string(),
 			format, size);
@@ -158,7 +158,7 @@ std::string application::get_cover_image_url(uint16_t size, const image_type for
 }
 
 std::string application::get_icon_url(uint16_t size, const image_type format) const {
-	if (!this->icon.to_string().empty()) {
+	if (!this->icon.to_string().empty() && this->id) {
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
 	 		"app-icons/" + std::to_string(this->id) + "/" + this->icon.to_string(),
 		 	format, size);

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -24,6 +24,7 @@
 #include <dpp/snowflake.h>
 #include <dpp/managed.h>
 #include <dpp/json.h>
+#include <iostream>
 
 namespace dpp {
 
@@ -38,40 +39,25 @@ application::~application() = default;
 application& application::fill_from_json_impl(nlohmann::json* j) {
 	set_snowflake_not_null(j, "id", id);
 	set_string_not_null(j, "name", name);
-	std::string ic = string_not_null(j, "icon");
-	if (!ic.empty()) {
-		icon = ic;
-	}
+	set_iconhash_not_null(j, "icon", icon);
 	set_string_not_null(j, "description", description);
-	set_string_not_null(j, "rpc_origins", rpc_origins);
+
+	if (j->contains("rpc_origins")) {
+		for (const auto& rpc : (*j)["rpc_origins"]) {
+			this->rpc_origins.push_back(to_string(rpc));
+		}
+	}
+
 	set_bool_not_null(j, "bot_public", bot_public);
 	set_bool_not_null(j, "bot_require_code_grant", bot_require_code_grant);
+	bot = user().fill_from_json(&((*j)["bot"]));
 	set_string_not_null(j, "terms_of_service_url", terms_of_service_url);
 	set_string_not_null(j, "privacy_policy_url", privacy_policy_url);
 	owner = user().fill_from_json(&((*j)["owner"]));
+	// TODO: Remove the setting of 'summary' when v11 is released.
 	set_string_not_null(j, "summary", summary);
 	set_string_not_null(j, "verify_key", verify_key);
-	set_snowflake_not_null(j, "guild_id", guild_id);
-	set_snowflake_not_null(j, "primary_sku_id", primary_sku_id);
-	set_string_not_null(j, "slug", slug);
-	std::string ci = string_not_null(j, "cover_image");
-	if (!ci.empty()) {
-		cover_image = ci;
-	}
-	set_int32_not_null(j, "flags", flags);
-	if (j->contains("tags")) {
-		for (const auto& tag : (*j)["tags"]) {
-			this->tags.push_back(to_string(tag));
-		}
-	}
-	if (j->contains("install_params")) {
-		json& p = (*j)["install_params"];
-		set_snowflake_not_null(&p, "permissions", this->install_params.permissions);
-		for (const auto& scope : p["scopes"]) {
-			this->install_params.scopes.push_back(to_string(scope));
-		}
-	}
-	set_string_not_null(j, "custom_install_url", custom_install_url);
+
 	if (j->contains("team")) {
 		json& t = (*j)["team"];
 		std::string i = string_not_null(&t, "icon");
@@ -100,28 +86,85 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 			this->team.members.emplace_back(tm);
 		}
 	}
+
+	set_snowflake_not_null(j, "guild_id", guild_id);
+	guild_obj = guild().fill_from_json(&((*j)["guild"]));
+	set_snowflake_not_null(j, "primary_sku_id", primary_sku_id);
+	set_string_not_null(j, "slug", slug);
+	set_iconhash_not_null(j, "cover_image", cover_image);
+	set_int32_not_null(j, "flags", flags);
+	set_int64_not_null(j, "approximate_guild_count", approximate_guild_count);
+
+	if (j->contains("redirect_uris")) {
+		for (const auto& uri : (*j)["redirect_uris"]) {
+			this->redirect_uris.push_back(to_string(uri));
+		}
+	}
+
+	set_string_not_null(j, "interactions_endpoint_url", interactions_endpoint_url);
 	set_string_not_null(j, "role_connections_verification_url", role_connections_verification_url);
+
+	if (j->contains("tags")) {
+		for (const auto& tag : (*j)["tags"]) {
+			this->tags.push_back(to_string(tag));
+		}
+	}
+
+	if (j->contains("install_params")) {
+		json& p = (*j)["install_params"];
+		set_snowflake_not_null(&p, "permissions", this->install_params.permissions);
+		for (const auto& scope : p["scopes"]) {
+			this->install_params.scopes.push_back(to_string(scope));
+		}
+	}
+
+	set_string_not_null(j, "custom_install_url", custom_install_url);
+
+	// TODO: Investigate https://discord.com/developers/docs/resources/application#application-resource when v11 releases. See if the variables below are documented.
+
+	set_int8_not_null(j, "discoverability_state", discoverability_state);
+	set_int32_not_null(j, "discovery_eligibility_flags", discovery_eligibility_flags);
+	set_int8_not_null(j, "explicit_content_filter", explicit_content_filter);
+	set_int8_not_null(j, "creator_monetization_state", creator_monetization_state);
+	set_bool_not_null(j, "integration_public", integration_public);
+	set_bool_not_null(j, "integration_require_code_grant", integration_require_code_grant);
+
+	if (j->contains("interactions_event_types")) {
+		for (const auto& event_type : (*j)["interactions_event_types"]) {
+			this->interactions_event_types.push_back(to_string(event_type));
+		}
+	}
+
+	set_int8_not_null(j, "interactions_version", interactions_version);
+	set_bool_not_null(j, "is_monetized", is_monetized);
+	set_int32_not_null(j, "monetization_eligibility_flags", monetization_eligibility_flags);
+	set_int8_not_null(j, "monetization_state", monetization_state);
+	set_bool_not_null(j, "hook", hook);
+	set_int8_not_null(j, "rpc_application_state", rpc_application_state);
+	set_int8_not_null(j, "store_application_state", store_application_state);
+	set_int8_not_null(j, "verification_state", verification_state);
+
 	return *this;
 }
 
 std::string application::get_cover_image_url(uint16_t size, const image_type format) const {
-	if (!this->cover_image.to_string().empty() && this->id) {
+	if (!this->cover_image.to_string().empty()) {
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
-										 "app-icons/" + std::to_string(this->id) + "/" + this->cover_image.to_string(),
-										 format, size);
-	} else {
-		return std::string();
+	 		"app-icons/" + std::to_string(this->id) + "/" + this->cover_image.to_string(),
+			format, size);
 	}
+
+	return "";
 }
 
 std::string application::get_icon_url(uint16_t size, const image_type format) const {
-	if (!this->icon.to_string().empty() && this->id) {
+	if (!this->icon.to_string().empty()) {
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
-										 "app-icons/" + std::to_string(this->id) + "/" + this->icon.to_string(),
-										 format, size);
-	} else {
-		return std::string();
+	 		"app-icons/" + std::to_string(this->id) + "/" + this->icon.to_string(),
+		 	format, size);
 	}
+
+	return "";
 }
 
 } // namespace dpp

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -128,6 +128,14 @@ void set_string_not_null(const json* j, const char *keyname, std::string &v) {
 	}
 }
 
+void set_iconhash_not_null(const json* j, const char *keyname, utility::iconhash &v) {
+	/* Returns empty string if the value is not a string, or is null or not defined */
+	auto k = j->find(keyname);
+	if (k != j->end()) {
+		v = !k->is_null() && k->is_string() ? k->get<std::string>() : "";
+	}
+}
+
 double double_not_null(const json* j, const char *keyname) {
 	auto k = j->find(keyname);
 	if (k != j->end()) {


### PR DESCRIPTION
This PR now updates dpp::application, making it up-to-date (and even have content discord doesn't document yet). It also adds `set_iconhash_not_null`, meaning we don't have to do workarounds to set the iconhash as it can be set from a string.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
