### PR TITLE
refactor: changed the way messages holds files

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1372,7 +1372,7 @@ public:
 	 * @param filecontent List of file content to post for POST requests (for uploading files)
 	 * @param filemimetypes List of mime types for each file to post for POST requests (for uploading files)
 	 */
-	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename = {}, const std::vector<std::string>& filecontent = {}, const std::vector<std::string>& filemimetypes = {});
+	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<message_file_data> &file_data = {});
 
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asynchronous access to HTTP APIs outside of Discord.

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1368,9 +1368,7 @@ public:
 	 * @param method Method, e.g. GET, POST
 	 * @param postdata Post data (usually JSON encoded)
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
-	 * @param filename List of filenames to post for POST requests (for uploading files)
-	 * @param filecontent List of file content to post for POST requests (for uploading files)
-	 * @param filemimetypes List of mime types for each file to post for POST requests (for uploading files)
+	 * @param file_data List of files to post for POST requests (for uploading files)
 	 */
 	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<message_file_data> &file_data = {});
 

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -115,6 +115,30 @@ struct component_emoji {
 };
 
 /**
+ * @brief The data for a file attached to a message.
+ *
+ * @todo Change the naming of this and make stickers (and potentially anything else that has data like this) use this.
+ */
+struct message_file_data {
+	/**
+	 * @brief Name of file to upload (for use server-side in discord's url).
+	 */
+	std::string name{};
+
+	/**
+	 * @brief File content to upload (raw binary)
+	 */
+	std::string content{};
+
+	/**
+	 * @brief Mime type of files to upload.
+	 *
+	 * @todo Look at turning this into an enum? This would allow people to easily compare mimetypes if they happen to change.
+	 */
+	std::string mimetype{};
+};
+
+/**
  * @brief Types of text input
  */
 enum text_style_type : uint8_t {
@@ -1709,26 +1733,6 @@ namespace cache_policy {
 };
 
 /**
- * @brief The data for a file.
- */
-struct message_file_data {
-	/**
-	 * @brief Name of file to upload (for use server-side in discord's url).
-	 */
-	std::string name{};
-
-	/**
-	 * @brief File content to upload (raw binary)
-	 */
-	std::string content{};
-
-	/**
-	 * @brief Mime type of files to upload.
-	 */
-	std::string mimetype{};
-};
-
-/**
  * @brief Represents messages sent and received on Discord
  */
 struct DPP_EXPORT message : public managed, json_interface<message> {
@@ -1848,7 +1852,9 @@ public:
 	std::vector<sticker> stickers;
 
 	/**
-	 * @brief An array of file data.
+	 * @brief An array of file data to use for uploading files.
+	 *
+	 * @note You should use dpp::message::add_file to add data to this!
 	 */
 	std::vector<message_file_data> file_data;
 

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1709,6 +1709,26 @@ namespace cache_policy {
 };
 
 /**
+ * @brief The data for a file.
+ */
+struct message_file_data {
+	/**
+	 * @brief Name of file to upload (for use server-side in discord's url).
+	 */
+	std::string name{};
+
+	/**
+	 * @brief File content to upload (raw binary)
+	 */
+	std::string content{};
+
+	/**
+	 * @brief Mime type of files to upload.
+	 */
+	std::string mimetype{};
+};
+
+/**
  * @brief Represents messages sent and received on Discord
  */
 struct DPP_EXPORT message : public managed, json_interface<message> {
@@ -1828,19 +1848,9 @@ public:
 	std::vector<sticker> stickers;
 
 	/**
-	 * @brief Name of file to upload (for use server-side in discord's url).
+	 * @brief An array of file data.
 	 */
-	std::vector<std::string> filename;
-
-	/**
-	 * @brief File content to upload (raw binary)
-	 */
-	std::vector<std::string> filecontent;
-
-	/**
-	 * @brief Mime type of files to upload.
-	 */
-	std::vector<std::string> filemimetype;
+	std::vector<message_file_data> file_data;
 
 	/**
 	 * @brief Reference to another message, e.g. a reply

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -339,7 +339,17 @@ void cluster::post_rest(const std::string &endpoint, const std::string &major_pa
 	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetype, protocol));
 }
 
-void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<std::string> &filename, const std::vector<std::string> &filecontent, const std::vector<std::string> &filemimetypes) {
+void cluster::post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<message_file_data> &file_data) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(const message_file_data& data : file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	/* NOTE: This is not a memory leak! The request_queue will free the http_request once it reaches the end of its lifecycle */
 	rest->post_request(new http_request(endpoint + (!major_parameters.empty() ? "/" : "") + major_parameters, parameters, [endpoint, callback](http_request_completion_t rv) {
 		json j;
@@ -354,7 +364,7 @@ void cluster::post_rest_multipart(const std::string &endpoint, const std::string
 		if (callback) {
 			callback(j, rv);
 		}
-	}, postdata, method, get_audit_reason(), filename, filecontent, filemimetypes));
+	}, postdata, method, get_audit_reason(), file_names, file_contents, file_mimetypes));
 }
 
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -136,39 +136,19 @@ void cluster::guild_commands_get(snowflake guild_id, command_completion_event_t 
 }
 
 void cluster::interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : r.msg.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/interactions", std::to_string(interaction_id), utility::url_encode(token) + "/callback", m_post, r.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, r.msg.file_data);
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::interaction_response_get_original(const std::string &token, command_completion_event_t callback) {
@@ -176,39 +156,19 @@ void cluster::interaction_response_get_original(const std::string &token, comman
 }
 
 void cluster::interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token), m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::interaction_followup_delete(const std::string &token, command_completion_event_t callback) {
@@ -216,21 +176,11 @@ void cluster::interaction_followup_delete(const std::string &token, command_comp
 }
 
 void cluster::interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/" + std::to_string(m.id), m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -136,19 +136,39 @@ void cluster::guild_commands_get(snowflake guild_id, command_completion_event_t 
 }
 
 void cluster::interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : r.msg.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/interactions", std::to_string(interaction_id), utility::url_encode(token) + "/callback", m_post, r.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, r.msg.filename, r.msg.filecontent, r.msg.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::interaction_response_get_original(const std::string &token, command_completion_event_t callback) {
