### PR TITLE
Ability to suppress embeds

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1770,6 +1770,15 @@ public:
 	void message_edit(const struct message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
+	 * @brief Edit the flags of a message on a channel. The callback function is called when the message has been edited
+	 *
+	 * @param m Message to edit the flags of
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void message_edit_flags(const struct message &m, command_completion_event_t callback = utility::log_error());
+
+	/**
 	 * @brief Add a reaction to a message. The reaction string must be either an `emojiname:id` or a unicode character.
 	 *
 	 * @see https://discord.com/developers/docs/resources/channel#create-reaction

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2112,7 +2112,7 @@ public:
 	/**
 	 * @brief Set whether embeds should be suppressed
 	 *
-	 * @param f whether embeds should be suppressed
+	 * @param suppress whether embeds should be suppressed
 	 * @return message& reference to self
 	 */
 	message& suppress_embeds(bool suppress);

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2110,6 +2110,14 @@ public:
 	bool suppress_embeds() const;
 
 	/**
+	 * @brief Set whether embeds should be suppressed
+	 *
+	 * @param f whether embeds should be suppressed
+	 * @return message& reference to self
+	 */
+	message& suppress_embeds(bool suppress);
+
+	/**
 	 * @brief True if source message was deleted
 	 * 
 	 * @return true if source message deleted

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -119,6 +119,16 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 	}, m.file_data);
 }
 
+void cluster::message_edit_flags(const message &m, command_completion_event_t callback) {
+	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, nlohmann::json{
+		{"flags", m.flags},
+	}.dump(), [this, callback](json &j, const http_request_completion_t& http) {
+		if (callback) {
+			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
+		}
+	}, m.file_data);
+}
+
 
 void cluster::message_get(snowflake message_id, snowflake channel_id, command_completion_event_t callback) {
 	rest_request<message>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id), m_get, "", callback);

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -357,7 +357,7 @@ void to_json(json& j, const component& cp) {
 					o["type"] = "channel";
 				} else if (v.type == dpp::cdt_user) {
 					o["type"] = "user";
-				}				
+				}
 				j["default_values"].push_back(o);
 			}
 		}
@@ -841,7 +841,7 @@ reaction::reaction(json* j) {
 	}
 }
 
-attachment::attachment(struct message* o) 
+attachment::attachment(struct message* o)
 	: id(0)
 	, size(0)
 	, width(0)
@@ -1034,6 +1034,15 @@ bool message::is_dm() const {
 
 bool message::suppress_embeds() const {
 	return flags & m_suppress_embeds;
+}
+
+message& message::suppress_embeds(bool suppress) {
+	if (suppress) {
+		flags |= m_suppress_embeds;
+	} else {
+		flags &= ~m_suppress_embeds;
+	}
+	return *this;
 }
 
 bool message::is_source_message_deleted() const {


### PR DESCRIPTION
This change adds the ability to suppress embeds in a message from another user through a combination of `dpp::message::suppress_embeds(bool)` and `dpp::cluster::message_edit_flags`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
