### PR TITLE
FIX: QOL: non fatal utf8 handling.

### DIFF
--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -1985,6 +1985,70 @@ message_map messages_get_sync(snowflake channel_id, snowflake around, snowflake 
 confirmation message_unpin_sync(snowflake channel_id, snowflake message_id);
 
 /**
+ * @brief Get a list of users that voted for this specific answer.
+ *
+ * @param m Message that contains the poll to retrieve the answers from
+ * @param answer_id ID of the answer to retrieve votes from (see poll_answer::answer_id)
+ * @param after Users after this ID should be retrieved if this is set to non-zero
+ * @param limit This number of users maximum should be returned, up to 100
+ * @return user_map returned object on completion
+ * @see dpp::cluster::poll_get_answer_voters
+ * @see https://discord.com/developers/docs/resources/poll#get-answer-voters
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+user_map poll_get_answer_voters_sync(const message& m, uint32_t answer_id, snowflake after, uint64_t limit);
+
+/**
+ * @brief Get a list of users that voted for this specific answer.
+ *
+ * @param message_id ID of the message with the poll to retrieve the answers from
+ * @param channel_id ID of the channel with the poll to retrieve the answers from
+ * @param answer_id ID of the answer to retrieve votes from (see poll_answer::answer_id)
+ * @param after Users after this ID should be retrieved if this is set to non-zero
+ * @param limit This number of users maximum should be returned, up to 100
+ * @return user_map returned object on completion
+ * @see dpp::cluster::poll_get_answer_voters
+ * @see https://discord.com/developers/docs/resources/poll#get-answer-voters
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+user_map poll_get_answer_voters_sync(snowflake message_id, snowflake channel_id, uint32_t answer_id, snowflake after, uint64_t limit);
+
+/**
+ * @brief Immediately end a poll.
+ *
+ * @param m Message that contains the poll
+ * @return message returned object on completion
+ * @see dpp::cluster::poll_end
+ * @see https://discord.com/developers/docs/resources/poll#end-poll
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+message poll_end_sync(const message &m);
+
+/**
+ * @brief Immediately end a poll.
+ *
+ * @param message_id ID of the message with the poll to end
+ * @param channel_id ID of the channel with the poll to end
+ * @return message returned object on completion
+ * @see dpp::cluster::poll_end
+ * @see https://discord.com/developers/docs/resources/poll#end-poll
+ * \memberof dpp::cluster
+ * @throw dpp::rest_exception upon failure to execute REST function
+ * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
+ * Avoid direct use of this function inside an event handler.
+ */
+message poll_end_sync(snowflake message_id, snowflake channel_id);
+
+/**
  * @brief Get a channel's pins
  * @see dpp::cluster::channel_pins_get
  * @see https://discord.com/developers/docs/resources/channel#get-pinned-messages

--- a/include/dpp/json_interface.h
+++ b/include/dpp/json_interface.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #include <dpp/export.h>
-#include <dpp/json_fwd.h>
+#include <dpp/json.h>
 
 namespace dpp {
 
@@ -66,7 +66,7 @@ struct json_interface {
 	 */
 	template <typename U = T, typename = decltype(std::declval<U&>().to_json_impl(bool{}))>
 	std::string build_json(bool with_id = false) const {
-		return to_json(with_id).dump(-1, ' ', false, nlohmann::json::error_handler_t::ignore);
+		return to_json(with_id).dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
 	}
 };
 

--- a/include/dpp/json_interface.h
+++ b/include/dpp/json_interface.h
@@ -66,7 +66,7 @@ struct json_interface {
 	 */
 	template <typename U = T, typename = decltype(std::declval<U&>().to_json_impl(bool{}))>
 	std::string build_json(bool with_id = false) const {
-		return to_json(with_id).dump();
+		return to_json(with_id).dump(-1, ' ', false, nlohmann::json::error_handler_t::ignore);
 	}
 };
 

--- a/include/dpp/nlohmann/json.hpp
+++ b/include/dpp/nlohmann/json.hpp
@@ -24300,7 +24300,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
 std::string to_string(const NLOHMANN_BASIC_JSON_TPL& j)
 {
-    return j.dump();
+    return j.dump(-1, ' ', false, json::error_handler_t::ignore);
 }
 
 inline namespace literals

--- a/src/dpp/auditlog.cpp
+++ b/src/dpp/auditlog.cpp
@@ -42,10 +42,10 @@ audit_entry &audit_entry::fill_from_json_impl(nlohmann::json *j) {
 			audit_change ac;
 			ac.key = string_not_null(&change, "key");
 			if (change.find("new_value") != change.end()) {
-				ac.new_value = change["new_value"].dump(-1, ' ', false, json::error_handler_t::ignore);
+				ac.new_value = change["new_value"].dump(-1, ' ', false, json::error_handler_t::replace);
 			}
 			if (change.find("old_value") != change.end()) {
-				ac.old_value = change["old_value"].dump(-1, ' ', false, json::error_handler_t::ignore);
+				ac.old_value = change["old_value"].dump(-1, ' ', false, json::error_handler_t::replace);
 			}
 			this->changes.push_back(ac);
 		}

