### PR TITLE
fix: remove unnecessary SSL_free

### DIFF
--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -650,9 +650,6 @@ void ssl_client::cleanup()
 {
 	this->close();
 	if (!keepalive) {
-		if (ssl != nullptr) {
-			SSL_free(ssl->ssl);
-		}
 		delete ssl;
 	}
 }


### PR DESCRIPTION
As correctly noticed by @braindigitalis, #1049 introduced an unnecessary `SSL_free` call. This PR removes it.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
