### PR TITLE
style: refactored comments in several files to follow standard

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -48,27 +48,59 @@ namespace dpp {
  * These are the possible parameter value types.
  */
 enum command_option_type : uint8_t {
-	/** A sub-command */
+	/**
+	 * @brief A sub-command.
+	 */
 	co_sub_command = 1,
-	/** A sub-command group */
+
+	/**
+	 * @brief A sub-command group.
+	 */
 	co_sub_command_group = 2,
-	/** A string value */
+
+	/**
+	 * @brief A string value.
+	 */
 	co_string = 3,
-	/** An integer value */
+
+	/**
+	 * @brief An integer value.
+	 */
 	co_integer = 4,
-	/** A boolean value */
+
+	/**
+	 * @brief A boolean value.
+	 */
 	co_boolean = 5,
-	/** A user snowflake id */
+
+	/**
+	 * @brief A user snowflake id.
+	 */
 	co_user = 6,
-	/** A channel snowflake id. Includes all channel types and categories */
+
+	/**
+	 * @brief A channel snowflake id. Includes all channel types and categories.
+	 */
 	co_channel = 7,
-	/** A role snowflake id */
+
+	/**
+	 * @brief A role id (snowflake).
+	 */
 	co_role = 8,
-	/** A mentionable. Includes users and roles */
+
+	/**
+	 * @brief A mentionable (users and roles).
+	 */
 	co_mentionable = 9,
-	/** Any double between -2^53 and 2^53 */
+
+	/**
+	 * @brief Any double between -2^53 and 2^53.
+	 */
 	co_number = 10,
-	/** File attachment type */
+
+	/**
+	 * @brief File attachment type.
+	 */
 	co_attachment = 11,
 };
 
@@ -104,9 +136,20 @@ protected:
 	command_option_choice& fill_from_json_impl(nlohmann::json* j);
 
 public:
-	std::string name;	//!< Option name (1-32 chars)
-	command_value value;	//!< Option value
-	std::map<std::string, std::string> name_localizations; //!< Localisations of command option name
+	/**
+	 * @brief Option name (1-32 chars).
+	 */
+	std::string name;
+
+	/**
+	 * @brief Option value.
+	 */
+	command_value value;
+
+	/**
+	 * @brief Localisations of command option name.
+	 */
+	std::map<std::string, std::string> name_localizations;
 
 	/**
 	 * @brief Construct a new command option choice object
@@ -170,22 +213,79 @@ protected:
 	command_option& fill_from_json_impl(nlohmann::json* j);
 
 public:
-	command_option_type type;                    //!< Option type (what type of value is accepted)
-	std::string name;                            //!< Option name (1-32 chars)
-	std::string description;                     //!< Option description (1-100 chars)
-	bool required;                               //!< True if this is a mandatory parameter
-	bool focused;                                //!< True if the user is typing in this field, when sent via autocomplete
-	command_value value;                         //!< Set only by autocomplete went sent as part of an interaction
-	std::vector<command_option_choice> choices;  //!< List of choices for multiple choice command
-	bool autocomplete;                           //!< True if this option supports auto completion
-	std::vector<command_option> options;         //!< Sub-commands
-	std::vector<channel_type> channel_types;     //!< Allowed channel types for channel snowflake id options
-	// Combines the `min_length` and `max_length` field by storing its value in the int64_t of the command_option_range
-	command_option_range min_value;              //!< Minimum value/length that can be entered, for dpp::co_number, dpp::co_integer and dpp::co_string types only
-	command_option_range max_value;              //!< Maximum value/length that can be entered, for dpp::co_number, dpp::co_integer and dpp::co_string types only
-	std::map<std::string, std::string> name_localizations; //!< Localisations of command name
-	std::map<std::string, std::string> description_localizations; //!< Localisations of command description
+	/**
+	 * @brief Option type (what type of value is accepted).
+	 */
+	command_option_type type;
 
+	/**
+	 * @brief Option name (1-32 chars).
+	 */
+	std::string name;
+
+	/**
+	 * @brief Option description (1-100 chars).
+	 */
+	std::string description;
+
+	/**
+	 * @brief Is this a mandatory parameter?
+	 */
+	bool required;
+
+	/**
+	 * @brief Is the user is typing in this field?
+	 *
+	 * @note This is sent via autocomplete.
+	 */
+	bool focused;
+
+	/**
+	 * @brief Set only by autocomplete when sent as part of an interaction.
+	 */
+	command_value value;
+
+	/**
+	 * @brief List of choices for multiple choice command.
+	 */
+	std::vector<command_option_choice> choices;
+
+	/**
+	 * @brief Does this option supports auto completion?
+	 */
+	bool autocomplete;
+
+	/**
+	 * @brief An array of sub-commands (options).
+	 */
+	std::vector<command_option> options;
+
+	/**
+	 * @brief Allowed channel types for channel snowflake id options.
+	 */
+	std::vector<channel_type> channel_types;
+
+	// Combines the `min_length` and `max_length` field by storing its value in the int64_t of the command_option_range
+
+	/**
+	 * @brief Minimum value/length that can be entered, for dpp::co_number, dpp::co_integer and dpp::co_string types only.
+	 */
+	command_option_range min_value;
+
+	/**
+	 * @brief Maximum value/length that can be entered, for dpp::co_number, dpp::co_integer and dpp::co_string types only.
+	 */
+	command_option_range max_value;
+
+	/**
+	 * @brief Localisations of command name.
+	 */
+	std::map<std::string, std::string> name_localizations;
+
+	/**
+	 * @brief Localisations of command description.
+	 */
+	std::map<std::string, std::string> description_localizations;
 
 	/**
 	 * @brief Construct a new command option object
@@ -302,10 +402,12 @@ enum interaction_response_type {
 	 * @brief Acknowledge a Ping
 	 */
 	ir_pong = 1,
+
 	/**
 	 * @brief Respond to an interaction with a message.
 	 */
 	ir_channel_message_with_source = 4,
+
 	/**
 	 * @brief Acknowledge an interaction and edit a response later, the user sees a loading state
 	 */
@@ -584,18 +686,37 @@ struct DPP_EXPORT command_resolved {
  * the command on a channel or in DM.
  */
 struct DPP_EXPORT command_data_option {
-	std::string name;                          //!< the name of the parameter
-	command_option_type type;                  //!< value of ApplicationCommandOptionType
-	command_value value;                       //!< Optional: the value of the pair
-	std::vector<command_data_option> options;  //!< Optional: present if this option is a group or subcommand
-	bool focused;                              //!< Optional: true if this option is the currently focused option for autocomplete
+	/**
+	 * @brief The name of the parameter.
+	 */
+	std::string name;
+
+	/**
+	 * @brief The type of option (value of ApplicationCommandOptionType).
+	 */
+	command_option_type type;
+
+	/**
+	 * @brief Optional: the value of the pair
+	 */
+	command_value value;
+
+	/**
+	 * @brief Optional: present if this option is a group or subcommand
+	 */
+	std::vector<command_data_option> options;
+
+	/**
+	 * @brief Optional: true if this option is the currently focused option for autocomplete
+	 */
+	bool focused;
 
 	/**
 	 * @brief Check if the value variant holds std::monostate and options vector is empty (i.e. the option wasn't supplied) 
 	 * @return bool true, if value variant holds std::monostate and options vector is empty
 	 */
 	bool empty() {
-	    return std::holds_alternative<std::monostate>(value) && options.empty();
+		return std::holds_alternative<std::monostate>(value) && options.empty();
 	}
 
 	/**
@@ -623,21 +744,55 @@ void from_json(const nlohmann::json& j, command_data_option& cdo);
 /** Types of interaction in the dpp::interaction class
  */
 enum interaction_type {
-	it_ping = 1,			//!< ping
-	it_application_command = 2,	//!< application command (slash command)
-	it_component_button = 3,	//!< button click or select menu chosen (component interaction)
-	it_autocomplete = 4,		//!< Autocomplete interaction
-	it_modal_submit = 5,		//!< Modal form submission
+	/**
+	 * @brief A ping interaction.
+	 */
+	it_ping = 1,
+
+	/**
+	 * @brief Application command (slash command) interaction.
+	 */
+	it_application_command = 2,
+
+	/**
+	 * @brief Button click or select menu chosen (component interaction)
+	 */
+	it_component_button = 3,
+
+	/**
+	 * @brief Autocomplete interaction.
+	 */
+	it_autocomplete = 4,
+
+	/**
+	 * @brief Modal form submission.
+	 */
+	it_modal_submit = 5,
 };
 
 /**
  * @brief Right-click context menu types
  */
 enum slashcommand_contextmenu_type {
-    ctxm_none = 0,        //!< Undefined context menu type
-    ctxm_chat_input = 1,    //!< DEFAULT, these are the slash commands you're used to
-    ctxm_user = 2,        //!< Add command to user context menu
-    ctxm_message = 3    //!< Add command to message context menu
+	/**
+	 * @brief Undefined context menu type
+	 */
+	ctxm_none = 0,
+
+	/**
+	 * @brief DEFAULT: these are the generic slash commands (e.g. /ping, /pong, etc)
+	 */
+	ctxm_chat_input = 1,
+
+	/**
+	 * @brief A slashcommand that goes in the user context menu.
+	 */
+	ctxm_user = 2,
+
+	/**
+	 * @brief A slashcommand that goes in the message context menu.
+	 */
+	ctxm_message = 3
 };
 
 /**
@@ -646,11 +801,32 @@ enum slashcommand_contextmenu_type {
  * with the interaction.
  */
 struct DPP_EXPORT command_interaction {
-	snowflake id;                              //!< the ID of the invoked command
-	std::string name;                          //!< the name of the invoked command
-	std::vector<command_data_option> options;  //!< Optional: the params + values from the user
-	slashcommand_contextmenu_type type;        //!< type of the command interaction
-	dpp::snowflake target_id;                  //!< Non-zero target ID for context menu actions. e.g. user id or message id whom clicked or tapped with the context menu https://discord.com/developers/docs/interactions/application-commands#user-commands
+	/**
+	 * @brief The ID of the invoked command.
+	 */
+	snowflake id;
+
+	/**
+	 * @brief The name of the invoked command.
+	 */
+	std::string name;
+
+	/**
+	 * @brief Optional: the params + values from the user.
+	 */
+	std::vector<command_data_option> options;
+
+	/**
+	 * @brief The type of command interaction.
+	 */
+	slashcommand_contextmenu_type type;
+
+	/**
+	 * @brief Non-zero target ID for context menu actions (e.g. user id or message id whom clicked or tapped with the context menu).
+	 *
+	 * @see https://discord.com/developers/docs/interactions/application-commands#user-commands
+	 */
+	dpp::snowflake target_id;
 
 	/**
 	 * @brief Get an option value by index
@@ -690,10 +866,12 @@ struct DPP_EXPORT component_interaction {
 	 * @brief Component type (dpp::component_type)
 	 */
 	uint8_t component_type;
+
 	/**
 	 * @brief Custom ID set when created
 	 */
 	std::string custom_id;
+
 	/**
 	 * @brief Possible values for a drop down list
 	 */
@@ -1031,12 +1209,11 @@ void from_json(const nlohmann::json& j, interaction& i);
 enum command_permission_type {
 	/**
 	 * @brief Role permission
-	 * 
 	 */
 	cpt_role = 1,
+
 	/**
 	 * @brief User permission
-	 * 
 	 */
 	cpt_user = 2,
 };
@@ -1058,12 +1235,23 @@ protected:
 	command_permission &fill_from_json_impl(nlohmann::json *j);
 
 public:
-	snowflake id;                  //!< the ID of the role or user
-	command_permission_type type;  //!< the type of permission
-	bool permission;               //!< true to allow, false, to disallow
+	/**
+	 * @brief The ID of the role/user.
+	 */
+	snowflake id;
 
 	/**
-	 * @brief Construct a new command permission object
+	 * @brief The type of permission.
+	 */
+	command_permission_type type;
+
+	/**
+	 * @brief True to allow, false to disallow.
+	 */
+	bool permission;
+
+	/**
+	 * @brief Construct a new command permission object.
 	 */
 	command_permission() = default;
 
@@ -1105,10 +1293,25 @@ protected:
 	guild_command_permissions &fill_from_json_impl(nlohmann::json *j);
 
 public:
-	snowflake id;                                 //!< the id of the command
-	snowflake application_id;                     //!< the id of the application the command belongs to
-	snowflake guild_id;                           //!< the id of the guild
-	std::vector<command_permission> permissions;  //!< the permissions for the command in the guild
+	/**
+	 * @brief The id of the command.
+	 */
+	snowflake id;
+
+	/**
+	 * @brief The id of the application the command belongs to.
+	 */
+	snowflake application_id;
+
+	/**
+	 * @brief The id of the guild.
+	 */
+	snowflake guild_id;
+
+	/**
+	 * @brief The permissions for the command, in the guild.
+	 */
+	std::vector<command_permission> permissions;
 
 	/**
 	 * @brief Construct a new guild command permissions object

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -37,9 +37,13 @@ namespace dpp {
  * @brief status of a member of a team who maintain a bot/application
  */
 enum team_member_status : uint8_t {
-	/// User was invited to the team
+	/**
+	 * @brief User was invited to the team.
+	 */
 	tms_invited = 1,
-	/// User has accepted membership onto the team
+	/**
+	 * @brief User has accepted membership onto the team.
+	 */
 	tms_accepted = 2
 };
 
@@ -47,25 +51,54 @@ enum team_member_status : uint8_t {
  * @brief Flags for a bot or application
  */
 enum application_flags : uint32_t {
-	/// Indicates if an app uses the Auto Moderation API
+	/**
+	 * @brief Indicates if an app uses the Auto Moderation API
+	 */
 	apf_application_automod_rule_create_badge = (1 << 6),
-	/// Has gateway presence intent
+
+	/**
+	 * @brief Has gateway presence intent
+	 */
 	apf_gateway_presence = (1 << 12),
-	/// Has gateway presence intent for <100 guilds
+
+	/**
+	 * @brief Has gateway presence intent for <100 guilds
+	 */
 	apf_gateway_presence_limited = (1 << 13),
-	/// Has guild members intent 
+
+	/**
+	 * @brief Has guild members intent
+	 */
 	apf_gateway_guild_members = (1 << 14),
-	/// Has guild members intent for <100 guilds
+
+	/**
+	 * @brief Has guild members intent for <100 guilds
+	 */
 	apf_gateway_guild_members_limited = (1 << 15),
-	/// Verification is pending
+
+	/**
+	 * @brief Verification is pending
+	 */
 	apf_verification_pending_guild_limit = (1 << 16),
-	/// Embedded
+
+	/**
+	 * @brief Embedded
+	 */
 	apf_embedded = (1 << 17),
-	/// Has approval for message content
+
+	/**
+	 * @brief Has approval for message content
+	 */
 	apf_gateway_message_content = (1 << 18),
-	/// Has message content, but <100 guilds
+
+	/**
+	 * @brief Has message content, but <100 guilds
+	 */
 	apf_gateway_message_content_limited = (1 << 19),
-	/// Indicates if the app has registered global application commands
+
+	/**
+	 * @brief Indicates if the app has registered global application commands
+	 */
 	apf_application_command_badge = (1 << 23)
 };
 
@@ -73,8 +106,17 @@ enum application_flags : uint32_t {
  * @brief Represents the settings for the bot/application's in-app authorization link
  */
 struct DPP_EXPORT application_install_params {
-	permission permissions;	//!< A bitmask of dpp::permissions to request for the bot role
-	std::vector<std::string> scopes;	//!< The [scopes](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes) as strings to add the application to the server with
+	/**
+	 * @brief A bitmask of dpp::permissions to request for the bot role.
+	 */
+	permission permissions;
+
+	/**
+	 * @brief The scopes as strings to add the application to the server with.
+	 *
+	 * @see https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
+	 */
+	std::vector<std::string> scopes;
 };
 
 /**
@@ -84,10 +126,25 @@ struct DPP_EXPORT application_install_params {
  * this enum will be extended to support them.
  */
 enum team_member_role_t : uint8_t {
-	tmr_owner,	//!< Team owner
-	tmr_admin,	//!< Team admin
-	tmr_developer,	//!< Developer
-	tmr_readonly,	//!< Read-Only
+	/**
+	 * @brief Team owner.
+	 */
+	tmr_owner,
+
+	/**
+	 * @brief Team admin.
+	 */
+	tmr_admin,
+
+	/**
+	 * @brief Developer
+	 */
+	tmr_developer,
+
+	/**
+	 * @brief Read-Only
+	 */
+	tmr_readonly,
 };
 
 /**
@@ -95,11 +152,30 @@ enum team_member_role_t : uint8_t {
  */
 class DPP_EXPORT team_member {
 public:
-	team_member_status	membership_state;	//!< the user's membership state on the team
-	std::string		permissions;		//!< will always be [""]
-	snowflake		team_id;		//!< the id of the parent team of which they are a member
-	user			member_user;		//!< the avatar, discriminator, id, and username of the user
-	team_member_role_t	member_role;		//!< the role of the user
+	/**
+	 * @brief The user's membership state on the team.
+	 */
+	team_member_status membership_state;
+
+	/**
+	 * @brief Will always be "".
+	 */
+	std::string permissions;
+
+	/**
+	 * @brief The id of the parent team of which they are a member.
+	 */
+	snowflake team_id;
+
+	/**
+	 * @brief The avatar, discriminator, id, and username, of the user.
+	 */
+	user member_user;
+
+	/**
+	 * @brief The role of the user in the team.
+	 */
+	team_member_role_t member_role;
 };
 
 /**
@@ -107,11 +183,30 @@ public:
  */
 class DPP_EXPORT app_team {
 public:
-	utility::iconhash		icon;		//!< a hash of the image of the team's icon (may be empty)
-	snowflake			id;		//!< the unique id of the team
-	std::vector<team_member>	members;	//!< the members of the team
-	std::string			name;		//!< the name of the team
-	snowflake			owner_user_id;	//!< the user id of the current team owner
+	/**
+	 * @brief A hash of the image of the team's icon (may be empty).
+	 */
+	utility::iconhash icon;
+
+	/**
+	 * @brief The id of the team.
+	 */
+	snowflake id;
+
+	/**
+	 * @brief The members of the team.
+	 */
+	std::vector<team_member> members;
+
+	/**
+	 * @brief The name of the team.
+	 */
+	std::string name;
+
+	/**
+	 * @brief The user id of the current team owner.
+	 */
+	snowflake owner_user_id;
 };
 
 /**
@@ -128,48 +223,213 @@ protected:
 	application& fill_from_json_impl(nlohmann::json* j);
 
 public:
-	std::string		name;				//!< the name of the app
-	utility::iconhash	icon;				//!< the icon hash of the app (may be empty)
-	std::string		description;			//!< the description of the app
-	std::vector<std::string> rpc_origins;			//!< Optional: an array of rpc origin urls, if rpc is enabled
-	bool			bot_public;			//!< when false only app owner can join the app's bot to guilds
-	bool			bot_require_code_grant;		//!< when true the app's bot will only join upon completion of the full oauth2 code grant flow
-	user			bot;				//!< Optional: Partial user object for the bot user associated with the app.
-	std::string		terms_of_service_url;		//!< Optional: the url of the app's terms of service
-	std::string		privacy_policy_url;		//!< Optional: the url of the app's privacy policy
-	user			owner;				//!< Optional: partial user object containing info on the owner of the application
-	std::string		summary;			//!< if this application is a game sold on Discord, this field will be the summary field for the store page of its primary sku @deprecated Will be removed in v11
-	std::string		verify_key;			//!< the hex encoded key for verification in interactions and the GameSDK's GetTicket
-	app_team		team;				//!< if the application belongs to a team, this will be a list of the members of that team (may be empty)
-	snowflake		guild_id;			//!< Optional: if this application is a game sold on Discord, this field will be the guild to which it has been linked
-	guild			guild_obj;			//!< Optional: Partial object of the associated guild
-	snowflake		primary_sku_id;			//!< Optional: if this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists
-	std::string		slug;				//!< Optional: if this application is a game sold on Discord, this field will be the URL slug that links to the store page
-	utility::iconhash	cover_image;			//!< Optional: the application's default rich presence invite cover image hash
-	uint32_t		flags;				//!< Optional: the application's public flags
-	uint64_t		approximate_guild_count;	//!< Optional: Approximate count of guilds the app has been added to
-	std::vector<std::string> redirect_uris;			//!< Optional: Array of redirect URIs for the app
-	std::string		interactions_endpoint_url;	//!< Optional: Interactions endpoint URL for the app
-	std::string 	role_connections_verification_url;	//!< The application's role connection verification entry point, which when configured will render the app as a verification method in the guild role verification configuration
-	std::vector<std::string> tags;				//!< Up to 5 tags describing the content and functionality of the application
-	application_install_params install_params;		//!< Settings for the application's default in-app authorization link, if enabled
-	std::string 		custom_install_url;		//!< The application's default custom authorization link, if enabled
+	/**
+	 * @brief The name of the app.
+	 */
+	std::string name;
 
-	uint8_t			discoverability_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint32_t 		discovery_eligibility_flags;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			explicit_content_filter;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			creator_monetization_state;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	bool			integration_public;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	bool			integration_require_code_grant;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	std::vector<std::string> interactions_event_types;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			interactions_version;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	bool			is_monetized;			//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint32_t		monetization_eligibility_flags;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			monetization_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	bool			hook;				//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			rpc_application_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			store_application_state;	//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
-	uint8_t			verification_state;		//!< @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	/**
+	 * @brief The icon hash of the app (may be empty).
+	 */
+	utility::iconhash icon;
+
+	/**
+	 * @brief The description of the app.
+	 */
+	std::string description;
+
+	/**
+	 * @brief Optional: an array of rpc origin urls, if rpc is enabled.
+	 */
+	std::vector<std::string> rpc_origins;
+
+	/**
+	 * @brief When false, only app owner add the bot to guilds.
+	 */
+	bool bot_public;
+
+	/**
+	 * @brief When true, the app's bot will only join upon completion of the full oauth2 code grant flow
+	 */
+	bool bot_require_code_grant;
+
+	/**
+	 * @brief Optional: Partial user object for the bot user associated with the app.
+	 */
+	user bot;
+
+	/**
+	 * @brief Optional: the url of the app's terms of service.
+	 */
+	std::string terms_of_service_url;
+
+	/**
+	 * @brief Optional: the url of the app's privacy policy.
+	 */
+	std::string privacy_policy_url;
+
+	/**
+	 * @brief Optional: partial user object containing info on the owner of the application.
+	 */
+	user owner;
+
+	/**
+	 * @brief If this application is a game sold on Discord, this field will be the summary field for the store page of its primary SKU.
+	 *
+	 * @deprecated Will be removed in v11
+	 */
+	std::string summary;
+
+	/**
+	 * @brief The hex encoded key for verification in interactions and the GameSDK's GetTicket.
+	 */
+	std::string verify_key;
+
+	/**
+	 * @brief If the application belongs to a team, this will be a list of the members of that team (may be empty).
+	 */
+	app_team team;
+
+	/**
+	 * @brief Optional: if this application is a game sold on Discord, this field will be the guild to which it has been linked.
+	 */
+	snowflake guild_id;
+
+	/**
+	 * @brief Partial object of the associated guild.
+	 */
+	guild guild_obj;
+
+	/**
+	 * @brief Optional: if this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists.
+	 */
+	snowflake primary_sku_id;
+
+	/**
+	 * @brief Optional: if this application is a game sold on Discord, this field will be the URL slug that links to the store page.
+	 */
+	std::string slug;
+
+	/**
+	 * @brief Optional: the application's default rich presence invite cover image hash
+	 */
+	utility::iconhash cover_image;
+
+	/**
+	 * @brief Optional: the application's public flags.
+	 */
+	uint32_t flags;
+
+	/**
+	 * @brief Optional: Approximate count of guilds the app has been added to.
+	 */
+	uint64_t approximate_guild_count;
+
+	/**
+	 * @brief Optional: Array of redirect URIs for the app.
+	 */
+	std::vector<std::string> redirect_uris;
+
+	/**
+	 * @brief Optional: Interactions endpoint URL for the app.
+	 */
+	std::string interactions_endpoint_url;
+
+	/**
+	 * @brief The application's role connection verification entry point
+	 * which, when configured, will render the app as a verification method
+	 * in the guild role verification configuration.
+	 */
+	std::string role_connections_verification_url;
+
+	/**
+	 * @brief Up to 5 tags describing the content and functionality of the application.
+	 */
+	std::vector<std::string> tags;
+
+	/**
+	 * @brief Settings for the application's default in-app authorization link, if enabled.
+	 */
+	application_install_params install_params;
+
+	/**
+	 * @brief The application's default custom authorization link, if enabled.
+	 */
+	std::string custom_install_url;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	discoverability_state;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint32_t discovery_eligibility_flags;
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	explicit_content_filter;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	creator_monetization_state;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	bool integration_public;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	bool integration_require_code_grant;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	std::vector<std::string> interactions_event_types;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	interactions_version;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	bool is_monetized;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint32_t monetization_eligibility_flags;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	monetization_state;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	bool hook;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	rpc_application_state;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	store_application_state;
+
+	/**
+	 * @warning This variable is not documented by discord, we have no idea what it means and how it works. Use at your own risk.
+	 */
+	uint8_t	verification_state;
 
 	/** Constructor */
 	application();
@@ -198,7 +458,9 @@ public:
 	std::string get_icon_url(uint16_t size = 0, const image_type format = i_png) const;
 };
 
-/** A group of applications.
+/**
+ * @brief A group of applications.
+ *
  * This is not currently ever sent by Discord API but the DPP standard setup for
  * objects that can be received by REST has the possibility for this, so this exists.
  * Don't ever expect to see one at present.

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -38,10 +38,12 @@ enum automod_preset_type : uint8_t {
 	 * @brief Strong swearing
 	 */
 	amod_preset_profanity = 1,
+
 	/**
 	 * @brief Sexual phrases and words
 	 */
 	amod_preset_sexual_content = 2,
+
 	/**
 	 * @brief Racial and other slurs, hate speech
 	 */
@@ -57,10 +59,12 @@ enum automod_action_type : uint8_t {
 	 * A custom explanation can be specified and shown to members whenever their message is blocked
 	 */
 	amod_action_block_message = 1,
+
 	/**
 	 * @brief Send an alert to a given channel
 	 */
 	amod_action_send_alert = 2,
+
 	/**
 	 * @brief timeout the user
 	 * @note Can only be set up for rules with trigger types of dpp::amod_type_keyword and dpp::amod_type_mention_spam
@@ -86,19 +90,23 @@ enum automod_trigger_type : uint8_t {
 	 * @brief Check if content contains words from a user defined list of keywords (max 6 of this type per guild)
 	 */
 	amod_type_keyword = 1,
+
 	/**
 	 * @brief Harmful/malware links
 	 * @deprecated Removed by Discord
 	 */
 	amod_type_harmful_link = 2,
+
 	/**
 	 * @brief Check if content represents generic spam (max 1 of this type per guild)
 	 */
 	amod_type_spam = 3,
+
 	/**
 	 * @brief Check if content contains words from discord pre-defined wordsets (max 1 of this type per guild)
 	 */
 	amod_type_keyword_preset = 4,
+
 	/**
 	 * @brief Check if content contains more mentions than allowed (max 1 of this type per guild)
 	 */
@@ -141,31 +149,31 @@ public:
 	 * Prefix - word must start with the keyword
 	 *
 	 * | keyword  | matches                             |
-     * |----------|-------------------------------------|
-     * | cat*     | <u><b>cat</b></u>ch, <u><b>Cat</b></u>apult, <u><b>CAt</b></u>tLE |
-     * | the mat* | <u><b>the mat</b></u>rix                      |
-     *
-     * Suffix - word must end with the keyword
-     *
-     * | keyword  | matches                  |
-     * |----------|--------------------------|
-     * | *cat     | wild<u><b>cat</b></u>, copy<u><b>Cat</b></u> |
-     * | *the mat | brea<u><b>the mat</b></u>          |
-     *
-     * Anywhere - keyword can appear anywhere in the content
-     *
-     * | keyword   | matches                     |
-     * |-----------|-----------------------------|
-     * | \*cat*     | lo<u><b>cat</b></u>ion, edu<u><b>Cat</b></u>ion |
-     * | \*the mat* | brea<u><b>the mat</b></u>ter          |
-     *
-     * Whole Word - keyword is a full word or phrase and must be surrounded by whitespace at the beginning and end
-     *
-     * | keyword | matches     |
-     * |---------|-------------|
-     * | cat     | <u><b>Cat</b></u>     |
-     * | the mat | <u><b>the mat</b></u> |
-     *
+     	 * |----------|-------------------------------------|
+     	 * | cat*     | <u><b>cat</b></u>ch, <u><b>Cat</b></u>apult, <u><b>CAt</b></u>tLE |
+     	 * | the mat* | <u><b>the mat</b></u>rix                      |
+     	 *
+     	 * Suffix - word must end with the keyword
+     	 *
+     	 * | keyword  | matches                  |
+     	 * |----------|--------------------------|
+     	 * | *cat     | wild<u><b>cat</b></u>, copy<u><b>Cat</b></u> |
+     	 * | *the mat | brea<u><b>the mat</b></u>          |
+     	 *
+     	 * Anywhere - keyword can appear anywhere in the content
+    	 *
+    	 * | keyword   | matches                     |
+    	 * |-----------|-----------------------------|
+    	 * | \*cat*     | lo<u><b>cat</b></u>ion, edu<u><b>Cat</b></u>ion |
+     	 * | \*the mat* | brea<u><b>the mat</b></u>ter          |
+     	 *
+    	 * Whole Word - keyword is a full word or phrase and must be surrounded by whitespace at the beginning and end
+    	 *
+    	 * | keyword | matches     |
+    	 * |---------|-------------|
+    	 * | cat     | <u><b>Cat</b></u>     |
+    	 * | the mat | <u><b>the mat</b></u> |
+    	 *
 	 */
 	std::vector<std::string> keywords;
 
@@ -196,31 +204,31 @@ public:
 	 * Prefix - word must start with the keyword
 	 *
 	 * | keyword  | matches                             |
-     * |----------|-------------------------------------|
-     * | cat*     | <u><b>cat</b></u>ch, <u><b>Cat</b></u>apult, <u><b>CAt</b></u>tLE |
-     * | the mat* | <u><b>the mat</b></u>rix                      |
-     *
-     * Suffix - word must end with the keyword
-     *
-     * | keyword  | matches                  |
-     * |----------|--------------------------|
-     * | *cat     | wild<u><b>cat</b></u>, copy<u><b>Cat</b></u> |
-     * | *the mat | brea<u><b>the mat</b></u>          |
-     *
-     * Anywhere - keyword can appear anywhere in the content
-     *
-     * | keyword   | matches                     |
-     * |-----------|-----------------------------|
-     * | \*cat*     | lo<u><b>cat</b></u>ion, edu<u><b>Cat</b></u>ion |
-     * | \*the mat* | brea<u><b>the mat</b></u>ter          |
-     *
-     * Whole Word - keyword is a full word or phrase and must be surrounded by whitespace at the beginning and end
-     *
-     * | keyword | matches     |
-     * |---------|-------------|
-     * | cat     | <u><b>Cat</b></u>     |
-     * | the mat | <u><b>the mat</b></u> |
-     *
+     	 * |----------|-------------------------------------|
+     	 * | cat*     | <u><b>cat</b></u>ch, <u><b>Cat</b></u>apult, <u><b>CAt</b></u>tLE |
+     	 * | the mat* | <u><b>the mat</b></u>rix                      |
+     	 *
+     	 * Suffix - word must end with the keyword
+     	 *
+     	 * | keyword  | matches                  |
+     	 * |----------|--------------------------|
+     	 * | *cat     | wild<u><b>cat</b></u>, copy<u><b>Cat</b></u> |
+     	 * | *the mat | brea<u><b>the mat</b></u>          |
+     	 *
+     	 * Anywhere - keyword can appear anywhere in the content
+     	 *
+     	 * | keyword   | matches                     |
+     	 * |-----------|-----------------------------|
+     	 * | \*cat*     | lo<u><b>cat</b></u>ion, edu<u><b>Cat</b></u>ion |
+     	 * | \*the mat* | brea<u><b>the mat</b></u>ter          |
+     	 *
+     	 * Whole Word - keyword is a full word or phrase and must be surrounded by whitespace at the beginning and end
+     	 *
+     	 * | keyword | matches     |
+     	 * |---------|-------------|
+     	 * | cat     | <u><b>Cat</b></u>     |
+     	 * | the mat | <u><b>the mat</b></u> |
+     	 *
 	 */
 	std::vector<std::string> allow_list;
 
@@ -326,42 +334,52 @@ public:
 	 * @brief the id of this rule
 	 */
 	snowflake       	id;
+
 	/**
 	 * @brief the guild which this rule belongs to
 	 */
 	snowflake       	guild_id;
+
 	/**
 	 * @brief the rule name
 	 */
 	std::string     	name;
+
 	/**
 	 * @brief The user which first created this rule
 	 */
 	snowflake       	creator_id;
+
 	/**
 	 * @brief The rule event type
 	 */
 	automod_event_type	event_type;
+
 	/**
 	 * @brief The rule trigger type
 	 */
 	automod_trigger_type	trigger_type;
+
 	/**
 	 * @brief The rule trigger metadata
 	 */
 	automod_metadata	trigger_metadata;
+
 	/**
 	 * @brief the actions which will execute when the rule is triggered
 	 */
 	std::vector<automod_action> actions;
+
 	/**
 	 * @brief Whether the rule is enabled
 	 */
 	bool			enabled;
+
 	/**
 	 * @brief the role ids that should not be affected by the rule (Maximum of 20)
 	 */
 	std::vector<snowflake>	exempt_roles;
+
 	/**
 	 * @brief the channel ids that should not be affected by the rule (Maximum of 50)
 	 */

--- a/include/dpp/ban.h
+++ b/include/dpp/ban.h
@@ -44,9 +44,14 @@ protected:
 	ban& fill_from_json_impl(nlohmann::json* j);
 
 public:
-	/** The ban reason */
+	/**
+	 * @brief The ban reason.
+	 */
 	std::string reason;
-	/** User ID the ban applies to */
+
+	/**
+	 * @brief User ID the ban applies to.
+	 */
 	snowflake user_id;
 
 	/** Constructor */
@@ -57,7 +62,7 @@ public:
 };
 
 /**
- * A group of bans. The key is the user ID
+ * @brief A group of bans. The key is the user ID.
  */
 typedef std::unordered_map<snowflake, ban> ban_map;
 

--- a/include/dpp/cache.h
+++ b/include/dpp/cache.h
@@ -65,7 +65,7 @@ public:
 	/**
 	 * @brief Construct a new cache object.
 	 * 
-	 * Caches must contain classes derived from dpp::managed.
+	 * @note Caches must contain classes derived from dpp::managed.
 	 */
 	cache() {
 		cache_map = new std::unordered_map<snowflake, T*>;
@@ -255,7 +255,8 @@ public:
 
 };
 
-/** Run garbage collection across all caches removing deleted items
+/**
+ * Run garbage collection across all caches removing deleted items
  * that have been deleted over 60 seconds ago.
  */
 void DPP_EXPORT garbage_collection();

--- a/include/dpp/coro/async.h
+++ b/include/dpp/coro/async.h
@@ -56,39 +56,54 @@ namespace async {
  * @brief Represents the step an std::async is at.
  */
 enum class state_t {
-	sent, /* Request was sent but not co_await-ed. handle is nullptr, result_storage is not constructed */
-	waiting, /* Request was co_await-ed. handle is valid, result_storage is not constructed */
-	done, /* Request was completed. handle is unknown, result_storage is valid */
-	dangling /* Request was never co_await-ed. */
+	/**
+	 * @brief Request was sent but not co_await-ed. handle is nullptr, result_storage is not constructed.
+	 */
+	sent,
+
+	/**
+	 * @brief Request was co_await-ed. handle is valid, result_storage is not constructed.
+	 */
+	waiting,
+
+	/**
+	 * @brief Request was completed. handle is unknown, result_storage is valid.
+	 */
+	done,
+
+	/**
+	 * @brief Request was never co_await-ed.
+	 */
+	dangling
 };
 
 /**
-	* @brief State of the async and its callback.
-	*
-	* Defined outside of dpp::async because this seems to work better with Intellisense.
-	*/
+ * @brief State of the async and its callback.
+ *
+ * Defined outside of dpp::async because this seems to work better with Intellisense.
+ */
 template <typename R>
 struct async_callback_data {
 	/**
-		* @brief Number of references to this callback state.
-		*/
+	 * @brief Number of references to this callback state.
+	 */
 	std::atomic<int> ref_count{1};
 
 	/**
-		* @brief State of the awaitable and the API callback
-		*/
+	 * @brief State of the awaitable and the API callback
+	 */
 	std::atomic<state_t> state = state_t::sent;
 
 	/**
-		* @brief The stored result of the API call, stored as an array of bytes to directly construct in place
-		*/
+	 * @brief The stored result of the API call, stored as an array of bytes to directly construct in place
+	 */
 	alignas(R) std::array<std::byte, sizeof(R)> result_storage;
 
 	/**
-		* @brief Handle to the coroutine co_await-ing on this API call
-		*
-		* @see <a href="https://en.cppreference.com/w/cpp/coroutine/coroutine_handle">std::coroutine_handle</a>
-		*/
+	 * @brief Handle to the coroutine co_await-ing on this API call
+	 *
+	 * @see <a href="https://en.cppreference.com/w/cpp/coroutine/coroutine_handle">std::coroutine_handle</a>
+	 */
 	std_coroutine::coroutine_handle<> coro_handle = nullptr;
 
 	/**
@@ -374,7 +389,8 @@ public:
 
 struct confirmation_callback_t;
 
-/** @class async async.h coro/async.h
+/**
+ * @class async async.h coro/async.h
  * @brief A co_await-able object handling an API call in parallel with the caller.
  *
  * This class is the return type of the dpp::cluster::co_* methods, but it can also be created manually to wrap any async call.

--- a/include/dpp/coro/coro.h
+++ b/include/dpp/coro/coro.h
@@ -45,17 +45,17 @@ namespace std {
 namespace dpp {
 
 /**
-	* @brief Implementation details for internal use only.
-	*
-	* @attention This is only meant to be used by D++ internally. Support will not be given regarding the facilities in this namespace.
-	*/
+ * @brief Implementation details for internal use only.
+ *
+ * @attention This is only meant to be used by D++ internally. Support will not be given regarding the facilities in this namespace.
+ */
 namespace detail {
 #ifdef _DOXYGEN_
 /**
-	* @brief Alias for either std or std::experimental depending on compiler and library. Used by coroutine implementation.
-	*
-	* @todo Remove and use std when all supported libraries have coroutines in it
-	*/
+ * @brief Alias for either std or std::experimental depending on compiler and library. Used by coroutine implementation.
+ *
+ * @todo Remove and use std when all supported libraries have coroutines in it
+ */
 namespace std_coroutine {}
 #else
 #  ifdef STDCORO_EXPERIMENTAL_NAMESPACE

--- a/include/dpp/coro/coroutine.h
+++ b/include/dpp/coro/coroutine.h
@@ -51,8 +51,8 @@ struct promise_t;
 
 template <typename R>
 /**
-	* @brief Alias for the handle_t of a coroutine.
-	*/
+ * @brief Alias for the handle_t of a coroutine.
+ */
 using handle_t = std_coroutine::coroutine_handle<promise_t<R>>;
 
 /**
@@ -188,7 +188,8 @@ public:
 
 } // namespace detail
 
-/** @class coroutine coroutine.h coro/coroutine.h
+/**
+ * @class coroutine coroutine.h coro/coroutine.h
  * @brief Base type for a coroutine, starts on co_await.
  *
  * @warning - This feature is EXPERIMENTAL. The API may change at any time and there may be bugs.

--- a/include/dpp/coro/job.h
+++ b/include/dpp/coro/job.h
@@ -38,7 +38,8 @@ struct job_dummy {
 
 namespace dpp {
 
-/** @class job job.h coro/job.h
+/**
+ * @class job job.h coro/job.h
  * @brief Extremely light coroutine object designed to send off a coroutine to execute on its own.
  * Can be used in conjunction with coroutine events via @ref dpp::event_router_t::operator()(F&&) "event routers", or on its own.
  *
@@ -78,20 +79,20 @@ struct promise {
 	}
 #endif
 
-	/*
-	* @brief Function called when the job is done.
-	*
-	* @return <a href="https://en.cppreference.com/w/cpp/coroutine/suspend_never">std::suspend_never</a> Do not suspend at the end, destroying the handle immediately
-	*/
+	/**
+	 * @brief Function called when the job is done.
+	 *
+	 * @return <a href="https://en.cppreference.com/w/cpp/coroutine/suspend_never">std::suspend_never</a> Do not suspend at the end, destroying the handle immediately
+	 */
 	std_coroutine::suspend_never final_suspend() const noexcept {
 		return {};
 	}
 
-	/*
-	* @brief Function called when the job is started.
-	*
-	* @return <a href="https://en.cppreference.com/w/cpp/coroutine/suspend_never">std::suspend_never</a> Do not suspend at the start, starting the job immediately
-	*/
+	/**
+	 * @brief Function called when the job is started.
+	 *
+	 * @return <a href="https://en.cppreference.com/w/cpp/coroutine/suspend_never">std::suspend_never</a> Do not suspend at the start, starting the job immediately
+	 */
 	std_coroutine::suspend_never initial_suspend() const noexcept {
 		return {};
 	}

--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -51,15 +51,25 @@ namespace detail {
 /* Internal cogwheels for dpp::task */
 namespace task {
 
-/** @brief State of a task */
+/**
+ * @brief State of a task
+ */
 enum class state_t {
-	/** @brief Task was started but never co_await-ed */
+	/**
+	 * @brief Task was started but never co_await-ed
+	 */
 	started,
-	/** @brief Task was co_await-ed and is pending completion */
+	/**
+	 * @brief Task was co_await-ed and is pending completion
+	 */
 	awaited,
-	/** @brief Task is completed */
+	/**
+	 * @brief Task is completed
+	 */
 	done,
-	/** @brief Task is still running but the actual dpp::task object is destroyed */
+	/**
+	 * @brief Task is still running but the actual dpp::task object is destroyed
+	 */
 	dangling
 };
 
@@ -261,7 +271,8 @@ public:
 
 } // namespace detail
 
-/** @class task task.h coro/task.h
+/**
+ * @class task task.h coro/task.h
  * @brief A coroutine task. It starts immediately on construction and can be co_await-ed, making it perfect for parallel coroutines returning a value.
  *
  * @warning - This feature is EXPERIMENTAL. The API may change at any time and there may be bugs.
@@ -487,7 +498,7 @@ public:
 #endif /* _DOXYGEN_ */
 
 namespace detail::task {
-	/**
+/**
  * @brief Awaitable returned from task::promise_t's final_suspend. Resumes the parent and cleans up its handle if needed
  */
 template <typename R>
@@ -499,7 +510,7 @@ struct final_awaiter {
 		return (false);
 	}
 
-	/*
+	/**
 	 * @brief The suspension logic of the coroutine when it finishes. Always suspend the caller, meaning cleaning up the handle is on us
 	 *
 	 * @param handle The handle of this coroutine
@@ -507,7 +518,7 @@ struct final_awaiter {
 	 */
 	[[nodiscard]] std_coroutine::coroutine_handle<> await_suspend(handle_t<R> handle) const noexcept;
 
-	/*
+	/**
 	 * @brief Function called when this object is co_awaited by the standard library at the end of final_suspend. Do nothing, return nothing
 	 */
 	void await_resume() const noexcept {}

--- a/include/dpp/coro/when_any.h
+++ b/include/dpp/coro/when_any.h
@@ -45,18 +45,30 @@ class awaitable;
 
 }
 
-/** @brief Internal cogwheels for dpp::when_any */
+/**
+ * @brief Internal cogwheels for dpp::when_any
+ */
 namespace when_any {
 
-/** @brief Current state of a when_any object */
+/**
+ * @brief Current state of a when_any object
+ */
 enum class await_state {
-	/** @brief Object was started but not awaited */
+	/**
+	 * @brief Object was started but not awaited
+	 */
 	started,
-	/** @brief Object is being awaited */
+	/**
+	 * @brief Object is being awaited
+	 */
 	waiting,
-	/** @brief Object was resumed*/
+	/**
+	 * @brief Object was resumed
+	 */
 	done,
-	/** @brief Object was destroyed */
+	/**
+	 * @brief Object was destroyed
+	 */
 	dangling
 };
 
@@ -102,14 +114,20 @@ using awaitable_type = typename arg_helper_s<T>::type;
 template <typename T>
 using arg_helper = arg_helper_s<std::remove_cvref_t<T>>;
 
-/** @brief Empty result from void-returning awaitable */
+/**
+ * @brief Empty result from void-returning awaitable
+ */
 struct empty{};
 
-/** @brief Actual type a result will be stores as in when_any */
+/**
+ * @brief Actual type a result will be stores as in when_any
+ */
 template <typename T>
 using storage_type = std::conditional_t<std::is_void_v<T>, empty, T>;
 
-/** @brief Concept satisfied if a stored result is void */
+/**
+ * @brief Concept satisfied if a stored result is void
+ */
 template <typename T>
 concept void_result = std::same_as<T, empty>;
 
@@ -117,7 +135,8 @@ concept void_result = std::same_as<T, empty>;
 
 } // namespace detail
 
-/** @class when_any when_any.h coro/when_any.h
+/**
+ * @class when_any when_any.h coro/when_any.h
  * @brief Experimental class to co_await on a bunch of awaitable objects, resuming when the first one completes.
  * On completion, returns a @ref result object that contains the index of the awaitable that finished first.
  * A user can call @ref result::index() and @ref result::get<N>() on the result object to get the result, similar to std::variant.
@@ -130,7 +149,9 @@ template <typename... Args>
 requires (sizeof...(Args) >= 1)
 #endif
 class when_any {
-	/** @brief Alias for the type of the result variant */
+	/**
+	 * @brief Alias for the type of the result variant
+	 */
 	using variant_type = std::variant<std::exception_ptr, std::remove_cvref_t<detail::when_any::storage_type<detail::awaitable_result<Args>>>...>;
 
 	/**
@@ -193,9 +214,9 @@ class when_any {
 	template <size_t N>
 	static dpp::job make_job(std::shared_ptr<state_t> shared_state) {
 		/**
-			* Any exceptions from the awaitable's await_suspend should be thrown to the caller (the coroutine creating the when_any object)
-			* If the co_await passes, and it is the first one to complete, try construct the result, catch any exceptions to rethrow at resumption, and resume.
-			*/
+		 * Any exceptions from the awaitable's await_suspend should be thrown to the caller (the coroutine creating the when_any object)
+		 * If the co_await passes, and it is the first one to complete, try construct the result, catch any exceptions to rethrow at resumption, and resume.
+		 */
 		if constexpr (!std::same_as<result_t<N>, detail::when_any::empty>) {
 			decltype(auto) result = co_await std::get<N>(shared_state->awaitables);
 
@@ -236,7 +257,8 @@ class when_any {
 	}
 
 	/**
-	 * @brief Spawn a dpp::job to handle each awaitable. Each of them will co_await the awaitable and set the result if they are the first to finish
+	 * @brief Spawn a dpp::job to handle each awaitable.
+	 * Each of them will co_await the awaitable and set the result if they are the first to finish
 	 */
 	void make_jobs() {
 		[]<size_t... Ns>(when_any *self, std::index_sequence<Ns...>) {
@@ -251,26 +273,40 @@ public:
 	class result {
 		friend class when_any<Args...>;
 
-		/** @brief Reference to the shared state to pull the data from */
+		/**
+		 * @brief Reference to the shared state to pull the data from
+		 */
 		std::shared_ptr<state_t> shared_state;
 
-		/** @brief Default construction is deleted */
+		/**
+		 * @brief Default construction is deleted
+		 */
 		result() = delete;
 
-		/** @brief Internal constructor taking the shared state */
+		/**
+		 * @brief Internal constructor taking the shared state
+		 */
 		result(std::shared_ptr<state_t> state) : shared_state{state} {}
 
 	public:
-		/** @brief Move constructor */
+		/**
+		 * @brief Move constructor
+		 */
 		result(result&&) = default;
 
-		/** @brief This object is not copyable. */
+		/**
+		 * @brief This object is not copyable.
+		 */
 		result(const result &) = delete;
 
-		/** @brief Move assignment operator */
+		/**
+		 * @brief Move assignment operator
+		 */
 		result &operator=(result&&) = default;
 
-		/** @brief This object is not copyable. */
+		/**
+		 * @brief This object is not copyable.
+		 */
 		result &operator=(const result&) = delete;
 
 		/**
@@ -361,7 +397,9 @@ public:
 	 * @see result
 	 */
 	struct awaiter {
-		/** @brief Pointer to the when_any object */
+		/**
+		 * @brief Pointer to the when_any object
+		 */
 		when_any *self;
 
 		/**
@@ -394,7 +432,10 @@ public:
 		}
 	};
 
-	/** @brief Default constructor. A when_any object created this way holds no state */
+	/**
+	 * @brief Default constructor.
+	 * A when_any object created this way holds no state
+	 */
 	when_any() = default;
 
 	/**
@@ -411,10 +452,14 @@ public:
 		make_jobs();
 	}
 
-	/** @brief This object is not copyable. */
+	/**
+	 * @brief This object is not copyable.
+	 */
 	when_any(const when_any &) = delete;
 
-	/** @brief Move constructor. */
+	/**
+	 * @brief Move constructor.
+	 */
 	when_any(when_any &&) noexcept = default;
 
 	/**
@@ -444,10 +489,14 @@ public:
 		}(this, std::index_sequence_for<Args...>());
 	}
 
-	/** @brief This object is not copyable. */
+	/**
+	 * @brief This object is not copyable.
+	 */
 	when_any &operator=(const when_any &) = delete;
 
-	/** @brief Move assignment operator. */
+	/**
+	 * @brief Move assignment operator.
+	 */
 	when_any &operator=(when_any &&) noexcept = default;
 
 	/**

--- a/include/dpp/sku.h
+++ b/include/dpp/sku.h
@@ -38,6 +38,7 @@ enum sku_type : uint8_t {
 	 * @brief Represents a recurring subscription
 	 */
 	SUBSCRIPTION = 5,
+
 	/**
 	 * @brief System-generated group for each SUBSCRIPTION SKU created
 	 * @warning These are automatically created for each subscription SKU and are not used at this time. Please refrain from using these.
@@ -53,10 +54,12 @@ enum sku_flags : uint16_t {
 	 * @brief SKU is available for purchase
 	 */
 	sku_available =			0b000000000000100,
+
 	/**
 	 * @brief Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server.
 	 */
 	sku_guild_subscription = 	0b000000010000000,
+
 	/**
 	 * @brief Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server.
 	 */

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -37,6 +37,7 @@ enum websocket_protocol_t : uint8_t {
 	 * @brief JSON data, text, UTF-8 character set
 	 */
 	ws_json = 0,
+	
 	/**
 	 * @brief Erlang Term Format (ETF) binary protocol
 	 */
@@ -65,12 +66,35 @@ enum ws_state : uint8_t {
  */
 enum ws_opcode : uint8_t
 {
-        OP_CONTINUATION = 0x00,	//!< Continuation
-        OP_TEXT = 0x01,		//!< Text frame
-        OP_BINARY = 0x02,	//!< Binary frame
-        OP_CLOSE = 0x08,	//!< Close notification with close code
-        OP_PING = 0x09,		//!< Low level ping
-        OP_PONG = 0x0a		//!< Low level pong
+	/**
+	 * @brief Continuation.
+	 */
+        OP_CONTINUATION = 0x00,
+
+	/**
+	 * @brief Text frame.
+	 */
+        OP_TEXT = 0x01,
+
+	/**
+	 * @brief Binary frame.
+	 */
+        OP_BINARY = 0x02,
+
+	/**
+	 * @brief Close notification with close code.
+	 */
+        OP_CLOSE = 0x08,
+
+	/**
+	 * @brief Low level ping.
+	 */
+        OP_PING = 0x09,
+
+	/**
+	 * @brief Low level pong.
+	 */
+        OP_PONG = 0x0a
 };
 
 /**


### PR DESCRIPTION
This PR refactors several files to follow the comments standard, as we discussed in Discord that many files didn't (they were doing `//!<` or `///`).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
