### PR TITLE
fix: correct wrong linking order to fix static build

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -258,7 +258,7 @@ foreach (fullmodname ${subdirlist})
 		endif()
 
 	else()
-		target_link_libraries(${modname} PUBLIC ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${ZLIB_LIBRARIES})
+		target_link_libraries(${modname} PUBLIC ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${ZLIB_LIBRARIES})
 		if (MINGW)
 			target_link_libraries(${modname} PUBLIC wsock32 ws2_32 crypt32)
 		endif ()


### PR DESCRIPTION
Build DPP statically causing linker errors with OpenSSL with undefined references

```
/usr/bin/ld: s3_lib.c:(.text+0x348): undefined reference to `OPENSSL_sk_pop_free'
/usr/bin/ld: s3_lib.c:(.text+0x35c): undefined reference to `CRYPTO_free'
/usr/bin/ld: s3_lib.c:(.text+0x377): undefined reference to `CRYPTO_clear_free'
/usr/bin/ld: s3_lib.c:(.text+0x38b): undefined reference to `CRYPTO_free'
/usr/bin/ld: s3_lib.c:(.text+0x39f): undefined reference to `CRYPTO_free'
/usr/bin/ld: s3_lib.c:(.text+0x3ab): undefined reference to `EVP_PKEY_free'
/usr/bin/ld: s3_lib.c:(.text+0x3b7): undefined reference to `EVP_PKEY_free'
/usr/bin/ld: s3_lib.c:(.text+0x3d3): undefined reference to `CRYPTO_free'
/usr/bin/ld: s3_lib.c:(.text+0x3e7): undefined reference to `CRYPTO_free'
/usr/bin/ld: s3_lib.c:(.text+0x440): undefined reference to `CRYPTO_free'
```

So i corrected the linking order to fix that problem.

## Code change checklist

- [ N/A ] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [ N/A ] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ Yes ] I tested that my change works before raising the PR.
- [ Yes ] I have ensured that I did not break any existing API calls.
- [ Yes ] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
