### PR TITLE
fix: ts_not_null now works for all timezones

### DIFF
--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -319,18 +319,18 @@ void set_ts_not_null(const json* j, const char* keyname, time_t &v)
 			}
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%dT%T", &timestamp);
 			timestamp.tm_isdst = 0;
-#ifndef _WIN32
-			retval = timegm(&timestamp);
-#else
-			retval = _mkgmtime(&timestamp);
-#endif
+			#ifndef _WIN32
+				retval = timegm(&timestamp);
+			#else
+				retval = _mkgmtime(&timestamp);
+			#endif
 		} else {
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%d %T", &timestamp);
-#ifndef _WIN32
-			retval = timegm(&timestamp);
-#else
-			retval = _mkgmtime(&timestamp);
-#endif
+			#ifndef _WIN32
+				retval = timegm(&timestamp);
+			#else
+				retval = _mkgmtime(&timestamp);
+			#endif
 		}
 		v = retval;
 	}

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -286,10 +286,18 @@ time_t ts_not_null(const json* j, const char* keyname)
 			}
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%dT%T", &timestamp);
 			timestamp.tm_isdst = 0;
-			retval = mktime(&timestamp);
+			#ifndef _WIN32
+				retval = timegm(&timestamp);
+			#else
+				retval = _mkgmtime(&timestamp);
+			#endif
 		} else {
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%d %T", &timestamp);
-			retval = mktime(&timestamp);
+			#ifndef _WIN32
+				retval = timegm(&timestamp);
+			#else
+				retval = _mkgmtime(&timestamp);
+			#endif
 		}
 	}
 	return retval;

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -319,10 +319,18 @@ void set_ts_not_null(const json* j, const char* keyname, time_t &v)
 			}
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%dT%T", &timestamp);
 			timestamp.tm_isdst = 0;
-			retval = mktime(&timestamp);
+#ifndef _WIN32
+			retval = timegm(&timestamp);
+#else
+			retval = _mkgmtime(&timestamp);
+#endif
 		} else {
 			crossplatform_strptime(timedate.substr(0, 19).c_str(), "%Y-%m-%d %T", &timestamp);
-			retval = mktime(&timestamp);
+#ifndef _WIN32
+			retval = timegm(&timestamp);
+#else
+			retval = _mkgmtime(&timestamp);
+#endif
 		}
 		v = retval;
 	}


### PR DESCRIPTION
This PR fixes the `ts_not_null` unittest breaking on a non-UTC machine. It also fixes `set_ts_not_null`.

For more understanding, `mktime` returns a **local time**, not a UTC time. It's also not based off your BIOS time, as previously assumed in #1063, but rather the user-level time.

Fixes #1063 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
