### PR TITLE
feat: added roles to emojis

### DIFF
--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -72,7 +72,7 @@ protected:
 	json to_json_impl(bool with_id = false) const;
 
 public:
-	std::string 			name{};		//<! emoji name
+	std::string 			name{};		//!< emoji name
 	std::vector<snowflake>		roles;		//!< roles allowed to use this emoji
 	snowflake 			user_id;	//!< user id that created this emoji
 	std::string 			image_data{};	//!< Image data for the emoji if uploading

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -73,7 +73,7 @@ protected:
 
 public:
 	std::string 			name{};		//<! emoji name
-	std::vector<dpp::snowflake>	roles;		//!< roles allowed to use this emoji
+	std::vector<snowflake>		roles;		//!< roles allowed to use this emoji
 	snowflake 			user_id;	//!< user id that created this emoji
 	std::string 			image_data{};	//!< Image data for the emoji if uploading
 	uint8_t 			flags{0};	//!< Flags for the emoji from dpp::emoji_flags

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -74,7 +74,7 @@ protected:
 public:
 	std::string 			name{};		//<! emoji name
 	std::vector<dpp::snowflake>	roles;		//!< roles allowed to use this emoji
-	user 				user_obj;	//!< user that created this emoji
+	snowflake 			user_id;	//!< user id that created this emoji
 	std::string 			image_data{};	//!< Image data for the emoji if uploading
 	uint8_t 			flags{0};	//!< Flags for the emoji from dpp::emoji_flags
 

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -71,11 +71,30 @@ protected:
 	json to_json_impl(bool with_id = false) const;
 
 public:
