### PR TITLE
fix: out-of-bounds read of MIME types

### DIFF
--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -103,7 +103,7 @@ multipart_content https_client::build_multipart(const std::string &json, const s
 			/* Multiple files */
 			for (size_t i = 0; i < filenames.size(); ++i) {
 				content += part_start + "name=\"files[" + std::to_string(i) + "]\"; filename=\"" + filenames[i] + "\"";
-				content += "\r\nContent-Type: " + (mimetypes.size() < i || mimetypes[i].empty() ? default_mime_type : mimetypes[i]) + two_cr;
+				content += "\r\nContent-Type: " + (mimetypes.size() <= i || mimetypes[i].empty() ? default_mime_type : mimetypes[i]) + two_cr;
 				content += contents[i];
 				content += "\r\n";
 			}


### PR DESCRIPTION
Since `i` is the index, it should be less than the size of the vector but the `mimetypes.size() < i` condition does not check for `i` being the same as the size of the vector, which causes an out-of-bounds read in the right operand of the logical OR (`||`) operator which is `mimetypes[i].empty()`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
