### PR TITLE
feat: add embed-only message ctor

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2024,12 +2024,19 @@ public:
 	message(snowflake channel_id, const std::string &content, message_type type = mt_default);
 
 	/**
+	 * @brief Construct a new message object with content
+	 *
+	 * @param _embed An embed to send
+	 */
+	message(const embed& _embed);
+
+	/**
 	 * @brief Construct a new message object with a channel and content
 	 *
 	 * @param channel_id The channel to send the message to
 	 * @param _embed An embed to send
 	 */
-	message(snowflake channel_id, const embed & _embed);
+	message(snowflake channel_id, const embed& _embed);
 
 	/**
 	 * @brief Construct a new message object with content

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -622,9 +622,12 @@ message::message(const std::string &_content, message_type t) : message() {
 	type = t;
 }
 
-message::message(snowflake _channel_id, const embed& _embed) : message() {
-	channel_id = _channel_id;
+message::message(const embed& _embed) : message() {
 	embeds.emplace_back(_embed);
+}
+
+message::message(snowflake _channel_id, const embed& _embed) : message(_embed) {
+	channel_id = _channel_id;
 }
 
 embed::embed(json* j) : embed() {


### PR DESCRIPTION
This PR adds an embed-only constructor to `dpp::message`. Since `message(snowflake channel_id, const embed& _embed)` exists, it seemed natural and useful to have a version without the channel id.

```c++
// this is probably the most common reply on my bot
event.reply(dpp::message{}.add_embed(embed));

// now you could just do this
event.reply(dpp::message{embed});

// or this with the implicit conversion
event.reply(embed);
```

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.