### PR TITLE
fix: cmyk calculations - blue value calculations

### DIFF
--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -408,7 +408,7 @@ uint32_t rgb(int red, int green, int blue) {
 uint32_t cmyk(double c, double m, double y, double k) {
 	int r = (int)(255 * (1 - c) * (1 - k));
 	int g = (int)(255 * (1 - m) * (1 - k));
-	int b = (int)(255 * (1 - y) * (1 - m));
+	int b = (int)(255 * (1 - y) * (1 - k));
 	return rgb(r, g, b);
 }
 


### PR DESCRIPTION
During conversion from cmyk to rgb, blue value was calculated with m (magenta) instead of k (black)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
