### PR TITLE
fix: voiceregion now fills correctly, removed VIP from regions.

### DIFF
--- a/include/dpp/voiceregion.h
+++ b/include/dpp/voiceregion.h
@@ -44,14 +44,7 @@ enum voiceregion_flags {
 	/**
 	 * @brief A custom voice region (used for events/etc).
 	 */
-	v_custom = 0x00000100,
-
-	/**
-	 * @brief A VIP voice server.
-	 *
-	 * @warning This is undocumented by Discord and may not even exist anymore.
-	 */
-	v_vip = 0x00001000
+	v_custom = 0x00000100
 };
 
 /**
@@ -123,13 +116,6 @@ public:
 	 * @return true if custom
 	 */
 	bool is_custom() const;
-
-	/**
-	 * @brief True if is a VIP voice server
-	 * 
-	 * @return true if VIP 
-	 */
-	bool is_vip() const;
 };
 
 /**

--- a/src/dpp/voiceregion.cpp
+++ b/src/dpp/voiceregion.cpp
@@ -32,20 +32,21 @@ voiceregion::voiceregion() : flags(0)
 }
 
 voiceregion& voiceregion::fill_from_json_impl(nlohmann::json* j) {
-	id = string_not_null(j, "id");
-	name = string_not_null(j, "id");
+	set_string_not_null(j, "id", id);
+	set_string_not_null(j, "name", name);
+
 	if (bool_not_null(j, "optimal")) {
 		flags |= v_optimal;
 	}
+
 	if (bool_not_null(j, "deprecated")) {
 		flags |= v_deprecated;
 	}
+
 	if (bool_not_null(j, "custom")) {
 		flags |= v_custom;
 	}
-	if (bool_not_null(j, "vip")) {
-		flags |= v_vip;
-	}
+
 	return *this;
 }
 
@@ -55,8 +56,7 @@ json voiceregion::to_json_impl(bool with_id) const {
 		{ "name", name },
 		{ "optimal", is_optimal() },
 		{ "deprecated", is_deprecated() },
-		{ "custom", is_custom() },
-		{ "vip", is_vip() }
+		{ "custom", is_custom() }
 	};
 }
 
@@ -71,11 +71,6 @@ bool voiceregion::is_deprecated() const {
 bool voiceregion::is_custom() const {
 	return flags & v_custom;
 }
-
-bool voiceregion::is_vip() const {
-	return flags & v_vip;
-}
-
 
 } // namespace dpp
 


### PR DESCRIPTION
This PR fixes voiceregion, now filling it from json correctly. It also removes `VIP` from voiceregion as that was removed a while ago and replaced with `VIP_REGIONS` in a guild object (meaning guilds can set bitrate to 384kbps).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
