### PR TITLE
fix: changed default audio type for windows

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -597,8 +597,8 @@ public:
 	 */
 	enum send_audio_type_t
 	{
-	    satype_recorded_audio,
-	    satype_live_audio,
+		satype_recorded_audio,
+		satype_live_audio,
 		satype_overlap_audio
 	} send_audio_type =
 #ifdef _WIN32

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -599,9 +599,9 @@ public:
 		satype_overlap_audio
 	} send_audio_type =
 #ifdef _WIN32
-        satype_overlap_audio;
+	satype_overlap_audio;
 #else
-        satype_recorded_audio;
+	satype_recorded_audio;
 #endif
 
 	/**

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -564,7 +564,10 @@ public:
 	snowflake channel_id;
 
 	/**
-	 * @brief The audio type to be sent. The default type is recorded audio.
+	 * @brief The audio type to be sent.
+	 *
+	 * @note On Windows, the default type is overlap audio.
+	 * On all other platforms, it is recorded audio.
 	 *
 	 * If the audio is recorded, the sending of audio packets is throttled.
 	 * Otherwise, if the audio is live, the sending is not throttled.

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -599,9 +599,9 @@ public:
 		satype_overlap_audio
 	} send_audio_type =
 #ifdef _WIN32
-            satype_overlap_audio;
+        satype_overlap_audio;
 #else
-            satype_recorded_audio;
+        satype_recorded_audio;
 #endif
 
 	/**

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -597,7 +597,12 @@ public:
 	    satype_recorded_audio,
 	    satype_live_audio,
 		satype_overlap_audio
-	} send_audio_type = satype_recorded_audio;
+	} send_audio_type =
+#ifdef _WIN32
+            satype_overlap_audio;
+#else
+            satype_recorded_audio;
+#endif
 
 	/**
 	 * @brief Sets the gain for the specified user.


### PR DESCRIPTION
This PR changes `send_audio_type` in discordvoiceclient.h to be `satype_overlap_audio` if on windows. This should make issues like #978 hopefully appear less, if not at all.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