@@ -156,19 +176,39 @@ void cluster::interaction_response_get_original(const std::string &token, comman
 }
 
 void cluster::interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token), m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::interaction_followup_delete(const std::string &token, command_completion_event_t callback) {
@@ -176,11 +216,21 @@ void cluster::interaction_followup_delete(const std::string &token, command_comp
 }
 
 void cluster::interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/" + std::to_string(m.id), m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -36,11 +36,21 @@ void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, c
 
 
 void cluster::message_create(const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages", m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 
@@ -112,11 +122,21 @@ void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake chan
 
 
 void cluster::message_edit(const message &m, command_completion_event_t callback) {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, m.build_json(true), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -36,21 +36,11 @@ void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, c
 
 
 void cluster::message_create(const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages", m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 
@@ -122,21 +112,11 @@ void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake chan
 
 
 void cluster::message_edit(const message &m, command_completion_event_t callback) {
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, m.build_json(true), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -111,6 +111,17 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			j["auto_archive_duration"] = 10080;
 			break;
 	}
+
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : msg.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			auto t = thread().fill_from_json(&j);
@@ -122,7 +133,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			}
 			callback(confirmation_callback_t(this, t, http));
 		}
-	}, msg.filename, msg.filecontent, msg.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -112,16 +112,6 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			break;
 	}
 
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : msg.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			auto t = thread().fill_from_json(&j);
@@ -133,7 +123,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			}
 			callback(confirmation_callback_t(this, t, http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, msg.file_data);
 }
 
 void cluster::thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -50,11 +50,22 @@ void cluster::edit_webhook_message(const class webhook &wh, const struct message
 	std::string parameters = utility::make_url_parameters({
 		{"thread_id", thread_id},
 	});
+
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(m.id) + parameters, m_patch, m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::edit_webhook_with_token(const class webhook& wh, command_completion_event_t callback) {
@@ -84,11 +95,22 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		}
 		body = j.dump();
 	}
