### PR TITLE
feat!: updated integration to now contain more information

### DIFF
--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -26,6 +26,7 @@
 #include <dpp/json_fwd.h>
 #include <unordered_map>
 #include <dpp/json_interface.h>
+#include <dpp/user.h>
 
 namespace dpp {
 
@@ -47,41 +48,37 @@ enum integration_type {
  * @brief Integration flags
  */
 enum integration_flags {
-	/// Integration enabled
-	if_enabled =     0b00000001,
-	/// Integration syncing
-	if_syncing =     0b00000010,
-	/// Emoji integration
-	if_emoticons =   0b00000100,
-	/// Integration revoked
-	if_revoked =     0b00001000,
-	/// Kick users when their subscription expires
-	if_expire_kick = 0b00010000,
+	if_enabled 	=	0b00000001,		//!< is this integration enabled
+	if_syncing 	=	0b00000010,		//!< is this integration syncing @warning This is not provided for discord bot integrations.
+	if_emoticons 	=	0b00000100,		//!< whether emoticons should be synced for this integration (twitch only currently) @warning This is not provided for discord bot integrations.
+	if_revoked 	=	0b00001000,		//!< has this integration been revoked @warning This is not provided for discord bot integrations.
+	if_expire_kick 	= 	0b00010000,		//!< kick user when their subscription expires, otherwise only remove the role that is specified by `role_id`. @warning This is not provided for discord bot integrations.
 };
 
 /**
  * @brief An application that has been integrated
  */
 struct DPP_EXPORT integration_app {
-	/// Integration id
-	snowflake id;
-	/// Name
-	std::string name;
-	/// Icon
-	std::string icon;
-	/// Description
-	std::string description;
-	/// Integration summary @deprecated Removed by Discord
-	std::string summary;
-	/// Pointer to bot user
-	class user* bot;
+	snowflake		id;		//!< the id of the app
+	std::string 		name;		//!< the name of the app
+	utility::iconhash 	icon;		//!< the icon hash of the app
+	std::string 		description;	//!< the description of the app
+	class user* 		bot; 		//!< the bot associated with this application
+};
+
+/**
+ * @brief The account information for an integration.
+ */
+struct DPP_EXPORT integration_account {
+	snowflake		id;		//!< id of the account
+	std::string 		name;		//!< name of the account
 };
 
 /**
  * @brief Represents an integration on a guild, e.g. a connection to twitch.
  */
 class DPP_EXPORT integration : public managed, public json_interface<integration> {
-protected:
+	protected:
 	friend struct json_interface<integration>;
 
 	/** Read class values from json object
@@ -96,29 +93,18 @@ protected:
 	 */
 	virtual json to_json_impl(bool with_id = false) const;
 
-public:
-	/** Integration name */
-	std::string name;
-	/** Integration type */
-	integration_type type;
-	/** Integration flags from dpp::integration_flags */
-	uint8_t flags;
-	/** Role id */
-	snowflake role_id;
-	/** User id */
-	snowflake user_id;
-	/** The grace period (in days) before expiring subscribers */
-	uint32_t expire_grace_period;
-	/** Sync time */
-	time_t synced_at;
-	/** Subscriber count */
-	uint32_t subscriber_count;
-	/** Account id */
-	std::string account_id;
-	/** Account name */
-	std::string account_name;
-	/** The bot/OAuth2 application for discord integrations */
-	integration_app app;
+	public:
+	std::string 			name;			//!< integration name
+	integration_type 		type;			//!< integration type (twitch, youtube, discord, or guild_subscription)
+	uint8_t 			flags;			//!< integration flags from dpp::integration_flags
+	snowflake 			role_id;		//!< id that this integration uses for "subscribers" @warning This is not provided for discord bot integrations.
+	uint32_t 			expire_grace_period;	//!< The grace period (in days) before expiring subscribers @warning This is not provided for discord bot integrations.
+	user 				user_obj;		//!< user for this integration
+	integration_account		account;		//!< integration account information
+	time_t 				synced_at;		//!< when this integration was last synced @warning This is not provided for discord bot integrations.
+	uint32_t 			subscriber_count;	//!< how many subscribers this integration has @warning This is not provided for discord bot integrations.
+	integration_app 		app;			//!< the bot/OAuth2 application for discord integrations
+	std::vector<std::string> 	scopes;			//!< the scopes the application has been authorized for
 
 	/** Default constructor */
 	integration();
@@ -126,15 +112,35 @@ public:
 	/** Default destructor */
 	~integration() = default;
 
-	/** True if emoticons are enabled */
+	/**
+	 * Are emoticons enabled for this integration?
+	 * @warning This is not provided for discord bot integrations.
+	 */
 	bool emoticons_enabled() const;
-	/** True if integration is enabled */
+
+	/**
+	 * Is the integration enabled?
+	 * @warning This is not provided for discord bot integrations.
+	 */
 	bool is_enabled() const;
-	/** True if is syncing */
+
+	/**
+	 * Is the integration syncing?
+	 * @warning This is not provided for discord bot integrations.
+	 */
 	bool is_syncing() const;
-	/** True if has been revoked */
+
+	/**
+	 * Has this integration been revoked?
+	 * @warning This is not provided for discord bot integrations.
+	 */
 	bool is_revoked() const;
-	/** True if expiring kicks the user */
+
+	/**
+	 * Will the user be kicked if their subscription runs out to the integration?
+	 * If false, the integration will simply remove the role that is specified by `role_id`.
+	 * @warning This is not provided for discord bot integrations.
+	 */
 	bool expiry_kicks_user() const;
 };
 
@@ -142,7 +148,7 @@ public:
  * @brief The connection object that the user has attached.
  */
 class DPP_EXPORT connection : public json_interface<connection> {
-protected:
+	protected:
 	friend struct json_interface<connection>;
 
 	/** Read class values from json object
@@ -151,7 +157,7 @@ protected:
 	 */
 	connection& fill_from_json_impl(nlohmann::json* j);
 
-public:
+	public:
 	std::string			id;		//!< id of the connection account
 	std::string			name;		//!< the username of the connection account
 	std::string			type;		//!< the service of the connection (twitch, youtube, discord, or guild_subscription)

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -78,7 +78,7 @@ struct DPP_EXPORT integration_account {
  * @brief Represents an integration on a guild, e.g. a connection to twitch.
  */
 class DPP_EXPORT integration : public managed, public json_interface<integration> {
-	protected:
+protected:
 	friend struct json_interface<integration>;
 
 	/** Read class values from json object
@@ -93,7 +93,7 @@ class DPP_EXPORT integration : public managed, public json_interface<integration
 	 */
 	virtual json to_json_impl(bool with_id = false) const;
 
-	public:
+public:
 	std::string 			name;			//!< integration name
 	integration_type 		type;			//!< integration type (twitch, youtube, discord, or guild_subscription)
 	uint8_t 			flags;			//!< integration flags from dpp::integration_flags
@@ -148,7 +148,7 @@ class DPP_EXPORT integration : public managed, public json_interface<integration
  * @brief The connection object that the user has attached.
  */
 class DPP_EXPORT connection : public json_interface<connection> {
-	protected:
+protected:
 	friend struct json_interface<connection>;
 
 	/** Read class values from json object
@@ -157,7 +157,7 @@ class DPP_EXPORT connection : public json_interface<connection> {
 	 */
 	connection& fill_from_json_impl(nlohmann::json* j);
 
-	public:
+public:
 	std::string			id;		//!< id of the connection account
 	std::string			name;		//!< the username of the connection account
 	std::string			type;		//!< the service of the connection (twitch, youtube, discord, or guild_subscription)

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -31,18 +31,7 @@ namespace dpp {
 
 using json = nlohmann::json;
 
-integration::integration() :
-	managed(),
-	type(i_twitch),
-	flags(0),
-	role_id(0),
-	user_id(0),
-	expire_grace_period(0),
-	synced_at(0),
-	subscriber_count(0)
-{
-	app.id = 0;
-	app.bot = nullptr;
+integration::integration() : managed(), type(i_twitch), flags(0), role_id(0), expire_grace_period(0), synced_at(0), subscriber_count(0) {
 }
 
 integration& integration::fill_from_json_impl(nlohmann::json* j)
@@ -54,51 +43,74 @@ integration& integration::fill_from_json_impl(nlohmann::json* j)
 		{ "discord", i_discord },
 		{ "guild_subscription", i_guild_subscription }
 	};
-	this->id = snowflake_not_null(j, "id");
-	this->name = string_not_null(j, "name");
+
+	set_snowflake_not_null(j, "id", id);
+	set_string_not_null(j, "name", name);
 	this->type = type_map[string_not_null(j, "type")];
+
 	if (bool_not_null(j, "enabled")) {
 		this->flags |= if_enabled;
 	}
 	if (bool_not_null(j, "syncing")) {
 		this->flags |= if_syncing;
 	}
+
+	set_snowflake_not_null(j, "role_id", role_id);
+
 	if (bool_not_null(j, "enable_emoticons")) {
 		this->flags |= if_emoticons;
-	}
-	if (bool_not_null(j, "revoked")) {
-		this->flags |= if_revoked;
 	}
 	if (int8_not_null(j, "expire_behavior")) {
 		this->flags |= if_expire_kick;
 	}
-	this->expire_grace_period = int32_not_null(j, "expire_grace_period");
-	if (j->contains("user")) {
-		auto t = (*j)["user"];
-		this->user_id = snowflake_not_null(&t, "user_id");
+
+	set_int32_not_null(j, "expire_grace_period", expire_grace_period);
+
+	if(j->contains("user")) {
+		user_obj = user().fill_from_json(&((*j)["user"]));
 	}
+
+	/* Should never be null, but best to check in-case they maybe change it */
+	if(j->contains("account")) {
+		auto & ac = (*j)["account"];
+		set_snowflake_not_null(&ac, "id", account.id);
+		set_string_not_null(&ac, "name", account.name);
+	}
+
+	set_ts_not_null(j, "synced_at", synced_at);
+	set_int32_not_null(j, "subscriber_count", subscriber_count);
+
+	if (bool_not_null(j, "revoked")) {
+		this->flags |= if_revoked;
+	}
+
 	if (j->contains("application")) {
 		auto & t = (*j)["application"];
-		this->app.id = snowflake_not_null(&t, "id");
+		set_snowflake_not_null(&t, "id", app.id);
+		set_string_not_null(&t, "name", app.name);
+		set_string_not_null(&t, "description", app.description);
+		set_iconhash_not_null(&t, "icon", app.icon);
 		if (t.find("bot") != t.end()) {
 			auto & b = t["bot"];
 			this->app.bot = dpp::find_user(snowflake_not_null(&b, "id"));
 		}
 	}
-	this->subscriber_count = int32_not_null(j, "subscriber_count");
 
-	this->account_id = string_not_null(&((*j)["account"]), "id");
-	this->account_name = string_not_null(&((*j)["account"]), "name");
+	if(j->contains("scopes")) {
+		for (const auto& scope : (*j)["scopes"]) {
+			this->scopes.push_back(to_string(scope));
+		}
+	}
 
 	return *this;
 }
 
 json integration::to_json_impl(bool with_id) const {
 	return json({
-		{ "expire_behavior", (flags & if_expire_kick) ? 1 : 0 },
-		{ "expire_grace_period", expire_grace_period },
-		{ "enable_emoticons", emoticons_enabled() }
-	}).dump();
+			    { "expire_behavior", (flags & if_expire_kick) ? 1 : 0 },
+			    { "expire_grace_period", expire_grace_period },
+			    { "enable_emoticons", emoticons_enabled() }
+		    }).dump();
 }
 
 bool integration::emoticons_enabled() const {
@@ -137,6 +149,5 @@ connection& connection::fill_from_json_impl(nlohmann::json* j) {
 	set_object_array_not_null<integration>(j, "integrations", integrations);
 	return *this;
 }
-
 
 } // namespace dpp


### PR DESCRIPTION
This PR updates integration according to [this page in the documentation](https://discord.com/developers/docs/resources/guild#integration-object). This may also be a breaking change as I removed a deprecated feature, along with changing `account_name` and `account_id` to a struct.

This PR also severely changes the documentation for many variables in this, as it never stated before which variables would **not** appear for a bot. It also just missing documentation that discord was providing.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
