### PR TITLE
fix: empty presences will now warn

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -388,6 +388,11 @@ gateway::gateway(nlohmann::json* j) {
 }
 
 void cluster::set_presence(const dpp::presence &p) {
+	if(p.activities.empty()) {
+		log(ll_warning, "An empty presence was passed to set_presence.");
+		return;
+	}
+
 	json pres = p.to_json();
 	for (auto& s : shards) {
 		if (s.second->is_connected()) {


### PR DESCRIPTION
This PR no longer allows empty presences for `set_presence`. It will now give a warning. 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
