### PR TITLE
[feat] alter set_allowed_mentions

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2074,15 +2074,15 @@ public:
 	/**
 	 * @brief Set the allowed mentions object for pings on the message
 	 * 
-	 * @param _parse_users whether or not to parse users in the message content or embeds
-	 * @param _parse_roles whether or not to parse roles in the message content or embeds
-	 * @param _parse_everyone whether or not to parse everyone/here in the message content or embeds 
-	 * @param _replied_user if set to true and this is a reply, then ping the user we reply to
-	 * @param users list of user ids to allow pings for
-	 * @param roles list of role ids to allow pings for
+	 * @param _parse_users whether or not to parse users in the message content or embeds, default false
+	 * @param _parse_roles whether or not to parse roles in the message content or embeds, default false
+	 * @param _parse_everyone whether or not to parse everyone/here in the message content or embeds, default false
+	 * @param _replied_user if set to true and this is a reply, then ping the user we reply to, default false
+	 * @param users list of user ids to allow pings for, default an empty vector
+	 * @param roles list of role ids to allow pings for, default an empty vector
 	 * @return message& reference to self
 	 */
-	message& set_allowed_mentions(bool _parse_users, bool _parse_roles, bool _parse_everyone, bool _replied_user, const std::vector<snowflake> &users, const std::vector<snowflake> &roles);
+	message& set_allowed_mentions(bool _parse_users = false, bool _parse_roles = false, bool _parse_everyone = false, bool _replied_user = false, const std::vector<snowflake> &users = {}, const std::vector<snowflake> &roles = {});
 
 	using json_interface<message>::fill_from_json;
 	using json_interface<message>::to_json;


### PR DESCRIPTION
This allows the developer to use only one parameter if they only require to change the first parameter and leave the others as default. Altered comments.
Example:
`dpp::message a = dpp::message().set_allowed_mentions(true); // this allows them to parse users but leave everything else as false`

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
