### PR TITLE
fix: add maybe_unused to build_type constexpr to squash warning

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -63,9 +63,9 @@ template<typename T> std::function<void(const T&)> make_intent_warning(cluster* 
 template <build_type BuildType>
 bool validate_configuration() {
 #ifdef _DEBUG
-	constexpr build_type expected = build_type::debug;
+	[[maybe_unused]] constexpr build_type expected = build_type::debug;
 #else
-	constexpr build_type expected = build_type::release;
+	[[maybe_unused]] constexpr build_type expected = build_type::release;
 #endif
 #ifdef _WIN32
 	if constexpr (BuildType != build_type::universal && BuildType != expected) {


### PR DESCRIPTION
## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
