### PR TITLE
doc: changes to buildlinux

### DIFF
--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -46,7 +46,6 @@ sudo chmod 644 /usr/local/lib/libdpp.so.10.0.29 && sudo chmod +x /usr/local/lib/
 ```
 
 - You need to specify the location for `libdpp.so` when compilling:
-
 ```bash
 g++ -std=c++17 -I/usr/local/include mydppbot.cpp -o dppbot /usr/local/lib/libdpp.so -Wl,-rpath,/usr/local/lib
 ```

--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -52,11 +52,9 @@ g++ -std=c++17 -I/usr/local/include mydppbot.cpp -o dppbot /usr/local/lib/libdpp
 The important flags in this command-line are:
 
 * `-std=c++17` - Required to compile the headers
-* `-L/usr/local/lib` - Required to tell the linker where libdpp is located
 * `-I/usr/local/include` - Required to tell the linker where dpp headers are located
 * `mydppbot.cpp` - Your source code
-* `dppbot` - The name of the executable to make
-* `-ldpp` - Link to libdpp.so
+* `-o dppbot` - The name of the executable to make
 * `/usr/local/lib/libdpp.so` - Required to specify the path to the shared library
 * `-Wl` - Required to pass options directly to the linker
 * `-rpath,/usr/local/lib` - Required to specify the runtime library search path

--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -46,7 +46,7 @@ The important flags in this command-line are:
 
 If you are on **Arch Linux**:
 
-- You need to give proper permission to `libdpp.so` and `libdpp.so.10.0.29`
+- You need to give proper permission to `libdpp.so.10.0.29`
 ```bash
 sudo chmod 755 /usr/local/lib/libdpp.so.10.0.29
 ```

--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -37,6 +37,13 @@ Once installed to the `/usr/local` directory, you can make use of the library in
 g++ -std=c++17 mydppbot.cpp -o dppbot -ldpp
 ```
 
+The important flags in this command-line are:
+
+* `-std=c++17` - Required to compile the headers
+* `mydppbot.cpp` - Your source code
+* `-o dppbot` - The name of the executable to make
+* `-ldpp` - Link to libdpp.so
+
 If you are on **Arch Linux**:
 
 - You need to give proper permission to `libdpp.so` and `libdpp.so.10.0.29`
@@ -49,12 +56,9 @@ sudo chmod 755 /usr/local/lib/libdpp.so.10.0.29
 g++ -std=c++17 -I/usr/local/include mydppbot.cpp -o dppbot /usr/local/lib/libdpp.so -Wl,-rpath,/usr/local/lib
 ```
 
-The important flags in this command-line are:
+The important flags in this command-line only for Arch Linux are:
 
-* `-std=c++17` - Required to compile the headers
 * `-I/usr/local/include` - Required to tell the linker where dpp headers are located
-* `mydppbot.cpp` - Your source code
-* `-o dppbot` - The name of the executable to make
 * `/usr/local/lib/libdpp.so` - Required to specify the path to the shared library
 * `-Wl` - Required to pass options directly to the linker
 * `-rpath,/usr/local/lib` - Required to specify the runtime library search path

--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -41,8 +41,7 @@ If you are on **Arch Linux**:
 
 - You need to give proper permission to `libdpp.so` and `libdpp.so.10.0.29`
 ```bash
-sudo chmod 644 /usr/local/lib/libdpp.so && sudo chmod +x /usr/local/lib/dpp.so
-sudo chmod 644 /usr/local/lib/libdpp.so.10.0.29 && sudo chmod +x /usr/local/lib/dpp.so.10.0.29
+sudo chmod 755 /usr/local/lib/libdpp.so.10.0.29
 ```
 
 - You need to specify the location for `libdpp.so` when compilling:
@@ -58,9 +57,9 @@ The important flags in this command-line are:
 * `mydppbot.cpp` - Your source code
 * `dppbot` - The name of the executable to make
 * `-ldpp` - Link to libdpp.so
-* `/usr/local/lib/libdpp.so` - Required to specifies the path to the shared library
+* `/usr/local/lib/libdpp.so` - Required to specify the path to the shared library
 * `-Wl` - Required to pass options directly to the linker
-* `-rpath,/usr/local/lib` - Required to specifies the runtime library search path
+* `-rpath,/usr/local/lib` - Required to specify the runtime library search path
 
 \include{doc} install_prebuilt_footer.dox
 

--- a/docpages/building/linux.md
+++ b/docpages/building/linux.md
@@ -37,27 +37,31 @@ Once installed to the `/usr/local` directory, you can make use of the library in
 g++ -std=c++17 mydppbot.cpp -o dppbot -ldpp
 ```
 
-If you are on **Arch Linux**, you will need to add `/usr/local` to your environment variables:
+If you are on **Arch Linux**:
 
+- You need to give proper permission to `libdpp.so` and `libdpp.so.10.0.29`
 ```bash
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-export CPLUS_INCLUDE_PATH=/usr/local/include:$CPLUS_INCLUDE_PATH
+sudo chmod 644 /usr/local/lib/libdpp.so && sudo chmod +x /usr/local/lib/dpp.so
+sudo chmod 644 /usr/local/lib/libdpp.so.10.0.29 && sudo chmod +x /usr/local/lib/dpp.so.10.0.29
 ```
 
-However, if you don't want to change your environment settings, you can use these flags to compile:
+- You need to specify the location for `libdpp.so` when compilling:
 
 ```bash
-g++ -std=c++17 -L/usr/local/lib -I/usr/local/include mydppbot.cpp -o dppbot -ldpp
+g++ -std=c++17 -I/usr/local/include mydppbot.cpp -o dppbot /usr/local/lib/libdpp.so -Wl,-rpath,/usr/local/lib
 ```
 
 The important flags in this command-line are:
 
 * `-std=c++17` - Required to compile the headers
-* `-L/usr/local/lib` - Required to tell the linker where libdpp is located.
-* `-I/usr/local/include` - Required to tell the linker where dpp headers are located.
+* `-L/usr/local/lib` - Required to tell the linker where libdpp is located
+* `-I/usr/local/include` - Required to tell the linker where dpp headers are located
 * `mydppbot.cpp` - Your source code
 * `dppbot` - The name of the executable to make
 * `-ldpp` - Link to libdpp.so
+* `/usr/local/lib/libdpp.so` - Required to specifies the path to the shared library
+* `-Wl` - Required to pass options directly to the linker
+* `-rpath,/usr/local/lib` - Required to specifies the runtime library search path
 
 \include{doc} install_prebuilt_footer.dox
 


### PR DESCRIPTION
In the docs the steps given to use d++ when build from source and located in `/usr/local/` was **incorrect** corrected it in this PR

## Documentation change checklist

- [x] My documentation changes follow the same style as the rest of the documentation and any examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
