### PR TITLE
Updated autocomplete tutorial

### DIFF
--- a/docpages/example_code/autocomplete.cpp
+++ b/docpages/example_code/autocomplete.cpp
@@ -50,10 +50,10 @@ int main()
 				 */
 				std::string uservalue = std::get<std::string>(opt.value);
 				bot.interaction_response_create(event.command.id, event.command.token, dpp::interaction_response(dpp::ir_autocomplete_reply)
-					.add_autocomplete_choice(dpp::command_option_choice("squids", "lots of squids"))
-					.add_autocomplete_choice(dpp::command_option_choice("cats", "a few cats"))
-					.add_autocomplete_choice(dpp::command_option_choice("dogs", "bucket of dogs"))
-					.add_autocomplete_choice(dpp::command_option_choice("elephants", "bottle of elephants"))
+					.add_autocomplete_choice(dpp::command_option_choice("squids", std::string("lots of squids")))
+					.add_autocomplete_choice(dpp::command_option_choice("cats", std::string("a few cats")))
+					.add_autocomplete_choice(dpp::command_option_choice("dogs", std::string("bucket of dogs")))
+					.add_autocomplete_choice(dpp::command_option_choice("elephants", std::string("bottle of elephants")))
 				);
 				bot.log(dpp::ll_debug, "Autocomplete " + opt.name + " with value '" + uservalue + "' in field " + event.name);
 				break;


### PR DESCRIPTION
Updated autocomplete tutorial to bypass recent command_type error with automatic conversion of c-style strings to booleans instead of to std::strings, with the hope that this code should now work out of the box for new developers.

The c-style string arguments near the ends of lines 53-56 are now explicitly converted to std::string before being converted implicitly to command_type.

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
