### PR TITLE
feat: removed version_checker for UE.

### DIFF
--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -66,7 +66,14 @@ struct DPP_EXPORT version_checker {
 	}
 };
 
+/*
+ * We need to tell DPP to NOT do the version checker if something from Unreal Engine is defined.
+ * We have to do this because UE is causing some weirdness where the version checker is broken and always errors.
+ * This is really only for DPP-UE. There is no reason to not do the version checker unless you are in Unreal Engine.
+ */
+#if !defined(UE_BUILD_DEBUG) && !defined(UE_BUILD_DEVELOPMENT) && !defined(UE_BUILD_TEST) && !defined(UE_BUILD_SHIPPING) && !defined(UE_GAME) && !defined(UE_EDITOR) && !defined(UE_BUILD_SHIPPING_WITH_EDITOR) && !defined(UE_BUILD_DOCS)
 static version_checker dpp_vc;
+#endif
 
 
 /**


### PR DESCRIPTION
This PR wraps the version checker in an if statement, checking if any UE definitions are declared. This means Unreal Engine will no longer constantly break with the version checker.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
