### PR TITLE
docs: made the setting_status page use the latest ready_t feature

### DIFF
--- a/docpages/example_code/setting_status2.cpp
+++ b/docpages/example_code/setting_status2.cpp
@@ -14,15 +14,7 @@ int main() {
 
 			/* Create a timer that runs every 120 seconds, that sets the status */
 			bot.start_timer([&bot](const dpp::timer& timer) {
-				/*
-				 * Because we need to get an up-to-date count, we can't use what was provided in the ready event.
-				 * So, we get the application from the bot and get the approximate guild count from there.
-				 */
-				bot.current_application_get([&bot](const dpp::confirmation_callback_t& callback) {
-					auto app = callback.get<dpp::application>();
-
-					bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(app.approximate_guild_count) + " guilds!"));
-				});
+				bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(dpp::get_guild_cache()->count()) + " guilds!"));
 			}, 120);
 		}
 	});

--- a/docpages/example_code/setting_status2.cpp
+++ b/docpages/example_code/setting_status2.cpp
@@ -10,11 +10,19 @@ int main() {
 		/* We put our status updating inside "run_once" so that multiple shards don't try do this as "set_presence" updates all the shards. */
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* We update the presence now as the timer will do the first execution after the x amount of seconds we specify */
-			bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(dpp::get_guild_cache()->count()) + " guilds!"));
+			bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(event.guild_count) + " guilds!"));
 
 			/* Create a timer that runs every 120 seconds, that sets the status */
 			bot.start_timer([&bot](const dpp::timer& timer) {
-				bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(dpp::get_guild_cache()->count()) + " guilds!"));
+				/*
+				 * Because we need to get an up-to-date count, we can't use what was provided in the ready event.
+				 * So, we get the application from the bot and get the approximate guild count from there.
+				 */
+				bot.current_application_get([&bot](const dpp::confirmation_callback_t& callback) {
+					auto app = callback.get<dpp::application>();
+
+					bot.set_presence(dpp::presence(dpp::presence_status::ps_online, dpp::activity_type::at_game, "with " + std::to_string(app.approximate_guild_count) + " guilds!"));
+				});
 			}, 120);
 		}
 	});

--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -2,8 +2,6 @@
 
 A bot status is pretty cool, and it'd be cooler if you knew how to do it! This tutorial will cover how to set the bot status to say `Playing games!`, as well as covering how to set the status to the amount of guilds every two minutes.
 
-\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use dpp::cluster::current_application_get and get the `approximate_guild_count` from dpp::application in the callback.
-
 First, we'll cover setting the bot status to `Playing games!`.
 
 \include{cpp} setting_status1.cpp
@@ -11,6 +9,9 @@ First, we'll cover setting the bot status to `Playing games!`.
 If all went well, your bot should now be online and say this on members list!
 
 \image html botonlinestatus.png
+
+If you wanted to make your bot show as Do Not Disturb, then you could change dpp::ps_online to dpp::ps_dnd.
+You can also play around with dpp::at_game, changing it to something like dpp::at_custom or dpp::at_listening!
 
 Now, let's cover setting the bot status to say `Playing with x guilds!` every two minutes.
 

--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -10,7 +10,7 @@ If all went well, your bot should now be online and say this on members list!
 
 \image html botonlinestatus.png
 
-If you wanted to make your bot show as Do Not Disturb, then you could change dpp::ps_online to dpp::ps_dnd.
+If you want to make your bot show as Do Not Disturb, then you could change dpp::ps_online to dpp::ps_dnd.
 You can also play around with dpp::at_game, changing it to something like dpp::at_custom or dpp::at_listening!
 
 Now, let's cover setting the bot status to say `Playing with x guilds!` every two minutes.

--- a/docpages/example_programs/misc/setting_status.md
+++ b/docpages/example_programs/misc/setting_status.md
@@ -2,6 +2,8 @@
 
 A bot status is pretty cool, and it'd be cooler if you knew how to do it! This tutorial will cover how to set the bot status to say `Playing games!`, as well as covering how to set the status to the amount of guilds every two minutes.
 
+\note dpp::get_guild_cache requires the bot to have the guild cache enabled, if your bot has this disabled then you can't use that. Instead, you should look to use dpp::cluster::current_application_get and get the `approximate_guild_count` from dpp::application in the callback.
+
 First, we'll cover setting the bot status to `Playing games!`.
 
 \include{cpp} setting_status1.cpp


### PR DESCRIPTION
This PR changes the setting_status page to use the feature added from #1038. I've also made the page move away from using the cache.

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
