### PR TITLE
fix: make embed color optional

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -658,7 +658,7 @@ struct DPP_EXPORT embed {
 	/** Optional: timestamp of embed content */
 	time_t				timestamp;
 	/** Optional: color code of the embed */
-	uint32_t			color;
+	std::optional<uint32_t>			color;
 	/** Optional: footer information */
 	std::optional<embed_footer>	footer;
 	/** Optional: image information */

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -618,7 +618,9 @@ embed::embed(json* j) : embed() {
 	description = string_not_null(j, "description");
 	url = string_not_null(j, "url");
 	timestamp = ts_not_null(j, "timestamp");
-	color = int32_not_null(j, "color");
+	if (j->contains("color")) {
+		color = int32_not_null(j, "color");
+	}
 	if (j->contains("footer")) {
 		dpp::embed_footer f;
 		json& fj = (*j)["footer"];

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -487,7 +487,7 @@ component &component::add_default_value(const snowflake id, const component_defa
 
 embed::~embed() = default;
 
-embed::embed() : timestamp(0), color(0) {
+embed::embed() : timestamp(0) {
 }
 
 message::message() : managed(0), channel_id(0), guild_id(0), sent(0), edited(0), webhook_id(0),
@@ -962,7 +962,9 @@ json message::to_json(bool with_id, bool is_interaction_response) const {
 		if (!embed.url.empty()) {
 			e["url"] = embed.url;
 		}
-		e["color"] = embed.color;
+		if (embed.color.has_value()) {
+			e["color"] = embed.color.value();
+		}
 		if (embed.footer.has_value()) {
 			e["footer"]["text"] = embed.footer->text;
 			e["footer"]["icon_url"] = embed.footer->icon_url;


### PR DESCRIPTION
made `embed::color` a `std::optional`
Discord does not use `0x000000` as the default embed color, so this actually does result in a visual change to the embeds created that dont have a color, (also has a more noticable change in light mode)

Before:
![CleanShot 2023-10-20 at 17 05 12](https://github.com/brainboxdotcc/DPP/assets/52634785/f0cd12e9-266a-4cdd-b347-97ad3f567859)![CleanShot 2023-10-20 at 17 05 04](https://github.com/brainboxdotcc/DPP/assets/52634785/109e0405-18e0-4da8-9568-c14a0bb01277)
After:
![CleanShot 2023-10-20 at 17 05 21](https://github.com/brainboxdotcc/DPP/assets/52634785/325bc33c-8147-4358-85bf-47a85aed8c54)![CleanShot 2023-10-20 at 17 05 06](https://github.com/brainboxdotcc/DPP/assets/52634785/7725e171-153d-45af-86e4-dd5fde769bdc)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