--- a/src/dpp/auditlog.cpp
+++ b/src/dpp/auditlog.cpp
@@ -42,10 +42,10 @@ audit_entry &audit_entry::fill_from_json_impl(nlohmann::json *j) {
 			audit_change ac;
 			ac.key = string_not_null(&change, "key");
 			if (change.find("new_value") != change.end()) {
-				ac.new_value = change["new_value"].dump();
+				ac.new_value = change["new_value"].dump(-1, ' ', false, json::error_handler_t::ignore);
 			}
 			if (change.find("old_value") != change.end()) {
-				ac.old_value = change["old_value"].dump();
+				ac.old_value = change["old_value"].dump(-1, ' ', false, json::error_handler_t::ignore);
 			}
 			this->changes.push_back(ac);
 		}

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -317,7 +317,7 @@ json error_response(const std::string& message, http_request_completion_t& rv)
 		}},
 		{"message", message}
 	});
-	rv.body = j.dump(-1, ' ', false, json::error_handler_t::ignore);
+	rv.body = j.dump(-1, ' ', false, json::error_handler_t::replace);
 	return j;
 }
 

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -317,7 +317,7 @@ json error_response(const std::string& message, http_request_completion_t& rv)
 		}},
 		{"message", message}
 	});
-	rv.body = j.dump();
+	rv.body = j.dump(-1, ' ', false, json::error_handler_t::ignore);
 	return j;
 }
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -28,7 +28,7 @@ void cluster::global_bulk_command_create(const std::vector<slashcommand> &comman
 	for (auto & s : commands) {
 		j.push_back(s.to_json(false));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::global_bulk_command_delete(command_completion_event_t callback) {
@@ -60,7 +60,7 @@ void cluster::guild_bulk_command_create(const std::vector<slashcommand> &command
 	for (auto & s : commands) {
 		j.push_back(s.to_json(false));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::guild_bulk_command_delete(snowflake guild_id, command_completion_event_t callback) {
@@ -85,7 +85,7 @@ void cluster::guild_bulk_command_edit_permissions(const std::vector<slashcommand
 		}
 		j.push_back(jcommand);
 	}
-	rest_request_list<guild_command_permissions>(this, API_PATH "/applications", std::to_string(me.id), "guilds/" + std::to_string(guild_id) + "/commands/permissions", m_put, j.dump(), callback);
+	rest_request_list<guild_command_permissions>(this, API_PATH "/applications", std::to_string(me.id), "guilds/" + std::to_string(guild_id) + "/commands/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::guild_command_create(const slashcommand &s, snowflake guild_id, command_completion_event_t callback) {
@@ -116,7 +116,7 @@ void cluster::guild_command_edit_permissions(const slashcommand &s, snowflake gu
 			j["permissions"].push_back(jperm);
 		}
 	}
-	rest_request<confirmation>(this, API_PATH "/applications", std::to_string(s.application_id ? s.application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands/" + std::to_string(s.id) + "/permissions", m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/applications", std::to_string(s.application_id ? s.application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands/" + std::to_string(s.id) + "/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::guild_command_get(snowflake id, snowflake guild_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -28,7 +28,7 @@ void cluster::global_bulk_command_create(const std::vector<slashcommand> &comman
 	for (auto & s : commands) {
 		j.push_back(s.to_json(false));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::global_bulk_command_delete(command_completion_event_t callback) {
@@ -60,7 +60,7 @@ void cluster::guild_bulk_command_create(const std::vector<slashcommand> &command
 	for (auto & s : commands) {
 		j.push_back(s.to_json(false));
 	}
-	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(commands.size() > 0 && commands[0].application_id ? commands[0].application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::guild_bulk_command_delete(snowflake guild_id, command_completion_event_t callback) {
@@ -85,7 +85,7 @@ void cluster::guild_bulk_command_edit_permissions(const std::vector<slashcommand
 		}
 		j.push_back(jcommand);
 	}
-	rest_request_list<guild_command_permissions>(this, API_PATH "/applications", std::to_string(me.id), "guilds/" + std::to_string(guild_id) + "/commands/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request_list<guild_command_permissions>(this, API_PATH "/applications", std::to_string(me.id), "guilds/" + std::to_string(guild_id) + "/commands/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::guild_command_create(const slashcommand &s, snowflake guild_id, command_completion_event_t callback) {
@@ -116,7 +116,7 @@ void cluster::guild_command_edit_permissions(const slashcommand &s, snowflake gu
 			j["permissions"].push_back(jperm);
 		}
 	}
-	rest_request<confirmation>(this, API_PATH "/applications", std::to_string(s.application_id ? s.application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands/" + std::to_string(s.id) + "/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/applications", std::to_string(s.application_id ? s.application_id : me.id), "guilds/" + std::to_string(guild_id) + "/commands/" + std::to_string(s.id) + "/permissions", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::guild_command_get(snowflake id, snowflake guild_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -43,7 +43,7 @@ void cluster::channel_edit_permissions(const class channel &c, const snowflake o
 
 void cluster::channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback) {
 	json j({ {"allow", std::to_string(allow)}, {"deny", std::to_string(deny)}, {"type", member ? 1 : 0}  });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "permissions/" + std::to_string(overwrite_id), m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "permissions/" + std::to_string(overwrite_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::channel_edit_positions(const std::vector<channel> &c, command_completion_event_t callback) {
@@ -61,7 +61,7 @@ void cluster::channel_edit_positions(const std::vector<channel> &c, command_comp
 		}
 		j.push_back(cj);
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(c[0].guild_id), "channels/" + std::to_string(c[0].id), m_patch, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(c[0].guild_id), "channels/" + std::to_string(c[0].id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::channel_edit(const class channel &c, command_completion_event_t callback) {
@@ -70,7 +70,7 @@ void cluster::channel_edit(const class channel &c, command_completion_event_t ca
 
 void cluster::channel_follow_news(const class channel &c, snowflake target_channel_id, command_completion_event_t callback) {
 	json j({ {"webhook_channel_id", target_channel_id} });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(c.id), "followers", m_post, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(c.id), "followers", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::channel_get(snowflake c, command_completion_event_t callback) {
@@ -100,7 +100,7 @@ void cluster::channels_get(snowflake guild_id, command_completion_event_t callba
 
 void cluster::channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback) {
 	json j({ {"status", status} });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 } // namespace dpp

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -43,7 +43,7 @@ void cluster::channel_edit_permissions(const class channel &c, const snowflake o
 
 void cluster::channel_edit_permissions(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member, command_completion_event_t callback) {
 	json j({ {"allow", std::to_string(allow)}, {"deny", std::to_string(deny)}, {"type", member ? 1 : 0}  });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "permissions/" + std::to_string(overwrite_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "permissions/" + std::to_string(overwrite_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::channel_edit_positions(const std::vector<channel> &c, command_completion_event_t callback) {
@@ -61,7 +61,7 @@ void cluster::channel_edit_positions(const std::vector<channel> &c, command_comp
 		}
 		j.push_back(cj);
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(c[0].guild_id), "channels/" + std::to_string(c[0].id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(c[0].guild_id), "channels/" + std::to_string(c[0].id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::channel_edit(const class channel &c, command_completion_event_t callback) {
@@ -70,7 +70,7 @@ void cluster::channel_edit(const class channel &c, command_completion_event_t ca
 
 void cluster::channel_follow_news(const class channel &c, snowflake target_channel_id, command_completion_event_t callback) {
 	json j({ {"webhook_channel_id", target_channel_id} });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(c.id), "followers", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(c.id), "followers", m_post, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::channel_get(snowflake c, command_completion_event_t callback) {
@@ -100,7 +100,7 @@ void cluster::channels_get(snowflake guild_id, command_completion_event_t callba
 
 void cluster::channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback) {
 	json j({ {"status", status} });
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 } // namespace dpp

--- a/src/dpp/cluster/dm.cpp
+++ b/src/dpp/cluster/dm.cpp
@@ -23,7 +23,7 @@
 namespace dpp {
 
 void cluster::create_dm_channel(snowflake user_id, command_completion_event_t callback) {
-	rest_request<channel>(this, API_PATH "/users", "@me", "channels", m_post, json({{"recipient_id", std::to_string(user_id)}}).dump(), callback);
+	rest_request<channel>(this, API_PATH "/users", "@me", "channels", m_post, json({{"recipient_id", std::to_string(user_id)}}).dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::current_user_get_dms(command_completion_event_t callback) {
@@ -56,7 +56,7 @@ void cluster::gdm_add(snowflake channel_id, snowflake user_id, const std::string
 	json params;
 	params["access_token"] = access_token;
 	params["nick"] = nick;
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "recipients/" + std::to_string(user_id), m_put, params.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "recipients/" + std::to_string(user_id), m_put, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::gdm_remove(snowflake channel_id, snowflake user_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/dm.cpp
+++ b/src/dpp/cluster/dm.cpp
@@ -23,7 +23,7 @@
 namespace dpp {
 
 void cluster::create_dm_channel(snowflake user_id, command_completion_event_t callback) {
-	rest_request<channel>(this, API_PATH "/users", "@me", "channels", m_post, json({{"recipient_id", std::to_string(user_id)}}).dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<channel>(this, API_PATH "/users", "@me", "channels", m_post, json({{"recipient_id", std::to_string(user_id)}}).dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::current_user_get_dms(command_completion_event_t callback) {
@@ -56,7 +56,7 @@ void cluster::gdm_add(snowflake channel_id, snowflake user_id, const std::string
 	json params;
 	params["access_token"] = access_token;
 	params["nick"] = nick;
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "recipients/" + std::to_string(user_id), m_put, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "recipients/" + std::to_string(user_id), m_put, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::gdm_remove(snowflake channel_id, snowflake user_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -24,7 +24,7 @@
 namespace dpp {
 
 void cluster::guild_current_member_edit(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
-	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::ignore);
+	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::replace);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, o, callback);
 }
 
@@ -52,7 +52,7 @@ void cluster::guild_ban_add(snowflake guild_id, snowflake user_id, uint32_t dele
 			}
 		}
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "bans/" + std::to_string(user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "bans/" + std::to_string(user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -140,7 +140,7 @@ void cluster::guild_begin_prune(snowflake guild_id, const struct prune& pruneinf
 
 
 void cluster::guild_set_nickname(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
-	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::ignore);
+	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::replace);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me/nick", m_patch, o, callback);
 }
 
@@ -165,7 +165,7 @@ void cluster::guild_get_welcome_screen(snowflake guild_id, command_completion_ev
 void cluster::guild_edit_welcome_screen(snowflake guild_id, const struct welcome_screen& welcome_screen, bool enabled, command_completion_event_t callback) {
 	json j = welcome_screen.to_json();
 	j["enabled"] = enabled;
-	rest_request<dpp::welcome_screen>(this, API_PATH "/guilds", std::to_string(guild_id), "welcome-screen", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<dpp::welcome_screen>(this, API_PATH "/guilds", std::to_string(guild_id), "welcome-screen", m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -24,7 +24,7 @@
 namespace dpp {
 
 void cluster::guild_current_member_edit(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
-	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump();
+	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::ignore);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, o, callback);
 }
 
@@ -52,7 +52,7 @@ void cluster::guild_ban_add(snowflake guild_id, snowflake user_id, uint32_t dele
 			}
 		}
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "bans/" + std::to_string(user_id), m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "bans/" + std::to_string(user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
@@ -140,7 +140,7 @@ void cluster::guild_begin_prune(snowflake guild_id, const struct prune& pruneinf
 
 
 void cluster::guild_set_nickname(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
-	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump();
+	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::ignore);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me/nick", m_patch, o, callback);
 }
 
@@ -165,7 +165,7 @@ void cluster::guild_get_welcome_screen(snowflake guild_id, command_completion_ev
 void cluster::guild_edit_welcome_screen(snowflake guild_id, const struct welcome_screen& welcome_screen, bool enabled, command_completion_event_t callback) {
 	json j = welcome_screen.to_json();
 	j["enabled"] = enabled;
-	rest_request<dpp::welcome_screen>(this, API_PATH "/guilds", std::to_string(guild_id), "welcome-screen", m_patch, j.dump(), callback);
+	rest_request<dpp::welcome_screen>(this, API_PATH "/guilds", std::to_string(guild_id), "welcome-screen", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -25,7 +25,7 @@ namespace dpp {
 void cluster::guild_add_member(const guild_member& gm, const std::string &access_token, command_completion_event_t callback) {
 	json j = gm.to_json();
 	j["access_token"] = access_token;
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_put, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
@@ -93,13 +93,13 @@ void cluster::guild_member_timeout(snowflake guild_id, snowflake user_id, time_t
 		j["communication_disabled_until"] = json::value_t::null;
 	}
 
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::guild_member_timeout_remove(snowflake guild_id, snowflake user_id, command_completion_event_t callback) {
 	json j;
 	j["communication_disabled_until"] = json::value_t::null;
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
@@ -122,7 +122,7 @@ void cluster::guild_member_move(const snowflake channel_id, const snowflake guil
         j["channel_id"] = json::value_t::null;
     }
 
-    this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(), [this, guild_id, user_id, callback](json &j, const http_request_completion_t& http) {
+    this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), [this, guild_id, user_id, callback](json &j, const http_request_completion_t& http) {
 	if (callback) {
 	    callback(confirmation_callback_t(this, guild_member().fill_from_json(&j, guild_id, user_id), http));
 	}

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -25,7 +25,7 @@ namespace dpp {
 void cluster::guild_add_member(const guild_member& gm, const std::string &access_token, command_completion_event_t callback) {
 	json j = gm.to_json();
 	j["access_token"] = access_token;
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -93,13 +93,13 @@ void cluster::guild_member_timeout(snowflake guild_id, snowflake user_id, time_t
 		j["communication_disabled_until"] = json::value_t::null;
 	}
 
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::guild_member_timeout_remove(snowflake guild_id, snowflake user_id, command_completion_event_t callback) {
 	json j;
 	j["communication_disabled_until"] = json::value_t::null;
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -122,7 +122,7 @@ void cluster::guild_member_move(const snowflake channel_id, const snowflake guil
         j["channel_id"] = json::value_t::null;
     }
 
-    this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), [this, guild_id, user_id, callback](json &j, const http_request_completion_t& http) {
+    this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "members/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), [this, guild_id, user_id, callback](json &j, const http_request_completion_t& http) {
 	if (callback) {
 	    callback(confirmation_callback_t(this, guild_member().fill_from_json(&j, guild_id, user_id), http));
 	}

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -66,7 +66,7 @@ void cluster::message_delete_bulk(const std::vector<snowflake>& message_ids, sno
 	for (auto & m : message_ids) {
 		j["messages"].push_back(std::to_string(m));
 	}
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "messages/bulk-delete", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "messages/bulk-delete", m_post, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -122,7 +122,7 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 void cluster::message_edit_flags(const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, nlohmann::json{
 		{"flags", m.flags},
-	}.dump(-1, ' ', false, json::error_handler_t::ignore), [this, callback](json &j, const http_request_completion_t& http) {
+	}.dump(-1, ' ', false, json::error_handler_t::replace), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -66,7 +66,7 @@ void cluster::message_delete_bulk(const std::vector<snowflake>& message_ids, sno
 	for (auto & m : message_ids) {
 		j["messages"].push_back(std::to_string(m));
 	}
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "messages/bulk-delete", m_post, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "messages/bulk-delete", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
@@ -122,7 +122,7 @@ void cluster::message_edit(const message &m, command_completion_event_t callback
 void cluster::message_edit_flags(const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id), m_patch, nlohmann::json{
 		{"flags", m.flags},
-	}.dump(), [this, callback](json &j, const http_request_completion_t& http) {
+	}.dump(-1, ' ', false, json::error_handler_t::ignore), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, message(this).fill_from_json(&j), http));
 		}

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -43,7 +43,7 @@ void cluster::roles_edit_position(snowflake guild_id, const std::vector<role> &r
 	for (auto & r : roles) {
 		j.push_back({ {"id", r.id}, {"position", r.position} });
 	}
-	rest_request_list<role>(this, API_PATH "/guilds", std::to_string(guild_id), "roles", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request_list<role>(this, API_PATH "/guilds", std::to_string(guild_id), "roles", m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::roles_get(snowflake guild_id, command_completion_event_t callback) {
@@ -59,7 +59,7 @@ void cluster::application_role_connection_update(snowflake application_id, const
 	for (const auto &conn_metadata : connection_metadata) {
 		j.push_back(conn_metadata.to_json());
 	}
-	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::user_application_role_connection_get(snowflake application_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -43,7 +43,7 @@ void cluster::roles_edit_position(snowflake guild_id, const std::vector<role> &r
 	for (auto & r : roles) {
 		j.push_back({ {"id", r.id}, {"position", r.position} });
 	}
-	rest_request_list<role>(this, API_PATH "/guilds", std::to_string(guild_id), "roles", m_patch, j.dump(), callback);
+	rest_request_list<role>(this, API_PATH "/guilds", std::to_string(guild_id), "roles", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::roles_get(snowflake guild_id, command_completion_event_t callback) {
@@ -59,7 +59,7 @@ void cluster::application_role_connection_update(snowflake application_id, const
 	for (const auto &conn_metadata : connection_metadata) {
 		j.push_back(conn_metadata.to_json());
 	}
-	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(), callback);
+	rest_request_vector<application_role_connection_metadata>(this, API_PATH "/applications", std::to_string(application_id), "role-connections/metadata", m_put, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::user_application_role_connection_get(snowflake application_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/template.cpp
+++ b/src/dpp/cluster/template.cpp
@@ -25,13 +25,13 @@ namespace dpp {
 
 void cluster::guild_create_from_template(const std::string &code, const std::string &name, command_completion_event_t callback) {
 	json params({{"name", name}});
-	rest_request<guild>(this, API_PATH "/guilds", "templates", code, m_post, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<guild>(this, API_PATH "/guilds", "templates", code, m_post, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
 void cluster::guild_template_create(snowflake guild_id, const std::string &name, const std::string &description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates", m_post, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates", m_post, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -42,7 +42,7 @@ void cluster::guild_template_delete(snowflake guild_id, const std::string &code,
 
 void cluster::guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_patch, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_patch, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 

--- a/src/dpp/cluster/template.cpp
+++ b/src/dpp/cluster/template.cpp
@@ -25,13 +25,13 @@ namespace dpp {
 
 void cluster::guild_create_from_template(const std::string &code, const std::string &name, command_completion_event_t callback) {
 	json params({{"name", name}});
-	rest_request<guild>(this, API_PATH "/guilds", "templates", code, m_post, params.dump(), callback);
+	rest_request<guild>(this, API_PATH "/guilds", "templates", code, m_post, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
 void cluster::guild_template_create(snowflake guild_id, const std::string &name, const std::string &description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates", m_post, params.dump(), callback);
+	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates", m_post, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 
@@ -42,7 +42,7 @@ void cluster::guild_template_delete(snowflake guild_id, const std::string &code,
 
 void cluster::guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_patch, params.dump(), callback);
+	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_patch, params.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -138,7 +138,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			break;
 	}
 
-	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(), [this, callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			auto t = thread().fill_from_json(&j);
 			confirmation_callback_t e(this, confirmation(), http);
@@ -161,7 +161,7 @@ void cluster::thread_create(const std::string& thread_name, snowflake channel_id
 		{"invitable", invitable},
 		{"rate_limit_per_user", rate_limit_per_user}
 	});
-	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(), callback);
+	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::thread_edit(const thread &t, command_completion_event_t callback)
@@ -176,7 +176,7 @@ void cluster::thread_create_with_message(const std::string& thread_name, snowfla
 		{"auto_archive_duration", auto_archive_duration},
 		{"rate_limit_per_user", rate_limit_per_user}
 	});
-	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id) + "/threads", m_post, j.dump(), callback);
+	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id) + "/threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::thread_member_add(snowflake thread_id, snowflake user_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -138,7 +138,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 			break;
 	}
 
-	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), [this, callback](json &j, const http_request_completion_t& http) {
+	this->post_rest_multipart(API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::replace), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			auto t = thread().fill_from_json(&j);
 			confirmation_callback_t e(this, confirmation(), http);
@@ -161,7 +161,7 @@ void cluster::thread_create(const std::string& thread_name, snowflake channel_id
 		{"invitable", invitable},
 		{"rate_limit_per_user", rate_limit_per_user}
 	});
-	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::thread_edit(const thread &t, command_completion_event_t callback)
@@ -176,7 +176,7 @@ void cluster::thread_create_with_message(const std::string& thread_name, snowfla
 		{"auto_archive_duration", auto_archive_duration},
 		{"rate_limit_per_user", rate_limit_per_user}
 	});
-	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id) + "/threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<thread>(this, API_PATH "/channels", std::to_string(channel_id), "messages/" + std::to_string(message_id) + "/threads", m_post, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::thread_member_add(snowflake thread_id, snowflake user_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -41,7 +41,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 		}
 		j["avatar"] = "data:" + mimetypes.find(type)->second + ";base64," + base64_encode((unsigned char const*)image_blob.data(), (unsigned int)image_blob.length());
 	}
-	rest_request<user>(this, API_PATH "/users", "@me", "", m_patch, j.dump(), callback);
+	rest_request<user>(this, API_PATH "/users", "@me", "", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::current_application_get(command_completion_event_t callback) {
@@ -65,7 +65,7 @@ void cluster::current_user_set_voice_state(snowflake guild_id, snowflake channel
 	} else {
 		j["request_to_speak_timestamp"] = json::value_t::null;
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/@me", m_patch, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/@me", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::user_set_voice_state(snowflake user_id, snowflake guild_id, snowflake channel_id, bool suppress, command_completion_event_t callback) {
@@ -73,7 +73,7 @@ void cluster::user_set_voice_state(snowflake user_id, snowflake guild_id, snowfl
 		{"channel_id", channel_id},
 		{"suppress", suppress}
 	});
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/" + std::to_string(user_id), m_patch, j.dump(), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::current_user_connections_get(command_completion_event_t callback) {

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -41,7 +41,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 		}
 		j["avatar"] = "data:" + mimetypes.find(type)->second + ";base64," + base64_encode((unsigned char const*)image_blob.data(), (unsigned int)image_blob.length());
 	}
-	rest_request<user>(this, API_PATH "/users", "@me", "", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<user>(this, API_PATH "/users", "@me", "", m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::current_application_get(command_completion_event_t callback) {
@@ -65,7 +65,7 @@ void cluster::current_user_set_voice_state(snowflake guild_id, snowflake channel
 	} else {
 		j["request_to_speak_timestamp"] = json::value_t::null;
 	}
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/@me", m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/@me", m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::user_set_voice_state(snowflake user_id, snowflake guild_id, snowflake channel_id, bool suppress, command_completion_event_t callback) {
@@ -73,7 +73,7 @@ void cluster::user_set_voice_state(snowflake user_id, snowflake guild_id, snowfl
 		{"channel_id", channel_id},
 		{"suppress", suppress}
 	});
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/voice-states/" + std::to_string(user_id), m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::current_user_connections_get(command_completion_event_t callback) {

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -63,7 +63,7 @@ void cluster::edit_webhook_with_token(const class webhook& wh, command_completio
 	if (jwh.find("channel_id") != jwh.end()) {
 		jwh.erase(jwh.find("channel_id"));
 	}
-	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(wh.token), m_patch, jwh.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
+	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(wh.token), m_patch, jwh.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 void cluster::execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, const std::string& thread_name, command_completion_event_t callback) {
@@ -83,7 +83,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		if (!wh.name.empty()) {
 			j["username"] = wh.name;
 		}
-		body = j.dump(-1, ' ', false, json::error_handler_t::ignore);
+		body = j.dump(-1, ' ', false, json::error_handler_t::replace);
 	}
 
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token : token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -63,7 +63,7 @@ void cluster::edit_webhook_with_token(const class webhook& wh, command_completio
 	if (jwh.find("channel_id") != jwh.end()) {
 		jwh.erase(jwh.find("channel_id"));
 	}
-	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(wh.token), m_patch, jwh.dump(), callback);
+	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(wh.token), m_patch, jwh.dump(-1, ' ', false, json::error_handler_t::ignore), callback);
 }
 
 void cluster::execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, const std::string& thread_name, command_completion_event_t callback) {
@@ -83,7 +83,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		if (!wh.name.empty()) {
 			j["username"] = wh.name;
 		}
-		body = j.dump();
+		body = j.dump(-1, ' ', false, json::error_handler_t::ignore);
 	}
 
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token : token) + parameters, m_post, !body.empty() ? body : m.build_json(false), [this, callback](json &j, const http_request_completion_t& http) {

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -529,6 +529,22 @@ confirmation cluster::message_unpin_sync(snowflake channel_id, snowflake message
 	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_unpin), channel_id, message_id);
 }
 
+user_map cluster::poll_get_answer_voters_sync(const message& m, uint32_t answer_id, snowflake after, uint64_t limit) {
+	return dpp::sync<user_map>(this, static_cast<void (cluster::*)(const message&, uint32_t, snowflake, uint64_t, command_completion_event_t)>(&cluster::poll_get_answer_voters), m, answer_id, after, limit);
+}
+
+user_map cluster::poll_get_answer_voters_sync(snowflake message_id, snowflake channel_id, uint32_t answer_id, snowflake after, uint64_t limit) {
+	return dpp::sync<user_map>(this, static_cast<void (cluster::*)(snowflake, snowflake, uint32_t, snowflake, uint64_t, command_completion_event_t)>(&cluster::poll_get_answer_voters), message_id, channel_id, answer_id, after, limit);
+}
+
+message cluster::poll_end_sync(const message &m) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(const message &, command_completion_event_t)>(&cluster::poll_end), m);
+}
+
+message cluster::poll_end_sync(snowflake message_id, snowflake channel_id) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::poll_end), message_id, channel_id);
+}
+
 message_map cluster::channel_pins_get_sync(snowflake channel_id) {
 	return dpp::sync<message_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channel_pins_get), channel_id);
 }

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -638,7 +638,7 @@ discord_client& discord_client::connect_voice(snowflake guild_id, snowflake chan
 
 std::string discord_client::jsonobj_to_string(const nlohmann::json& json) {
 	if (protocol == ws_json) {
-		return json.dump();
+		return json.dump(-1, ' ', false, json::error_handler_t::ignore);
 	} else {
 		return etf->build(json);
 	}

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -638,7 +638,7 @@ discord_client& discord_client::connect_voice(snowflake guild_id, snowflake chan
 
 std::string discord_client::jsonobj_to_string(const nlohmann::json& json) {
 	if (protocol == ws_json) {
-		return json.dump(-1, ' ', false, json::error_handler_t::ignore);
+		return json.dump(-1, ' ', false, json::error_handler_t::replace);
 	} else {
 		return etf->build(json);
 	}

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -431,7 +431,7 @@ void discord_client::handle_event(const std::string &event, json &j, const std::
 			ev_iter->second->handle(this, j, raw);
 		}
 	} else {
-		log(dpp::ll_debug, "Unhandled event: " + event + ", " + j.dump(-1, ' ', false, json::error_handler_t::ignore));
+		log(dpp::ll_debug, "Unhandled event: " + event + ", " + j.dump(-1, ' ', false, json::error_handler_t::replace));
 	}
 }
 

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -431,7 +431,7 @@ void discord_client::handle_event(const std::string &event, json &j, const std::
 			ev_iter->second->handle(this, j, raw);
 		}
 	} else {
-		log(dpp::ll_debug, "Unhandled event: " + event + ", " + j.dump());
+		log(dpp::ll_debug, "Unhandled event: " + event + ", " + j.dump(-1, ' ', false, json::error_handler_t::ignore));
 	}
 }
 

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -550,7 +550,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 							}
 						}
 					};
-					this->write(obj.dump(-1, ' ', false, json::error_handler_t::ignore));
+					this->write(obj.dump(-1, ' ', false, json::error_handler_t::replace));
 				} else {
 					log(dpp::ll_debug, "Connecting new voice session...");
 						json obj = {
@@ -565,7 +565,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 							}
 						}
 					};
-					this->write(obj.dump(-1, ' ', false, json::error_handler_t::ignore));
+					this->write(obj.dump(-1, ' ', false, json::error_handler_t::replace));
 				}
 				this->connect_time = time(nullptr);
 			}
@@ -655,7 +655,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 								}
 							}
 						}
-					}).dump(-1, ' ', false, json::error_handler_t::ignore));
+					}).dump(-1, ' ', false, json::error_handler_t::replace));
 				}
 			}
 			break;
@@ -1084,7 +1084,7 @@ void discord_voice_client::one_second_timer()
 		if (this->heartbeat_interval) {
 			/* Check if we're due to emit a heartbeat */
 			if (time(nullptr) > last_heartbeat + ((heartbeat_interval / 1000.0) * 0.75)) {
-				queue_message(json({{"op", 3}, {"d", rand()}}).dump(-1, ' ', false, json::error_handler_t::ignore), true);
+				queue_message(json({{"op", 3}, {"d", rand()}}).dump(-1, ' ', false, json::error_handler_t::replace), true);
 				last_heartbeat = time(nullptr);
 			}
 		}
@@ -1307,7 +1307,7 @@ discord_voice_client& discord_voice_client::speak() {
 			{"delay", 0},
 			{"ssrc", ssrc}
 		}}
-		}).dump(-1, ' ', false, json::error_handler_t::ignore), true);
+		}).dump(-1, ' ', false, json::error_handler_t::replace), true);
 		sending = true;
 	}
 	return *this;

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -550,7 +550,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 							}
 						}
 					};
-					this->write(obj.dump());
+					this->write(obj.dump(-1, ' ', false, json::error_handler_t::ignore));
 				} else {
 					log(dpp::ll_debug, "Connecting new voice session...");
 						json obj = {
@@ -565,7 +565,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 							}
 						}
 					};
-					this->write(obj.dump());
+					this->write(obj.dump(-1, ' ', false, json::error_handler_t::ignore));
 				}
 				this->connect_time = time(nullptr);
 			}
@@ -655,7 +655,7 @@ bool discord_voice_client::handle_frame(const std::string &data)
 								}
 							}
 						}
-					}).dump());
+					}).dump(-1, ' ', false, json::error_handler_t::ignore));
 				}
 			}
 			break;
@@ -1084,7 +1084,7 @@ void discord_voice_client::one_second_timer()
 		if (this->heartbeat_interval) {
 			/* Check if we're due to emit a heartbeat */
 			if (time(nullptr) > last_heartbeat + ((heartbeat_interval / 1000.0) * 0.75)) {
-				queue_message(json({{"op", 3}, {"d", rand()}}).dump(), true);
+				queue_message(json({{"op", 3}, {"d", rand()}}).dump(-1, ' ', false, json::error_handler_t::ignore), true);
 				last_heartbeat = time(nullptr);
 			}
 		}
@@ -1307,7 +1307,7 @@ discord_voice_client& discord_voice_client::speak() {
 			{"delay", 0},
 			{"ssrc", ssrc}
 		}}
-		}).dump(), true);
+		}).dump(-1, ' ', false, json::error_handler_t::ignore), true);
 		sending = true;
 	}
 	return *this;

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -781,7 +781,7 @@ guild_widget& guild_widget::fill_from_json_impl(nlohmann::json* j) {
 }
 
 json guild_widget::to_json_impl(bool with_id) const {
-	return json({{"channel_id", channel_id}, {"enabled", enabled}}).dump();
+	return json({{"channel_id", channel_id}, {"enabled", enabled}}).dump(-1, ' ', false, json::error_handler_t::ignore);
 }
 
 

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -781,7 +781,7 @@ guild_widget& guild_widget::fill_from_json_impl(nlohmann::json* j) {
 }
 
 json guild_widget::to_json_impl(bool with_id) const {
-	return json({{"channel_id", channel_id}, {"enabled", enabled}}).dump(-1, ' ', false, json::error_handler_t::ignore);
+	return json({{"channel_id", channel_id}, {"enabled", enabled}}).dump(-1, ' ', false, json::error_handler_t::replace);
 }
 
 

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -110,7 +110,7 @@ json integration::to_json_impl(bool with_id) const {
 			    { "expire_behavior", (flags & if_expire_kick) ? 1 : 0 },
 			    { "expire_grace_period", expire_grace_period },
 			    { "enable_emoticons", emoticons_enabled() }
-		    }).dump();
+		    }).dump(-1, ' ', false, json::error_handler_t::ignore);
 }
 
 bool integration::emoticons_enabled() const {

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -110,7 +110,7 @@ json integration::to_json_impl(bool with_id) const {
 			    { "expire_behavior", (flags & if_expire_kick) ? 1 : 0 },
 			    { "expire_grace_period", expire_grace_period },
 			    { "enable_emoticons", emoticons_enabled() }
-		    }).dump(-1, ' ', false, json::error_handler_t::ignore);
+		    }).dump(-1, ' ', false, json::error_handler_t::replace);
 }
 
 bool integration::emoticons_enabled() const {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1497,7 +1497,12 @@ json sticker_pack::to_json_impl(bool with_id) const {
 	j["description"] = description;
 	j["stickers"] = json::array();
 	for (auto& s : stickers) {
-		j["stickers"].push_back(json::parse(s.second.build_json(with_id)));
+		try {
+			j["stickers"].push_back(json::parse(s.second.build_json(with_id)));
+		}
+		catch (const std::exception &e) {
+			/* Protection against malformed json in sticker */
+		}
 	}
 	return j;
 }

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -474,7 +474,12 @@ json application_role_connection::to_json_impl(bool with_id) const {
 		j["platform_username"] = platform_username;
 	}
 	if (std::holds_alternative<application_role_connection_metadata>(metadata)) {
-		j["metadata"] = json::parse(std::get<application_role_connection_metadata>(metadata).build_json());
+		try {
+			j["metadata"] = json::parse(std::get<application_role_connection_metadata>(metadata).build_json());
+		}
+		catch (const std::exception &e) {
+			/* Protection against malformed json in metadata */
+		}
 	}
 	return j;
 }

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -957,6 +957,15 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			}
 		});
 