-	std::string 			name{};		//!< emoji name
-	std::vector<snowflake>		roles;		//!< roles allowed to use this emoji
-	snowflake 			user_id;	//!< user id that created this emoji
-	std::string 			image_data{};	//!< Image data for the emoji if uploading
-	uint8_t 			flags{0};	//!< Flags for the emoji from dpp::emoji_flags
+	/**
+	 * @brief Emoji name.
+	 */
+	std::string name{};
+
+	/**
+	 * @brief Roles allowed to use this emoji.
+	 */
+	std::vector<snowflake> roles;
+
+	/**
+	 * @brief The id of the user that created this emoji.
+	 */
+	snowflake user_id;
+
+	/**
+	 * @brief Image data for the emoji, if uploading.
+	 */
+	std::string image_data;
+
+	/**
+	 * @brief Flags for the emoji from dpp::emoji_flags.
+	 */
+	uint8_t flags{0};
 
 	/**
 	 * @brief Construct a new emoji object

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -26,6 +26,7 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/json_fwd.h>
+#include <dpp/user.h>
 #include <unordered_map>
 #include <dpp/json_interface.h>
 
@@ -71,22 +72,11 @@ protected:
 	json to_json_impl(bool with_id = false) const;
 
 public:
-	/**
-	 * @brief Emoji name
-	 */
-	std::string name{};
-	/**
-	 * @brief User id who uploaded the emoji
-	 */
-	snowflake user_id{0};
-	/**
-	 * @brief Flags for the emoji from dpp::emoji_flags
-	 */
-	uint8_t flags{0};
-	/**
-	 * @brief Image data for the emoji if uploading
-	 */
-	std::string image_data{};
+	std::string 			name{};		//<! emoji name
+	std::vector<dpp::snowflake>	roles;		//!< roles allowed to use this emoji
+	user 				user_obj;	//!< user that created this emoji
+	std::string 			image_data{};	//!< Image data for the emoji if uploading
+	uint8_t 			flags{0};	//!< Flags for the emoji from dpp::emoji_flags
 
 	/**
 	 * @brief Construct a new emoji object

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -26,7 +26,6 @@
 #include <dpp/managed.h>
 #include <dpp/utility.h>
 #include <dpp/json_fwd.h>
-#include <dpp/user.h>
 #include <unordered_map>
 #include <dpp/json_interface.h>
 

--- a/src/dpp/cluster/emoji.cpp
+++ b/src/dpp/cluster/emoji.cpp
@@ -23,7 +23,7 @@
 namespace dpp {
 
 void cluster::guild_emoji_create(snowflake guild_id, const class emoji& newemoji, command_completion_event_t callback) {
-	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis", m_post, newemoji.build_json(), callback);
+	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis", m_post, newemoji.build_json(false), callback);
 }
 
 void cluster::guild_emoji_delete(snowflake guild_id, snowflake emoji_id, command_completion_event_t callback) {
@@ -31,7 +31,17 @@ void cluster::guild_emoji_delete(snowflake guild_id, snowflake emoji_id, command
 }
 
 void cluster::guild_emoji_edit(snowflake guild_id, const class emoji& newemoji, command_completion_event_t callback) {
-	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis/" + std::to_string(newemoji.id), m_patch, newemoji.build_json(), callback);
+
+	/* Because newemoji.build_json will give more data than discord wants,
+	 * we will just pull the data into a new json object.
+	 */
+	json newemoji_json = newemoji.build_json(false);
+	json j;
+
+	j["name"] = newemoji_json["name"];
+	j["roles"] = newemoji_json["roles"];
+
+	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis/" + std::to_string(newemoji.id), m_patch, j, callback);
 }
 
 void cluster::guild_emoji_get(snowflake guild_id, snowflake emoji_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/emoji.cpp
+++ b/src/dpp/cluster/emoji.cpp
@@ -23,7 +23,7 @@
 namespace dpp {
 
 void cluster::guild_emoji_create(snowflake guild_id, const class emoji& newemoji, command_completion_event_t callback) {
-	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis", m_post, newemoji.build_json(false), callback);
+	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis", m_post, newemoji.build_json(), callback);
 }
 
 void cluster::guild_emoji_delete(snowflake guild_id, snowflake emoji_id, command_completion_event_t callback) {
@@ -31,17 +31,7 @@ void cluster::guild_emoji_delete(snowflake guild_id, snowflake emoji_id, command
 }
 
 void cluster::guild_emoji_edit(snowflake guild_id, const class emoji& newemoji, command_completion_event_t callback) {
-
-	/* Because newemoji.build_json will give more data than discord wants,
-	 * we will just pull the data into a new json object.
-	 */
-	json newemoji_json = newemoji.build_json(false);
-	json j;
-
-	j["name"] = newemoji_json["name"];
-	j["roles"] = newemoji_json["roles"];
-
-	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis/" + std::to_string(newemoji.id), m_patch, j, callback);
+	rest_request<emoji>(this, API_PATH "/guilds", std::to_string(guild_id), "emojis/" + std::to_string(newemoji.id), m_patch, newemoji.build_json(), callback);
 }
 
 void cluster::guild_emoji_get(snowflake guild_id, snowflake emoji_id, command_completion_event_t callback) {

--- a/src/dpp/emoji.cpp
+++ b/src/dpp/emoji.cpp
@@ -38,7 +38,8 @@ emoji& emoji::fill_from_json_impl(nlohmann::json* j) {
 	id = snowflake_not_null(j, "id");
 	name = string_not_null(j, "name");
 	if (j->contains("user")) {
-		user_obj = user().fill_from_json(&((*j)["user"]));
+		json & user = (*j)["user"];
+		user_id = snowflake_not_null(&user, "id");
 	}
 
 	if(j->contains("roles")) {

--- a/src/dpp/emoji.cpp
+++ b/src/dpp/emoji.cpp
@@ -73,7 +73,7 @@ json emoji::to_json_impl(bool with_id) const {
 	}
 	j["roles"] = json::array();
 	for (const auto& role : roles) {
-		j["roles"].push_back(role);
+		j["roles"].push_back(role.str());
 	}
 	return j;
 }


### PR DESCRIPTION
This PR adds roles to emojis, allowing bots to restrict emojis to certain roles. You can view discord's documentation about this at [this page](https://discord.com/developers/docs/resources/emoji#emoji-object).

This also changes how we store the user, along with how we send information to discord. We now store the actual user object rather than a user_id (as discord provides the user object, this helps people who may not have cache on so they don't have to make another API request to get the user).

The information above is a breaking change.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
