### PR TITLE
build: CI should no longer build from docpages changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - '**.cmake'
       - '**ci.yml'
       - '**CMakeLists.txt'
+      - '!**/docpages/**' # Never allow docpages to build CI from doc PRs.
   pull_request:
     paths:
       - '**Dockerfile'
@@ -20,6 +21,7 @@ on:
       - '**.cmake'
       - '**ci.yml'
       - '**CMakeLists.txt'
+      - '!**/docpages/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR fixes an issue we saw with #1019 where any files inside `example_code` would start the `D++ CI` workflow, which is incorrect.