### PR TITLE
fix: integer autocompletes no longer cause crash

### DIFF
--- a/src/dpp/events/interaction_create.cpp
+++ b/src/dpp/events/interaction_create.cpp
@@ -37,23 +37,31 @@ void fill_options(dpp::json option_json, std::vector<dpp::command_option>& optio
 		opt.type = (dpp::command_option_type)int8_not_null(&o, "type");
 		switch (opt.type) {
 			case co_boolean:
-				opt.value = o.at("value").get<bool>();
+				if(o.at("value").is_boolean()) {
+					opt.value = o.at("value").get<bool>();
+				}
 				break;
 			case co_channel:
 			case co_role:
-			case co_user:
 			case co_attachment:
+			case co_user:
 			case co_mentionable:
 				opt.value = dpp::snowflake(snowflake_not_null(&o, "value"));
 				break;
 			case co_integer:
-				opt.value = o.at("value").get<int64_t>();
+				if(o.at("value").is_number_integer()) {
+					opt.value = o.at("value").get<int64_t>();
+				}
 				break;
 			case co_string:
-				opt.value = o.at("value").get<std::string>();
+				if(o.at("value").is_string()) {
+					opt.value = o.at("value").get<std::string>();
+				}
 				break;
 			case co_number:
-				opt.value = o.at("value").get<double>();
+				if(o.at("value").is_number_float()) {
+					opt.value = o.at("value").get<double>();
+				}
 				break;
 			case co_sub_command:
 			case co_sub_command_group:

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -521,7 +521,9 @@ void from_json(const nlohmann::json& j, command_data_option& cdo) {
 	if (j.contains("value") && !j.at("value").is_null()) {
 		switch (cdo.type) {
 			case co_boolean:
-				cdo.value = j.at("value").get<bool>();
+				if(j.at("value").is_boolean()) {
+					cdo.value = j.at("value").get<bool>();
+				}
 				break;
 			case co_channel:
 			case co_role:
@@ -531,13 +533,19 @@ void from_json(const nlohmann::json& j, command_data_option& cdo) {
 				cdo.value = dpp::snowflake(snowflake_not_null(&j, "value"));
 				break;
 			case co_integer:
-				cdo.value = j.at("value").get<int64_t>();
+				if(j.at("value").is_number_integer()) {
+					cdo.value = j.at("value").get<int64_t>();
+				}
 				break;
 			case co_string:
-				cdo.value = j.at("value").get<std::string>();
+				if(j.at("value").is_string()) {
+					cdo.value = j.at("value").get<std::string>();
+				}
 				break;
 			case co_number:
-				cdo.value = j.at("value").get<double>();
+				if(j.at("value").is_number_float()) {
+					cdo.value = j.at("value").get<double>();
+				}
 				break;
 			case co_sub_command:
 			case co_sub_command_group:


### PR DESCRIPTION
This PR fixes #962, checking if a value from an autocomplete is actually what we expect it to be, rather than unsafely assuming. This caused a crash because discord sends `""` upon `on_autocomplete` (no data), however, because the type is int, it can't convert to int so it throws instead. This no longer happens and we now just don't bother with the set if the type doesn't match.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
