### PR TITLE
fix: Fixed getting archived threads

### DIFF
--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -70,7 +70,20 @@ void cluster::threads_get_private_archived(snowflake channel_id, time_t before_t
 		{"before", before_timestamp},
 		{"limit", limit},
 	});
-	rest_request_list<thread>(this, API_PATH "/channels", std::to_string(channel_id), "/threads/archived/private" + parameters, m_get, "", callback);
+	this->post_rest(API_PATH "/channels", std::to_string(channel_id), "/threads/archived/private" + parameters, m_get, "", [this, callback](json &j, const http_request_completion_t& http) {
+		std::unordered_map<snowflake, thread> list;
+		confirmation_callback_t e(this, confirmation(), http);
+		if (!e.is_error()) {
+			if (j.contains("threads")) {
+				for (auto &curr_item: j["threads"]) {
+					list[snowflake_not_null(&curr_item, "id")].fill_from_json(&curr_item);
+				}
+			}
+		}
+		if (callback) {
+			callback(confirmation_callback_t(this, list, http));
+		}
+	});	
 }
 
 void cluster::threads_get_public_archived(snowflake channel_id, time_t before_timestamp, uint16_t limit, command_completion_event_t callback) {
@@ -78,7 +91,20 @@ void cluster::threads_get_public_archived(snowflake channel_id, time_t before_ti
 		{"before", before_timestamp},
 		{"limit", limit},
 	});
-	rest_request_list<thread>(this, API_PATH "/channels", std::to_string(channel_id), "/threads/archived/public" + parameters, m_get, "", callback);
+	this->post_rest(API_PATH "/channels", std::to_string(channel_id), "/threads/archived/public" + parameters, m_get, "", [this, callback](json &j, const http_request_completion_t& http) {
+		std::unordered_map<snowflake, thread> list;
+		confirmation_callback_t e(this, confirmation(), http);
+		if (!e.is_error()) {
+			if (j.contains("threads")) {
+				for (auto &curr_item: j["threads"]) {
+					list[snowflake_not_null(&curr_item, "id")].fill_from_json(&curr_item);
+				}
+			}
+		}
+		if (callback) {
+			callback(confirmation_callback_t(this, list, http));
+		}
+	});
 }
 
 void cluster::thread_member_get(const snowflake thread_id, const snowflake user_id, command_completion_event_t callback) {


### PR DESCRIPTION
Used get_active_threads as a template to properly implement threads_get_public_archived and threads_get_private_archived

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
