### PR TITLE
feat: Added expire and issued timestamps in attachment

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1172,6 +1172,20 @@ struct DPP_EXPORT attachment {
 	 * @return true if remixed
 	 */
 	bool is_remix() const;
+	
+	/**
+	 * @brief Returns expiration timestamp for attachment's URL
+	 * 
+	 * @return timestamp of URL expiration
+	 */
+	time_t get_expire_time() const;
+	
+	/**
+	 * @brief Returns creation timestamp for attachment's URL
+	 * 
+	 * @return timestamp of URL creation
+	 */
+	time_t get_issued_time() const;
 };
 
 /**

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -883,10 +883,14 @@ bool attachment::is_remix() const {
 }
 
 time_t attachment::get_expire_time() const {
-	std::string attributes = url.substr(url.find('?')+1);
+	size_t attr_position = url.find('?');
+	/*If no attributes were sent in url, we do not need to parse more*/
+	if(url.npos == attr_position){
+		return 0;
+	}
+	std::string attributes = url.substr(attr_position+1);
 	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
 	auto ex_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "ex=";});
-	/*Check if discord sent us the 'ex' attribute*/
 	if(attr_list.end() == ex_attr){
 		return 0;
 	}
@@ -895,10 +899,14 @@ time_t attachment::get_expire_time() const {
 }
 
 time_t attachment::get_issued_time() const {
-	std::string attributes = url.substr(url.find('?')+1);
+	size_t attr_position = url.find('?');
+	/*No attributes were sent in url, so we do not need to parse more*/
+	if(url.npos == attr_position){
+		return 0;
+	}
+	std::string attributes = url.substr(attr_position+1);
 	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
 	auto is_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "is=";});
-	/*Check if discord sent us the 'is' attribute*/
 	if(attr_list.end() == is_attr){
 		return 0;
 	}

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -882,6 +882,30 @@ bool attachment::is_remix() const {
 	return flags & a_is_remix;
 }
 
+time_t attachment::get_expire_time() const {
+	std::string attributes = url.substr(url.find('?')+1);
+	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
+	auto ex_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "ex=";});
+	/*Check if discord sent us the 'ex' attribute*/
+	if(attr_list.end() == ex_attr){
+		return 0;
+	}
+	/*Erase 'ex=' prefix before parsing*/
+	return std::stol(ex_attr->substr(3),nullptr,16);
+}
+
+time_t attachment::get_issued_time() const {
+	std::string attributes = url.substr(url.find('?')+1);
+	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
+	auto is_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "is=";});
+	/*Check if discord sent us the 'is' attribute*/
+	if(attr_list.end() == is_attr){
+		return 0;
+	}
+	/*Erase 'is=' prefix before parsing*/
+	return std::stol(is_attr->substr(3),nullptr,16);
+}
+
 json message::to_json(bool with_id, bool is_interaction_response) const {
 	/* This is the basics. once it works, expand on it. */
 	json j({

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -884,34 +884,34 @@ bool attachment::is_remix() const {
 
 time_t attachment::get_expire_time() const {
 	size_t attr_position = url.find('?');
-	/*If no attributes were sent in url, we do not need to parse more*/
+	/* If no attributes were sent in url, we do not need to parse more */
 	if(url.npos == attr_position){
 		return 0;
 	}
-	std::string attributes = url.substr(attr_position+1);
-	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
-	auto ex_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "ex=";});
+	std::string attributes = url.substr(attr_position + 1);
+	std::vector<std::string> attr_list = utility::tokenize(attributes, "&");
+	auto ex_attr = std::find_if(attr_list.begin(), attr_list.end(), [](const std::string& s){return s.substr(0, 3) == "ex=";});
 	if(attr_list.end() == ex_attr){
 		return 0;
 	}
-	/*Erase 'ex=' prefix before parsing*/
-	return std::stol(ex_attr->substr(3),nullptr,16);
+	/* Erase 'ex=' prefix before parsing */
+	return std::stol(ex_attr->substr(3), nullptr, 16);
 }
 
 time_t attachment::get_issued_time() const {
 	size_t attr_position = url.find('?');
-	/*No attributes were sent in url, so we do not need to parse more*/
+	/* No attributes were sent in url, so we do not need to parse more */
 	if(url.npos == attr_position){
 		return 0;
 	}
-	std::string attributes = url.substr(attr_position+1);
-	std::vector<std::string> attr_list = utility::tokenize(attributes,"&");
-	auto is_attr = std::find_if(attr_list.begin(), attr_list.end(),[](const std::string& s){return s.substr(0,3) == "is=";});
+	std::string attributes = url.substr(attr_position + 1);
+	std::vector<std::string> attr_list = utility::tokenize(attributes, "&");
+	auto is_attr = std::find_if(attr_list.begin(), attr_list.end(), [](const std::string& s){return s.substr(0, 3) == "is=";});
 	if(attr_list.end() == is_attr){
 		return 0;
 	}
-	/*Erase 'is=' prefix before parsing*/
-	return std::stol(is_attr->substr(3),nullptr,16);
+	/* Erase 'is=' prefix before parsing */
+	return std::stol(is_attr->substr(3), nullptr, 16);
 }
 
 json message::to_json(bool with_id, bool is_interaction_response) const {


### PR DESCRIPTION
Added methods to extract expiration and issued timestamps from url

```c++
dpp::embed test{};
test.set_title("Test for file")
    .add_field("filename", fileAttachment.filename)
    .add_field("description", fileAttachment.description)
    .add_field("url", fileAttachment.url)
    .add_field("proxy_url", fileAttachment.proxy_url)
    .add_field("Expiration timestamp", std::to_string(fileAttachment.get_expire_time()))
    .add_field("issuing timestamp", std::to_string(fileAttachment.get_issued_time()));
```
![obraz](https://github.com/brainboxdotcc/DPP/assets/45640997/713fcf98-adb9-429d-921e-ba392e69fee3)


## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