+
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token : token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void cluster::get_channel_webhooks(snowflake channel_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -96,21 +96,11 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		body = j.dump();
 	}
 
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token : token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::get_channel_webhooks(snowflake channel_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -51,21 +51,11 @@ void cluster::edit_webhook_message(const class webhook &wh, const struct message
 		{"thread_id", thread_id},
 	});
 
-	std::vector<std::string> file_names{};
-	std::vector<std::string> file_contents{};
-	std::vector<std::string> file_mimetypes{};
-
-	for(message_file_data data : m.file_data) {
-		file_names.push_back(data.name);
-		file_contents.push_back(data.content);
-		file_mimetypes.push_back(data.mimetype);
-	}
-
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(m.id) + parameters, m_patch, m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void cluster::edit_webhook_with_token(const class webhook& wh, command_completion_event_t callback) {

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -176,7 +176,7 @@ void interaction_create_t::edit_original_response(const message& m, command_comp
 		if (cb) {
 			cb(confirmation_callback_t(creator, message().fill_from_json(&j), http));
 		}
-	}, file_names, file_contents, file_mimetypes);
+	}, m.file_data);
 }
 
 void interaction_create_t::delete_original_response(command_completion_event_t callback) const {

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -162,11 +162,21 @@ void interaction_create_t::get_original_response(command_completion_event_t call
 }
 
 void interaction_create_t::edit_original_response(const message& m, command_completion_event_t callback) const {
+	std::vector<std::string> file_names{};
+	std::vector<std::string> file_contents{};
+	std::vector<std::string> file_mimetypes{};
+
+	for(message_file_data data : m.file_data) {
+		file_names.push_back(data.name);
+		file_contents.push_back(data.content);
+		file_mimetypes.push_back(data.mimetype);
+	}
+
 	from->creator->post_rest_multipart(API_PATH "/webhooks", std::to_string(command.application_id), command.token + "/messages/@original", m_patch, m.build_json(), [creator = this->from->creator, cb = std::move(callback)](json& j, const http_request_completion_t& http) {
 		if (cb) {
 			cb(confirmation_callback_t(creator, message().fill_from_json(&j), http));
 		}
-	}, m.filename, m.filecontent, m.filemimetype);
+	}, file_names, file_contents, file_mimetypes);
 }
 
 void interaction_create_t::delete_original_response(command_completion_event_t callback) const {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -559,30 +559,39 @@ message& message::set_type(message_type t)
 	return *this;
 }
 
-message& message::set_filename(const std::string &fn)
-{
-	if (filename.empty()) {
-		filename.push_back(fn);
+message& message::set_filename(const std::string &fn) {
+	if (file_data.empty()) {
+		message_file_data data;
+		data.name = fn;
+
+		file_data.push_back(data);
 	} else {
-		filename[filename.size() - 1] = fn;
+		file_data[file_data.size() - 1].name = fn;
 	}
+
 	return *this;
 }
 
-message& message::set_file_content(const std::string &fc)
-{
-	if (filecontent.empty()) {
-		filecontent.push_back(fc);
+message& message::set_file_content(const std::string &fc) {
+	if (file_data.empty()) {
+		message_file_data data;
+		data.content = fc;
+
+		file_data.push_back(data);
 	} else {
-		filecontent[filecontent.size() - 1] = fc;
+		file_data[file_data.size() - 1].content = fc;
 	}
+
 	return *this;
 }
 
 message& message::add_file(const std::string &fn, const std::string &fc, const std::string &fm) {
-	filename.push_back(fn);
-	filecontent.push_back(fc);
-	filemimetype.push_back(fm);
+	message_file_data data;
+	data.name = fn;
+	data.content = fc;
+	data.mimetype = fm;
+
+	file_data.push_back(data);
 	return *this;
 }
 


### PR DESCRIPTION
This PR changes the way that messages hold files. Rather than there being 3 vectors of strings for: name, content and mimetypes, there is now a vector of `message_file_data` structs.

This doesn't break the way you add files, but rather breaks the way you read files you've added to a message.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
