### PR TITLE
feat: added newly_created bool to threads

### DIFF
--- a/include/dpp/thread.h
+++ b/include/dpp/thread.h
@@ -166,6 +166,12 @@ public:
 	uint8_t member_count = 0;
 
 	/**
+	 * @brief Was this thread newly created?
+	 * @note This will only show in dpp::cluster::on_thread_create if the thread was just made.
+	 */
+	bool newly_created{false};
+
+	/**
 	 * @brief Returns true if the thread is within an announcement channel
 	 *
 	 * @return true if announcement thread

--- a/src/dpp/thread.cpp
+++ b/src/dpp/thread.cpp
@@ -44,6 +44,8 @@ thread& thread::fill_from_json_impl(json* j) {
 	set_int32_not_null(j, "total_message_sent", this->total_messages_sent);
 	set_int8_not_null(j, "message_count", this->message_count);
 	set_int8_not_null(j, "member_count", this->member_count);
+	set_bool_not_null(j, "newly_created", this->newly_created);
+
 	auto json_metadata = (*j)["thread_metadata"];
 	metadata.archived = bool_not_null(&json_metadata, "archived");
 	metadata.archive_timestamp = ts_not_null(&json_metadata, "archive_timestamp");


### PR DESCRIPTION
This PR adds a `newly_created` bool to threads. As `on_thread_create` is also fired when a thread is added to an existing private thread (for example, adding a thread to a forum channel), there was no way to distinguish the actual creation event, Discord provides a `newly_created` bool so we now allow users to see that.

I avoided using the flags here in-case Discord add more flags (as `dpp::channel_flags` is close to its limit) to channels/threads.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
