### PR TITLE
refactor: fix and improve utf8 utilities

### DIFF
--- a/docpages/example_code/eval.cpp
+++ b/docpages/example_code/eval.cpp
@@ -34,7 +34,7 @@ int main() {
 	 * a multi-line slash command input type.
 	 */
 	bot.on_message_create([&bot](const auto & event) {
-		if (dpp::utility::utf8substr(event.msg.content, 0, 5) == "!eval") {
+		if (dpp::utility::utf8subview(event.msg.content, 0, 5) == "!eval") {
 
 			/** 
 			 * THIS IS CRITICALLY IMPORTANT!
@@ -63,7 +63,7 @@ int main() {
 				#include <fmt/format.h>\n\
 				#include \"eval.h\"\n\
 				extern \"C\" void so_exec(dpp::cluster& bot, dpp::message_create_t event) {\n\
-					" + dpp::utility::utf8substr(
+					" + dpp::utility::utf8subview(
 						event.msg.content,
 						6,
 						dpp::utility::utf8len(event.msg.content)

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -738,12 +738,13 @@ uint32_t DPP_EXPORT hsl(int h, int s, int l);
 std::string DPP_EXPORT debug_dump(uint8_t* data, size_t length);
 
 /**
- * @brief Returns the length of a UTF-8 string in codepoints
- * 
+ * @brief Returns the length of a UTF-8 string in codepoints.
+ * @note Result is unspecified for strings that are not valid UTF-8.
+ *
  * @param str string to count length of
- * @return size_t length of string (0 for invalid utf8)
+ * @return size_t Length of string
  */
-size_t DPP_EXPORT utf8len(const std::string &str);
+size_t DPP_EXPORT utf8len(std::string_view str);
 
 /**
  * @brief Return substring of a UTF-8 encoded string in codepoints

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -747,14 +747,15 @@ std::string DPP_EXPORT debug_dump(uint8_t* data, size_t length);
 size_t DPP_EXPORT utf8len(std::string_view str);
 
 /**
- * @brief Return substring of a UTF-8 encoded string in codepoints
- * 
+ * @brief Return substring of a UTF-8 encoded string in codepoints.
+ * @note Result is unspecified for strings that are not valid UTF-8.
+ *
  * @param str string to return substring from
  * @param start start codepoint offset
  * @param length length in codepoints
- * @return std::string Substring in UTF-8 or empty string if invalid UTF-8 passed in
+ * @return std::string The requested substring
  */
-std::string DPP_EXPORT utf8substr(const std::string& str, std::string::size_type start, std::string::size_type length);
+std::string DPP_EXPORT utf8substr(std::string_view str, size_t start, size_t length);
 
 /**
  * @brief Read a whole file into a std::string.

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -747,6 +747,18 @@ std::string DPP_EXPORT debug_dump(uint8_t* data, size_t length);
 size_t DPP_EXPORT utf8len(std::string_view str);
 
 /**
+ * @brief Return subview of a UTF-8 encoded string in codepoints.
+ * @note You must ensure that the resulting view is not used after the lifetime of the viewed string has ended.
+ * @note Result is unspecified for strings that are not valid UTF-8.
+ *
+ * @param str string to return substring from
+ * @param start start codepoint offset
+ * @param length length in codepoints
+ * @return std::string_view The requested subview
+ */
+std::string_view DPP_EXPORT utf8subview(std::string_view str, size_t start, size_t length);
+
+/**
  * @brief Return substring of a UTF-8 encoded string in codepoints.
  * @note Result is unspecified for strings that are not valid UTF-8.
  *

--- a/src/dpp/commandhandler.cpp
+++ b/src/dpp/commandhandler.cpp
@@ -168,7 +168,7 @@ bool commandhandler::string_has_prefix(std::string &str)
 {
 	for (auto& p : prefixes) {
 		size_t prefix_length = utility::utf8len(p);
-		if (utility::utf8substr(str, 0, prefix_length) == p) {
+		if (utility::utf8subview(str, 0, prefix_length) == p) {
 			str.erase(str.begin(), str.begin() + prefix_length);
 			return true;
 		}

--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -505,7 +505,7 @@ size_t utf8len(std::string_view str) {
 	return code_points;
 }
 
-std::string utf8substr(std::string_view str, size_t start, size_t length) {
+std::string_view utf8subview(std::string_view str, size_t start, size_t length) {
 	/* Shouldn't rely on signedness of char, better cast to unsigned char */
 	const auto* const s = reinterpret_cast<const unsigned char*>(str.data());
 
@@ -537,7 +537,11 @@ std::string utf8substr(std::string_view str, size_t start, size_t length) {
 		code_points += 1;
 	}
 
-	return std::string(str.substr(subview_start, subview_len));
+	return str.substr(subview_start, subview_len);
+}
+
+std::string utf8substr(std::string_view str, size_t start, size_t length) {
+	return std::string(utf8subview(str, start, length));
 }
 
 std::string read_file(const std::string& filename)


### PR DESCRIPTION
This PR solves the following problems:
- `dpp::utf8substr` is just broken: `dpp::utf8substr("abcdefg", 2, 2)` returns `"cdef"`. Probably unnoticed due to very limited variety of usage scenarios.
- `dpp::utf8substr` and `dpp::utf8len` claim to have a specific result (empty string or zero, respectively) if the supplied string is not a valid UTF-8 sequence. In reality though, not only do they not verify if the string is valid UTF-8, they actually invoke UB for some inputs (e.g. `dpp::utf8len("\xC0\xC0")`) due to reading past the end of the string.
- The implementations of these functions are convoluted (use of `goto`, defining lots of variables in one line etc.)
- They only work with `std::string`'s and not `std::string_view`s. In particular, `dp::utf8substr` returns a new `std::string`, which causes allocations and copies that could be avoided in some cases.

What I did:
- Dropped the "guarantees" on what exactly these functions return in case of non-UTF-8 strings. We shouldn't pretend that they are provided. Now we claim that the result is "unspecified" (so no UB).
- Introduced a separate function called `utf8subview` which returns `std::string_view` instead of `std::string`, and made use of it in several places across the code base, where applicable.
- Replaced `const std::string&` with `std::string_view` in parameter declarations of these functions.
- Replaced `std::string::size_type` with `size_t` in parameter declarations of these functions because IMO it only makes everything unnecessarily verbose, especially if we assume that `std::string::size_type` might be different from `std::string_view::size_type`. It's almost never used in other places anyway, so why bother in this one in particular?
- Completely rewrote the implementations of both functions. One important difference in their behavior is that now they don't treat null terminators in the middle of strings as their end markers. These are now no different from any other ASCII character. It's also important that we don't rely on their presence at the end because `std::string_view`s are not guaranteed to be null-terminated.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
