### PR TITLE
ci: unit tests now use ctest, macos now unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,15 +157,8 @@ jobs:
         env:
           DONT_RUN_VCPKG: true
 
-      - name: Run unit tests
+      - name: Run offline unit tests
         run: cd build && ctest -VV
-        env:
-          DPP_UNIT_TEST_TOKEN: ${{secrets.DPP_UNIT_TEST_TOKEN}}
-          TEST_GUILD_ID: ${{secrets.TEST_GUILD_ID}}
-          TEST_TEXT_CHANNEL_ID: ${{secrets.TEST_TEXT_CHANNEL_ID}}
-          TEST_VC_ID: ${{secrets.TEST_VC_ID}}
-          TEST_USER_ID: ${{secrets.TEST_USER_ID}}
-          TEST_EVENT_ID: ${{secrets.TEST_EVENT_ID}}
 
   windows: # Windows x64 and x86 build matrix
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: cd build && make -j2
 
       - name: Run unit tests
-        run: cd build/library && ./unittest
+        run: cd build && ctest -VV
         env:
           DPP_UNIT_TEST_TOKEN: ${{secrets.DPP_UNIT_TEST_TOKEN}}
           TEST_GUILD_ID: ${{secrets.TEST_GUILD_ID}}
@@ -156,6 +156,16 @@ jobs:
         run: cd build && make -j3
         env:
           DONT_RUN_VCPKG: true
+
+      - name: Run unit tests
+        run: cd build && ctest -VV
+        env:
+          DPP_UNIT_TEST_TOKEN: ${{secrets.DPP_UNIT_TEST_TOKEN}}
+          TEST_GUILD_ID: ${{secrets.TEST_GUILD_ID}}
+          TEST_TEXT_CHANNEL_ID: ${{secrets.TEST_TEXT_CHANNEL_ID}}
+          TEST_VC_ID: ${{secrets.TEST_VC_ID}}
+          TEST_USER_ID: ${{secrets.TEST_USER_ID}}
+          TEST_EVENT_ID: ${{secrets.TEST_EVENT_ID}}
 
   windows: # Windows x64 and x86 build matrix
     permissions:


### PR DESCRIPTION
This PR modifies the ci.yml file, making our unit tests now use `ctest -VV`. Since #1001 fixed the unit tests for Mac OS, we now unit test on the Mac OS runner.

The checklists do not apply to this PR.