### PR TITLE
docs: added install page for brew

### DIFF
--- a/docpages/03_installing.md
+++ b/docpages/03_installing.md
@@ -9,4 +9,5 @@ There are many ways to install D++, either from a package manager, or from sourc
 * \subpage install-windows-vs-zip
 * \subpage install-windows-clion-vcpkg
 * \subpage install-xmake
+* \subpage install-brew
 * \subpage install-from-source

--- a/docpages/install/install-brew.md
+++ b/docpages/install/install-brew.md
@@ -1,0 +1,17 @@
+\page install-brew Installing from Homebrew (OSX)
+
+To install D++ from brew, follow the steps below:
+
+```bash
+brew install libdpp
+
+brew link libdpp
+```
+
+You will now be able to use D++ by including its library on the command line:
+
+```bash
+clang++ -std=c++17 -L/opt/homebrew/lib -I/opt/homebrew/include -ldpp mybot.cpp -o mybot
+```
+
+\include{doc} install_prebuilt_footer.dox

--- a/docpages/install/install-brew.md
+++ b/docpages/install/install-brew.md
@@ -4,11 +4,12 @@ To install D++ from brew, follow the steps below:
 
 ```bash
 brew install libdpp
-
 brew link libdpp
 ```
 
-This command will install libdpp and setup links so it can be used correctly.
+This command will install libdpp and setup links.
+
+If it can't detect libdpp, please do `brew update` and repeat the steps above.
 
 You will now be able to use D++ by including its library on the command line:
 
@@ -26,6 +27,6 @@ brew unlink libdpp
 brew uninstall libdpp
 ```
 
-\note As a precaution, double check inside `/opt/homebrew/lib` and `/opt/homebrew/include` to make sure that libdpp does not exist. If it does, remove files/folders relating to libdpp. If there are files left here and you don't remove them, you may see issues arise with different versions of D++
+\note As a precaution, double check inside `/opt/homebrew/lib` and `/opt/homebrew/include` to make sure that libdpp does not exist. If it does, remove files/folders relating to libdpp. If there are files left here and you don't remove them, you may see issues arise with different versions of D++. Sometimes, it may still act like some version of D++ exists, if it does that then please restart your system!
 
 **Have fun!**

--- a/docpages/install/install-brew.md
+++ b/docpages/install/install-brew.md
@@ -13,10 +13,8 @@ This command will install libdpp and setup links so it can be used correctly.
 You will now be able to use D++ by including its library on the command line:
 
 ```bash
-clang++ -std=c++17 -I/opt/homebrew/include -ldpp mybot.cpp -o mybot
+clang++ -std=c++17 -L/opt/homebrew/lib -I/opt/homebrew/include -ldpp mybot.cpp -o mybot
 ```
-
-\note A crucial part of this command is `-I/opt/homebrew/include`. AppleClang should automatically have `/opt/homebrew/lib` added as a way to detect library (if it doesn't, you can do `-L/opt/homebrew/lib` with this command), however, AppleClang does not auto-detect includes from homebrew. This means, D++ needs you to link the includes folder.
 
 \include{doc} install_prebuilt_footer.dox
 

--- a/docpages/install/install-brew.md
+++ b/docpages/install/install-brew.md
@@ -8,10 +8,26 @@ brew install libdpp
 brew link libdpp
 ```
 
+This command will install libdpp and setup links so it can be used correctly.
+
 You will now be able to use D++ by including its library on the command line:
 
 ```bash
-clang++ -std=c++17 -L/opt/homebrew/lib -I/opt/homebrew/include -ldpp mybot.cpp -o mybot
+clang++ -std=c++17 -I/opt/homebrew/include -ldpp mybot.cpp -o mybot
 ```
 
+\note A crucial part of this command is `-I/opt/homebrew/include`. AppleClang should automatically have `/opt/homebrew/lib` added as a way to detect library (if it doesn't, you can do `-L/opt/homebrew/lib` with this command), however, AppleClang does not auto-detect includes from homebrew. This means, D++ needs you to link the includes folder.
+
 \include{doc} install_prebuilt_footer.dox
+
+## Uninstalling & Unlinking
+
+To unlink and uninstall dpp, run
+```bash
+brew unlink libdpp
+brew uninstall libdpp
+```
+
+Then, double check inside `/opt/homebrew/lib` and `/opt/homebrew/include` to make sure that libdpp does not exist. If it does, remove files/folders relating to libdpp.
+
+**Have fun!**

--- a/docpages/install/install-brew.md
+++ b/docpages/install/install-brew.md
@@ -28,6 +28,6 @@ brew unlink libdpp
 brew uninstall libdpp
 ```
 
-Then, double check inside `/opt/homebrew/lib` and `/opt/homebrew/include` to make sure that libdpp does not exist. If it does, remove files/folders relating to libdpp.
+\note As a precaution, double check inside `/opt/homebrew/lib` and `/opt/homebrew/include` to make sure that libdpp does not exist. If it does, remove files/folders relating to libdpp. If there are files left here and you don't remove them, you may see issues arise with different versions of D++
 
 **Have fun!**


### PR DESCRIPTION
This PR adds a page to instruct people how to install D++ from homebrew.

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
