### PR TITLE
refactor: renamed inner_emoji, changed select_menu and component to use it.

### DIFF
--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -82,7 +82,7 @@ struct component_emoji {
 	 * @note Only applies to custom emojis.
 	 */
 	bool animated{false};
-}
+};
 
 /**
  * @brief Represents an emoji for a dpp::guild

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -48,43 +48,6 @@ enum emoji_flags : uint8_t {
 };
 
 /**
- * @brief An emoji for a component (select menus included).
- *
- * To set an emoji on your button, you must set one of either the name or id fields.
- * The easiest way is to use the dpp::component::set_emoji method.
- *
- * @note This is a **very** scaled down version of dpp::emoji, we advise that you refrain from using this.
- */
-struct component_emoji {
-	/**
-	 * @brief The name of the emoji.
-	 *
-	 * For built in unicode emojis, set this to the
-	 * actual unicode value of the emoji e.g. "😄"
-	 * and not for example ":smile:"
-	 */
-	std::string name{""};
-
-	/**
-	 * @brief The emoji ID value for emojis that are custom
-	 * ones belonging to a guild.
-	 *
-	 * The same rules apply as with other emojis,
-	 * that the bot must be on the guild where the emoji resides
-	 * and it must be available for use
-	 * (e.g. not disabled due to lack of boosts, etc)
-	 */
-	dpp::snowflake id{0};
-
-	/**
-	 * @brief Is the emoji animated?
-	 *
-	 * @note Only applies to custom emojis.
-	 */
-	bool animated{false};
-};
-
-/**
  * @brief Represents an emoji for a dpp::guild
  */
 class DPP_EXPORT emoji : public managed, public json_interface<emoji> {

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -48,6 +48,43 @@ enum emoji_flags : uint8_t {
 };
 
 /**
+ * @brief An emoji for a component (select menus included).
+ *
+ * To set an emoji on your button, you must set one of either the name or id fields.
+ * The easiest way is to use the dpp::component::set_emoji method.
+ *
+ * @note This is a **very** scaled down version of dpp::emoji, we advise that you refrain from using this.
+ */
+struct component_emoji {
+	/**
+	 * @brief The name of the emoji.
+	 *
+	 * For built in unicode emojis, set this to the
+	 * actual unicode value of the emoji e.g. "😄"
+	 * and not for example ":smile:"
+	 */
+	std::string name{""};
+
+	/**
+	 * @brief The emoji ID value for emojis that are custom
+	 * ones belonging to a guild.
+	 *
+	 * The same rules apply as with other emojis,
+	 * that the bot must be on the guild where the emoji resides
+	 * and it must be available for use
+	 * (e.g. not disabled due to lack of boosts, etc)
+	 */
+	dpp::snowflake id{0};
+
+	/**
+	 * @brief Is the emoji animated?
+	 *
+	 * @note Only applies to custom emojis.
+	 */
+	bool animated{false};
+}
+
+/**
  * @brief Represents an emoji for a dpp::guild
  */
 class DPP_EXPORT emoji : public managed, public json_interface<emoji> {

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -140,7 +140,7 @@ public:
 	/**
 	 * @brief The emoji for the select option.
 	 */
-	inner_emoji emoji;
+	component_emoji emoji;
 
 	/**
 	 * @brief Construct a new select option object
@@ -320,7 +320,7 @@ public:
 	/**
 	 * @brief The emoji for this component.
 	 */
-	inner_emoji emoji;
+	component_emoji emoji;
 
 	/** Constructor
 	 */

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -25,6 +25,7 @@
 #include <dpp/managed.h>
 #include <dpp/user.h>
 #include <dpp/guild.h>
+#include <dpp/emoji.h>
 #include <optional>
 #include <variant>
 #include <dpp/json_fwd.h>
@@ -135,35 +136,11 @@ public:
 	 * @brief True if option is the default option
 	 */
 	bool is_default;
+
 	/**
-	 * @brief Emoji definition. To set an emoji on your button
-	 * you must set one of either the name or id fields.
-	 * The easiest way is to use the component::set_emoji
-	 * method.
+	 * @brief The emoji for the select option.
 	 */
-	struct inner_select_emoji {
-		/**
-		 * @brief Set the name field to the name of the emoji.
-		 * For built in unicode emojis, set this to the
-		 * actual unicode value of the emoji e.g. "😄"
-		 * and not for example ":smile:"
-		 */
-		std::string name;
-		/**
-		 * @brief The emoji ID value for emojis that are custom
-		 * ones belonging to a guild. The same rules apply
-		 * as with other emojis, that the bot must be on
-		 * the guild where the emoji resides and it must
-		 * be available for use (e.g. not disabled due to
-		 * lack of boosts etc)
-		 */
-		dpp::snowflake id = 0;
-		/**
-		 * @brief True if the emoji is animated. Only applies to
-		 * custom emojis.
-		 */
-		bool animated = false;
-	} emoji;
+	inner_emoji emoji;
 
 	/**
 	 * @brief Construct a new select option object
@@ -340,31 +317,10 @@ public:
 	 */
 	std::variant<std::monostate, std::string, int64_t, double> value;
 
-	/** Emoji definition. To set an emoji on your button
-	 * you must set one of either the name or id fields.
-	 * The easiest way is to use the component::set_emoji
-	 * method.
+	/**
+	 * @brief The emoji for this component.
 	 */
-	struct inner_emoji {
-		/** Set the name field to the name of the emoji.
-		 * For built in unicode emojis, set this to the
-		 * actual unicode value of the emoji e.g. "😄"
-		 * and not for example ":smile:"
-		 */
-		std::string name;
-		/** The emoji ID value for emojis that are custom
-		 * ones belonging to a guild. The same rules apply
-		 * as with other emojis, that the bot must be on
-		 * the guild where the emoji resides and it must
-		 * be available for use (e.g. not disabled due to
-		 * lack of boosts etc)
-		 */
-		dpp::snowflake id;
-		/** True if the emoji is animated. Only applies to
-		 * custom emojis.
-		 */
-		bool animated;
-	} emoji;
+	inner_emoji emoji;
 
 	/** Constructor
 	 */

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -25,7 +25,6 @@
 #include <dpp/managed.h>
 #include <dpp/user.h>
 #include <dpp/guild.h>
-#include <dpp/emoji.h>
 #include <optional>
 #include <variant>
 #include <dpp/json_fwd.h>
@@ -53,6 +52,43 @@ enum component_type : uint8_t {
 	cot_mentionable_selectmenu = 7,
 	/// Select menu for channels
 	cot_channel_selectmenu = 8,
+};
+
+/**
+ * @brief An emoji for a component (select menus included).
+ *
+ * To set an emoji on your button, you must set one of either the name or id fields.
+ * The easiest way is to use the dpp::component::set_emoji method.
+ *
+ * @note This is a **very** scaled down version of dpp::emoji, we advise that you refrain from using this.
+ */
+struct component_emoji {
+	/**
+	 * @brief The name of the emoji.
+	 *
+	 * For built in unicode emojis, set this to the
+	 * actual unicode value of the emoji e.g. "😄"
+	 * and not for example ":smile:"
+	 */
+	std::string name{""};
+
+	/**
+	 * @brief The emoji ID value for emojis that are custom
+	 * ones belonging to a guild.
+	 *
+	 * The same rules apply as with other emojis,
+	 * that the bot must be on the guild where the emoji resides
+	 * and it must be available for use
+	 * (e.g. not disabled due to lack of boosts, etc)
+	 */
+	dpp::snowflake id{0};
+
+	/**
+	 * @brief Is the emoji animated?
+	 *
+	 * @note Only applies to custom emojis.
+	 */
+	bool animated{false};
 };
 
 /**


### PR DESCRIPTION
This PR removed `inner_select_emoji` from `select_menu` and renames `inner_emoji` to `component_emoji`. `select_menu` now uses `component_emoji`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
