### PR TITLE
feat: Added the ability to set voice channel statuses

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3703,6 +3703,17 @@ public:
 	 */
 	void skus_get(command_completion_event_t callback = utility::log_error());
 
+	/**
+	 * @brief Set the status of a voice channel.
+	 *
+	 * @see https://github.com/discord/discord-api-docs/pull/6400 (please replace soon).
+	 * @param channel_id The channel to update.
+	 * @param status The new status for the channel.
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback = utility::log_error());
+
 #include <dpp/cluster_sync_calls.h>
 #ifdef DPP_CORO
 #include <dpp/cluster_coro_calls.h>

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -577,6 +577,18 @@
 [[nodiscard]] async<confirmation_callback_t> co_channels_get(snowflake guild_id);
 
 /**
+ * @brief Set the status of a voice channel.
+ *
+ * @see dpp::cluster::channel_set_voice_status
+ * @see https://github.com/discord/discord-api-docs/pull/6400 (please replace soon).
+ * @param channel_id The channel to update.
+ * @param status The new status for the channel.
+ * @return confirmation returned object on completion
+ * \memberof dpp::cluster
+ */
+[[nodiscard]] async<confirmation_callback_t> co_channel_set_voice_status(snowflake channel_id, const std::string& status);
+
+/**
  * @brief Create a dm channel
  * @see dpp::cluster::create_dm_channel
  * @see https://discord.com/developers/docs/resources/user#create-dm

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -715,6 +715,21 @@ confirmation channel_typing_sync(snowflake cid);
 channel_map channels_get_sync(snowflake guild_id);
 
 /**
+ * @brief Set the status of a voice channel.
+ *
+ * @see dpp::cluster::channel_set_voice_status
+ * @see https://github.com/discord/discord-api-docs/pull/6400 (please replace soon).
+ * @param channel_id The channel to update.
+ * @param status The new status for the channel.
+ * @return confirmation returned object on completion
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+confirmation channel_set_voice_status_sync(snowflake channel_id, const std::string& status);
+
+/**
  * @brief Create a dm channel
  * @see dpp::cluster::create_dm_channel
  * @see https://discord.com/developers/docs/resources/user#create-dm

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -98,4 +98,9 @@ void cluster::channels_get(snowflake guild_id, command_completion_event_t callba
 	rest_request_list<channel>(this, API_PATH "/guilds", std::to_string(guild_id), "channels", m_get, "", callback);
 }
 
+void cluster::channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback) {
+	json j({ {"status", status} });
+	rest_request_list<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(), callback);
+}
+
 } // namespace dpp

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -100,7 +100,7 @@ void cluster::channels_get(snowflake guild_id, command_completion_event_t callba
 
 void cluster::channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback) {
 	json j({ {"status", status} });
-	rest_request_list<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(), callback);
 }
 
 } // namespace dpp

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -219,6 +219,10 @@ async<confirmation_callback_t> cluster::co_channels_get(snowflake guild_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channels_get), guild_id };
 }
 
+async<confirmation_callback_t> cluster::co_channel_set_voice_status(snowflake channel_id, const std::string& status) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string&, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status };
+}
+
 async<confirmation_callback_t> cluster::co_create_dm_channel(snowflake user_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::create_dm_channel), user_id };
 }

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -217,6 +217,10 @@ channel_map cluster::channels_get_sync(snowflake guild_id) {
 	return dpp::sync<channel_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channels_get), guild_id);
 }
 
+confirmation cluster::channel_set_voice_status_sync(snowflake channel_id, const std::string& status) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string&, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status);
+}
+
 channel cluster::create_dm_channel_sync(snowflake user_id) {
 	return dpp::sync<channel>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::create_dm_channel), user_id);
 }


### PR DESCRIPTION
This PR adds the ability to set the status of a voice channel.

![image](https://github.com/brainboxdotcc/DPP/assets/46899449/82a3fce4-0ded-41fb-931d-d1d9f91af996)
![image](https://github.com/brainboxdotcc/DPP/assets/46899449/c193ab31-9b77-4293-951d-1f7b9fa9add6)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
