### PR TITLE
fix: use of uninitialized value in command_option copy ctor

### DIFF
--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -331,7 +331,7 @@ command_option_choice &command_option_choice::fill_from_json_impl(nlohmann::json
 }
 
 command_option::command_option(command_option_type t, const std::string &n, const std::string &d, bool r) :
-	type(t), name(n), description(d), required(r), autocomplete(false)
+	type(t), name(n), description(d), required(r), focused(false), autocomplete(false)
 {
 	if (std::any_of(n.begin(), n.end(), [](unsigned char c){ return std::isupper(c); })) {
 		throw dpp::logic_exception(err_command_has_caps, "Command options can not contain capital letters in the name of the option.");


### PR DESCRIPTION
Basically all examples of using `dpp::command_option` invoke undefined behavior Let's look at its typical usage example from the docs:
```cpp
dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);
newcommand.add_option(
    dpp::command_option(dpp::co_string, "animal", "The type of animal", true)
);
```

The problem here is that `dpp::command_option::command_option` does not initialize a boolean field called `focused`. And then inside `add_option` the implicitly-defined copy constructor is called. This constructor, among other things, copies that `focused` field, but since it was never initialized, we get UB.

This PR ensures that `focused` is initialized in `dpp::command_option::command_option` with `false`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
