### PR TITLE
docs: corrected some issues in clearing_slashcommands.cpp

### DIFF
--- a/docpages/example_code/clearing_slashcommands.cpp
+++ b/docpages/example_code/clearing_slashcommands.cpp
@@ -1,7 +1,6 @@
 #include <dpp/dpp.h>
 
-int main()
-{
+int main() {
 	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
@@ -12,7 +11,7 @@ int main()
 		if (dpp::run_once<struct clear_bot_commands>()) {
 			/* Now, we're going to wipe our commands */
 			bot.global_bulk_command_delete();
-			/* This one requires a guild id, otherwise it won't what guild's commands it needs to wipe! */
+			/* This one requires a guild id, otherwise it won't know what guild's commands it needs to wipe! */
 			bot.guild_bulk_command_delete(857692897221033129);
 		}
 


### PR DESCRIPTION
This PR makes some small changes to `clearing_slashcommands.cpp`, fixing up a spelling mistake. Thanks to @Mishura4 for spotting it 😅 

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
