### PR TITLE
docs: altered the OSX page

### DIFF
--- a/docpages/building/osx.md
+++ b/docpages/building/osx.md
@@ -10,8 +10,10 @@ Before compiling make sure you have all the tools installed.
 ## 2. Install External Dependencies
 
 ```bash
-brew install openssl
+brew install openssl pkgconfig
 ```
+
+\note Usually, you do not need pkgconfig. However, it seems that it throws errors about openssl without.
 
 For voice support, additional dependencies are required:
 
@@ -43,7 +45,7 @@ If you want to install the library, its dependencies, and header files to a diff
 cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
 ```
 
-Then once the build is complete, run `make install` to install to the location you specified.
+Then once the build is complete, run `sudo make install` to install to the location you specified.
 
 ## 6. Using the Library
 


### PR DESCRIPTION
This PR changes the OSX page as it was missing pkg-config.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
