### PR TITLE
ci: labeler no longer fails

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,7 @@ documentation:
     - '**SECURITY.md'
     - '**CONTRIBUTING.md'
     - '**CODE_OF_CONDUCT.md'
+
 build:
 - changed-files:
   - any-glob-to-any-file:
@@ -22,6 +23,7 @@ build:
     - '**CMakeSettings.json'
     - '**settings.json'
     - '**dpp.pc.in'
+
 packaging:
 - changed-files:
   - any-glob-to-any-file:
@@ -29,17 +31,20 @@ packaging:
     - '**makerelease.sh'
     - '**sign.sh'
     - '**Dockerfile'
+
 submodules:
 - changed-files:
   - any-glob-to-any-file:
     - '**.gitmodules'
     - '**doxygen-awesome-css/**' # Ideally, nobody should be touching this, but it's here just in-case.
+
 github_actions:
 - changed-files:
   - any-glob-to-any-file:
     - '**.github/labeler.yml'
     - '**.github/dependabot.yml'
     - '**.github/workflows/**'
+
 code:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,35 +1,47 @@
 documentation:
-- '**Doxyfile'
-- '**docpages/**'
-- '**/*.h'
-- '**/documentation.yml'
-- '**.cspell.json'
-- '**README.md'
-- '**SECURITY.md'
-- '**CONTRIBUTING.md'
-- '**CODE_OF_CONDUCT.md'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**Doxyfile'
+    - '**docpages/**'
+    - '**/*.h'
+    - '**/documentation.yml'
+    - '**.cspell.json'
+    - '**README.md'
+    - '**SECURITY.md'
+    - '**CONTRIBUTING.md'
+    - '**CODE_OF_CONDUCT.md'
 build:
-- '**buildtools/**'
-- '**cmake/**'
-- '**library-vcpkg/**'
-- '**library/**'
-- '**win32/**'
-- '**CMakeLists.txt'
-- '**CMakeSettings.json'
-- '**settings.json'
-- '**dpp.pc.in'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**buildtools/**'
+    - '**cmake/**'
+    - '**library-vcpkg/**'
+    - '**library/**'
+    - '**win32/**'
+    - '**CMakeLists.txt'
+    - '**CMakeSettings.json'
+    - '**settings.json'
+    - '**dpp.pc.in'
 packaging:
-- '**vcpkg/**'
-- '**makerelease.sh'
-- '**sign.sh'
-- '**Dockerfile'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**vcpkg/**'
+    - '**makerelease.sh'
+    - '**sign.sh'
+    - '**Dockerfile'
 submodules:
-- '**.gitmodules'
-- '**doxygen-awesome-css/**' # Ideally, nobody should be touching this, but it's here just in-case.
+- changed-files:
+  - any-glob-to-any-file:
+    - '**.gitmodules'
+    - '**doxygen-awesome-css/**' # Ideally, nobody should be touching this, but it's here just in-case.
 github_actions:
-- '**.github/labeler.yml'
-- '**.github/dependabot.yml'
-- '**.github/workflows/**'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**.github/labeler.yml'
+    - '**.github/dependabot.yml'
+    - '**.github/workflows/**'
 code:
-- '**src/**'
-- '**include/**'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**src/**'
+    - '**include/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 jobs:
-  triage:
+  labeler:
     permissions:
       pull-requests: write # Labeler needs to be able to add labels to PRs.
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes labeler from failing CIs due to the update that was made which broke configuration files.

The checklist does not apply here.