### PR TITLE
fix: get size of object instead of pointer

### DIFF
--- a/include/dpp/cache.h
+++ b/include/dpp/cache.h
@@ -250,7 +250,7 @@ public:
 	 */
 	size_t bytes() {
 		std::shared_lock l(cache_mutex);
-		return sizeof(this) + (cache_map->bucket_count() * sizeof(size_t));
+		return sizeof(*this) + (cache_map->bucket_count() * sizeof(size_t));
 	}
 
 };


### PR DESCRIPTION
The `this` keyword is evaluated to a pointer to an object of a given type so `sizeof(this)` returns the size of the pointer instead of the object so use `sizeof(*this)` instead.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
