### PR TITLE
feat: added guilds array and count to ready_t

### DIFF
--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -971,6 +971,16 @@ struct DPP_EXPORT ready_t : public event_dispatch_t {
 	 * @brief shard id
 	 */
 	uint32_t shard_id = {};
+
+	/**
+	 * @brief Array of guild IDs the bot is in, at the time of this event.
+	 */
+	std::vector<snowflake> guilds{};
+
+	/**
+	 * @brief The number of guilds the bot is in, at the time of this event.
+	 */
+	uint32_t guild_count{0};
 };
 
 /**

--- a/src/dpp/events/ready.cpp
+++ b/src/dpp/events/ready.cpp
@@ -71,6 +71,10 @@ void ready::handle(discord_client* client, json &j, const std::string &raw) {
 		dpp::ready_t r(client, raw);
 		r.session_id = client->sessionid;
 		r.shard_id = client->shard_id;
+		for (const auto& guild : j["d"]["guilds"]) {
+			r.guilds.emplace_back(snowflake_not_null(&guild, "id"));
+		}
+		r.guild_count = r.guilds.size();
 		client->creator->on_ready.call(r);
 	}
 }


### PR DESCRIPTION
This PR adds the guilds array and a count of the array to the ready_t event, [as Discord provides an array of unavailable guilds on the ready event](https://discord.com/developers/docs/topics/gateway-events#ready-ready-event-fields). This means people can now get the amount of guilds a bot is in from the ready_t event.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
