### PR TITLE
fix: Signal Handlers on Non-Windows Platforms in sslclient

### DIFF
--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -250,9 +250,9 @@ ssl_client::ssl_client(const std::string &_hostname, const std::string &_port, b
 {
 #ifndef WIN32
 	set_signal_handler(SIGALRM);
-	set_signal_handler(SIGHUP);
 	set_signal_handler(SIGXFSZ);
 	set_signal_handler(SIGCHLD);
+	signal(SIGHUP, SIG_IGN);
 	signal(SIGPIPE, SIG_IGN);
 #else
 	// Set up winsock.

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -229,7 +229,7 @@ void set_signal_handler(int signal)
 	struct sigaction sa;
 	sigaction(signal, nullptr, &sa);
 	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
-		memset(&sa, 0, sizeof(sa));
+		sa = {};
 		sigaction(signal, &sa, nullptr);
 	}
 }

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -228,8 +228,7 @@ void set_signal_handler(int signal)
 {
 	struct sigaction sa;
 	sigaction(signal, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
 		memset(&sa, 0, sizeof(sa));
 		sigaction(signal, &sa, nullptr);
 	}

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -238,49 +238,34 @@ ssl_client::ssl_client(const std::string &_hostname, const std::string &_port, b
 {
 #ifndef WIN32
 	struct sigaction sa;
+	struct sigaction action;
+	memset(&action, 0, sizeof(action));
+	action.sa_handler = SIG_IGN;
+	action.sa_flags = SA_RESTART;
+
 	sigaction(SIGALRM, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = SIG_IGN;
-		sa.sa_flags = SA_RESTART;
-		sigaction(SIGALRM, &sa, nullptr);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
+		sigaction(SIGALRM, &action, nullptr);
 	}
 
 	sigaction(SIGHUP, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = SIG_IGN;
-		sa.sa_flags = SA_RESTART;
-		sigaction(SIGHUP, &sa, nullptr);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
+		sigaction(SIGHUP, &action, nullptr);
 	}
 
 	sigaction(SIGPIPE, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = SIG_IGN;
-		sa.sa_flags = SA_RESTART;
-		sigaction(SIGPIPE, &sa, nullptr);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
+		sigaction(SIGPIPE, &action, nullptr);
 	}
 
 	sigaction(SIGCHLD, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = SIG_IGN;
-		sa.sa_flags = SA_RESTART;
-		sigaction(SIGCHLD, &sa, nullptr);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
+		sigaction(SIGCHLD, &action, nullptr);
 	}
 
 	sigaction(SIGXFSZ, nullptr, &sa);
-	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
-	{
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = SIG_IGN;
-		sa.sa_flags = SA_RESTART;
-		sigaction(SIGXFSZ, &sa, nullptr);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr) {
+		sigaction(SIGXFSZ, &action, nullptr);
 	}
 #else
 	// Set up winsock.

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -237,11 +237,51 @@ ssl_client::ssl_client(const std::string &_hostname, const std::string &_port, b
 	keepalive(reuse)
 {
 #ifndef WIN32
-	signal(SIGALRM, SIG_IGN);
-	signal(SIGHUP, SIG_IGN);
-	signal(SIGPIPE, SIG_IGN);
-	signal(SIGCHLD, SIG_IGN);
-	signal(SIGXFSZ, SIG_IGN);
+	struct sigaction sa;
+	sigaction(SIGALRM, nullptr, &sa);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
+	{
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = SIG_IGN;
+		sa.sa_flags = SA_RESTART;
+		sigaction(SIGALRM, &sa, nullptr);
+	}
+
+	sigaction(SIGHUP, nullptr, &sa);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
+	{
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = SIG_IGN;
+		sa.sa_flags = SA_RESTART;
+		sigaction(SIGHUP, &sa, nullptr);
+	}
+
+	sigaction(SIGPIPE, nullptr, &sa);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
+	{
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = SIG_IGN;
+		sa.sa_flags = SA_RESTART;
+		sigaction(SIGPIPE, &sa, nullptr);
+	}
+
+	sigaction(SIGCHLD, nullptr, &sa);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
+	{
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = SIG_IGN;
+		sa.sa_flags = SA_RESTART;
+		sigaction(SIGCHLD, &sa, nullptr);
+	}
+
+	sigaction(SIGXFSZ, nullptr, &sa);
+	if (sa.sa_flags == 0 && sa.sa_handler == nullptr)
+	{
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = SIG_IGN;
+		sa.sa_flags = SA_RESTART;
+		sigaction(SIGXFSZ, &sa, nullptr);
+	}
 #else
 	// Set up winsock.
 	WSADATA wsadata;


### PR DESCRIPTION
Only set signals to Ignore on non-Linux of no signal-handler is in place. Also set the SA_RESTART flag to avoid operations returning EINTR.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
