### PR TITLE
docs: corrected punctuation and refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ You can find more examples in our [example page](https://dpp.dev/example-program
 
 The library runs ideally on **Linux**.
 
-### Mac OS X and FreeBSD and OpenBSD
+### Mac OS X, FreeBSD, and OpenBSD
 
-The library is well-functional and stable on **Mac OS X**, **FreeBSD**, and **OpenBSD** too.
+The library is well-functional and stable on **Mac OS X**, **FreeBSD**, and **OpenBSD** too!
 
 ### Raspberry Pi
 

--- a/docpages/INDEX.md
+++ b/docpages/INDEX.md
@@ -48,8 +48,8 @@ You can find further releases in other architectures and formats or the source c
 ### Linux
 The library runs ideally on **Linux**.
 
-### Mac OS X and FreeBSD
-The library is well-functional and stable on **Mac OS X** and **FreeBSD** too.
+### Mac OS X, FreeBSD, and OpenBSD
+The library is well-functional and stable on **Mac OS X**, **FreeBSD**, and **OpenBSD** too!
 
 ### Raspberry Pi
 For running your bot on a **Raspberry Pi**, we offer a prebuilt .deb package for ARM64, ARM6, and ARM7 so that you do not have to wait for it to compile.
@@ -63,10 +63,10 @@ The library should work fine on other operating systems as well, and if you run 
 ## Getting started
 * [GitHub Repository](https://github.com/brainboxdotcc/DPP)
 * [Discord Server](https://discord.gg/dpp)
-* \ref frequently-asked-questions "Frequently Asked Questions"
-* \ref installing "Installing D++"
-* \ref example-programs "Example Programs"
-* \ref glossary-of-common-discord-terms "Commonly used terms"
+* \ref frequently-asked-questions
+* \ref installing
+* \ref example-programs
+* \ref glossary-of-common-discord-terms
 
 ## Architecture
 * \ref clusters-shards-guilds


### PR DESCRIPTION
This PR corrects some punctuation with the section with Mac in the README.md, it also corrects some references in INDEX.md.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
