### PR TITLE
fix: fix human_readable for good

### DIFF
--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -220,7 +220,7 @@ struct DPP_EXPORT error_detail {
 	/**
 	 * @brief Object field index
 	 */
-	int index = 0;
+	DPP_DEPRECATED("index is unused and will be removed in a future version") int index = 0;
 };
 
 /**

--- a/src/dpp/cluster/confirmation.cpp
+++ b/src/dpp/cluster/confirmation.cpp
@@ -92,7 +92,15 @@ std::vector<error_detail> find_errors_in_object(const std::string& obj, int inde
 	} else {
 		for (auto it = j.begin(); it != j.end(); ++it) {
 			std::vector<error_detail> sub_errors;
-			std::string               field = obj.empty() ? current_field : obj + '.' + current_field;
+			std::string               field;
+
+			if (obj.empty()) {
+				field = current_field;
+			} else if (isdigit(*current_field.c_str())) {
+				field = obj + '[' + current_field + ']';
+			} else {
+				field = obj + '.' + current_field;
+			}
 
 			if (it->is_array()) {
 				sub_errors = find_errors_in_array(field, index, it.key(), *it);

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -188,6 +188,23 @@ Markdown lol ||spoiler|| ~~strikethrough~~ `small *code* block`\n";
 	}";
 	error_message_success = (error_message_success && error_test.get_error().human_readable == "50035: Invalid Form Body - <array>[1].options[1].description: Must be between 1 and 100 in length. (BASE_TYPE_BAD_LENGTH)");
 
+	error_test.http_info.body = "{\
+  	\"message\": \"Invalid Form Body\",\
+  	\"code\": 50035,\
+  	\"errors\": {\
+  	  \"data\": {\
+  	    \"poll\": {\
+  	      \"_errors\": [\
+  	        {\
+							\"code\": \"POLL_TYPE_QUESTION_ALLOWS_TEXT_ONLY\",\
+ 							\"message\": \"This poll type cannot include attachments, emoji or stickers with the question\"}\
+  	      ]\
+  	    }\
+  	  }\
+  	}\
+	}";
+	error_message_success = (error_message_success && error_test.get_error().human_readable == "50035: Invalid Form Body - data.poll: This poll type cannot include attachments, emoji or stickers with the question (POLL_TYPE_QUESTION_ALLOWS_TEXT_ONLY)");
+
 	set_test(ERRORS, error_message_success);
 
 	set_test(MD_ESC_1, false);


### PR DESCRIPTION
Example:
```json
{
  "message": "Invalid Form Body",
  "code": 50035,
  "errors": {
    "data": {
      "poll": {
        "_errors": [
          {"code": "POLL_TYPE_QUESTION_ALLOWS_TEXT_ONLY", "message": "This poll type cannot include attachments, emoji or stickers with the question"}
        ]
      }
    }
  }
}
```

Currently the code assumes a `_errors` object either at the first or second level, this one is at the third level, so it wouldn't parse. This PR fixes that and adds handling of errors without an array: `Error: 50035: Invalid Form Body - data.poll: This poll type cannot include attachments, emoji or stickers with the question (POLL_TYPE_QUESTION_ALLOWS_TEXT_ONLY)`

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
