### PR TITLE
ci: Mac runner removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,10 @@ jobs:
     strategy:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
-        # arm64 is a self-hosted runner on a Mac M2 Mini, ran inside a virtual machine by Archie Jaskowicz.
+        # arm64 is a self-hosted runner on a Mac M2 Mini, ran inside a virtual machine by Archie Jaskowicz. NOTE: This runner no longer exists. It may come back in a few months.
         cfg:
           - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-14, cmake-flags: ''}
-          - { arch: 'arm64', concurrency: 2, os: [self-hosted, ARM64, macOS], cpp-version: clang++-15, cmake-flags: ''}
+#          - { arch: 'arm64', concurrency: 2, os: [self-hosted, ARM64, macOS], cpp-version: clang++-15, cmake-flags: ''}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1


### PR DESCRIPTION
This PR removes the self-hosted mac runner that is run by myself. It's getting too much to run this whilst also trying to test personal projects (thanks new mac os update). I'll look to bring it back in summer if I can figure out how to move it from a VM to a jailed process.