### PR TITLE
docs: changed wording of token page

### DIFF
--- a/docpages/make_a_bot/token.md
+++ b/docpages/make_a_bot/token.md
@@ -18,7 +18,7 @@ In this panel, you can get your bot token by clicking "Reset Token". A bot token
 
 \warning **Do not share this token** with anybody! If you ever somehow compromise your current bot token or see your bot in danger, you can regenerate the token in the panel.
 
-\note This token can only be seen once (when you generate a new one). We highly recommend that, if you're going to be reusing your token, you store it in a VERY safe place (something like a password manager).
+\note This token can only be seen once. We highly recommend that, if you're going to be reusing your token, you store it in a VERY safe place (like a password manager).
 
 ## Adding the Bot to Your Server
 
@@ -33,7 +33,7 @@ That's because you've created a bot application, but it's not on any server righ
 \image html create_application_navigate_to_url_generator.png
 3. Select the `bot` scope.
 
-\note For bots, you ONLY need the `bot` scope, nearly all of the other scopes are related to applications (external programs that communicate with Discord). Whilst you could also select `applications.commands`, the `bot` scope will include this silently. You can read more about scopes and which you need for your application [here](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
+\note For bots, you ONLY need the `bot` scope, nearly all of the other scopes are related to non-bot applications (external programs that communicate with Discord, such as Logitech G Hub). Whilst you can also select the `applications.commands` scope, the `bot` scope will automatically include this silently. You can read more about scopes and which ones you might need for your application [here](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
 
 4. Choose the permissions required for your bot to function in the "Bot Permissions" section.
 5. Copy and paste the resulting URL in your browser. Choose a server to invite the bot to, and click "Authorize".

--- a/docpages/make_a_bot/token.md
+++ b/docpages/make_a_bot/token.md
@@ -18,6 +18,8 @@ In this panel, you can get your bot token by clicking "Reset Token". A bot token
 
 \warning **Do not share this token** with anybody! If you ever somehow compromise your current bot token or see your bot in danger, you can regenerate the token in the panel.
 
+\note This token can only be seen once (when you generate a new one). We highly recommend that, if you're going to be reusing your token, you store it in a VERY safe place (something like a password manager).
+
 ## Adding the Bot to Your Server
 
 Once you've created your bot in the discord developer portal, you may wonder:
@@ -29,7 +31,10 @@ That's because you've created a bot application, but it's not on any server righ
 1. Go again into the [Applications page](https://discord.com/developers/applications) and click on your bot.
 2. Go to the "OAuth2" tab and click on the subpage "URL Generator".
 \image html create_application_navigate_to_url_generator.png
-3. Select the `bot` scope. If your bot uses slash commands, also select `applications.commands`. You can read more about scopes and which you need for your application [here](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
+3. Select the `bot` scope.
+
+\note For bots, you ONLY need the `bot` scope, nearly all of the other scopes are related to applications (external programs that communicate with Discord). Whilst you could also select `applications.commands`, the `bot` scope will include this silently. You can read more about scopes and which you need for your application [here](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
+
 4. Choose the permissions required for your bot to function in the "Bot Permissions" section.
 5. Copy and paste the resulting URL in your browser. Choose a server to invite the bot to, and click "Authorize".
 


### PR DESCRIPTION
This PR alters the wording in the Token page to tell users that they only need the `bot` scope, whilst also stating that they can look at the discord resource if they wish to see what might be applicable for them. I've seen an increase in users believing they need more than just the `bot` and `application.commands` scope, so I thought we should make it absolutely clear that they do not.

Whilst @braindigitalis and I discussed that technically it's currently correct saying they should also tick the `application.commands` scope, I still don't believe we should lead users to believe that they need the `application.commands` scope as Discord will silently include it regardless.

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
