### PR TITLE
docs: fixed colour scheme after recent doxygen changes

### DIFF
--- a/docpages/style.css
+++ b/docpages/style.css
@@ -57,7 +57,22 @@ table.doxtable td, table.doxtable th {
 
 dl.note {
 	background-color: #fcfcc0;
+	border-left-color: #f1b602;
 	color: #8d7400;
+}
+
+dl.note dt {
+	color: #f1b602;
+}
+
+dl.warning, dl.attention {
+	background: #2e1917;
+	border-left-color: #ad2617;
+	color: #f5b1aa;
+}
+
+dl.warning dt, dl.attention dt {
+	color: #ad2617;
 }
 
 #nav-tree .arrow {


### PR DESCRIPTION
The recent doxygen-awesome-css changes changed the colour of warnings and notes. I have rectified it and it is back to how it looked previously.

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs_standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
