### PR TITLE
docs: added a note to setting_status for guild cache

### DIFF
--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -2,6 +2,8 @@
 
 A bot status is pretty cool, and it'd be cooler if you knew how to do it! This tutorial will cover how to set the bot status to say `Playing games!`, as well as covering how to set the status to the amount of guilds every two minutes.
 
+\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use either dpp::cluster::current_user_get_guilds and seeing how many elements are in the array, or dpp::cluster::current_application_get and getting `approximate_guild_count` from the application in the callback.
+
 First, we'll cover setting the bot status to `Playing games!`.
 
 \include{cpp} setting_status1.cpp

--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -2,7 +2,7 @@
 
 A bot status is pretty cool, and it'd be cooler if you knew how to do it! This tutorial will cover how to set the bot status to say `Playing games!`, as well as covering how to set the status to the amount of guilds every two minutes.
 
-\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use either dpp::cluster::current_user_get_guilds and seeing how many elements are in the array, or dpp::cluster::current_application_get and getting `approximate_guild_count` from the application in the callback.
+\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use either dpp::cluster::current_user_get_guilds and seeing how many elements are in the array, or dpp::cluster::current_application_get and getting `approximate_guild_count` from dpp::application in the callback.
 
 First, we'll cover setting the bot status to `Playing games!`.
 

--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -2,7 +2,7 @@
 
 A bot status is pretty cool, and it'd be cooler if you knew how to do it! This tutorial will cover how to set the bot status to say `Playing games!`, as well as covering how to set the status to the amount of guilds every two minutes.
 
-\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use either dpp::cluster::current_user_get_guilds and seeing how many elements are in the array, or dpp::cluster::current_application_get and getting `approximate_guild_count` from dpp::application in the callback.
+\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use dpp::cluster::current_application_get and get the `approximate_guild_count` from dpp::application in the callback.
 
 First, we'll cover setting the bot status to `Playing games!`.
 


### PR DESCRIPTION
This PR adds a note to `setting_status.md` about the guild cache, telling people how they can still display a guild count without the guild cache on (if they wish to do so). I'm not entirely sure if you can safely call the two methods I provided every 120 seconds without getting rate-limited, so if there's a better method then please do say!

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