+		if (!offline) {
+			start_test(INVALIDUTF8);
+			bot.message_create(dpp::message(TEST_TEXT_CHANNEL_ID, "ä\xA9ü"), [](const auto &cc) {
+				set_status(INVALIDUTF8, ts_success);
+			});
+		} else {
+			set_status(INVALIDUTF8, ts_skipped);
+		}
+
 		dpp::utility::iconhash i;
 		std::string dummyval("fcffffffffffff55acaaaaaaaaaaaa66");
 		i = dummyval;

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -149,6 +149,7 @@ DPP_TEST(FORUM_CREATION, "create a forum channel", tf_online);
 DPP_TEST(FORUM_CHANNEL_GET, "retrieve the created forum channel", tf_online);
 DPP_TEST(FORUM_CHANNEL_DELETE, "delete the created forum channel", tf_online);
 DPP_TEST(ERRORS, "Human readable error translation", tf_offline);
+DPP_TEST(INVALIDUTF8, "Invalid UTF-8 handling", tf_online);
 
 DPP_TEST(GUILD_EDIT, "cluster::guild_edit", tf_online);
 DPP_TEST(GUILD_BAN_CREATE, "cluster::guild_ban_add ban three deleted discord accounts", tf_online);


### PR DESCRIPTION
The user can't catch these errors. We should be much more forgiving on what we accept because UTF8 is a total nightmare for end users. If there is something really bad we should let discord API report it as we do for other stuff.  nlohmann will now replace invalid utf8 with � instead of outright throwing and reconnecting the shard. This is much more durable, stable, and user friendly.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.

I have added a unit test for this.
