### PR TITLE
fix: error in logging with malformed json that doesnt fit the structure for an error

### DIFF
--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -638,11 +638,19 @@ std::function<void(const dpp::confirmation_callback_t& detail)> log_error() {
 	return [](const dpp::confirmation_callback_t& detail) {
 		if (detail.is_error()) {
 			if (detail.bot) {
-				error_info e = detail.get_error();
-				detail.bot->log(
-					dpp::ll_error, 
-					"Error: " + e.human_readable
-				);
+				try {
+					error_info e = detail.get_error();
+					detail.bot->log(
+						dpp::ll_error,
+						"Error: " + e.human_readable
+					);
+				}
+				catch (const std::exception& e) {
+					detail.bot->log(
+						dpp::ll_error,
+						"Error: " + std::string(e.what())
+					);
+				}
 			}
 		}
 	};


### PR DESCRIPTION
adds a try/catch around log_error internals to catch malformed or incorrect error output such as null error jsons

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
