### PR TITLE
docs: set_allow_multiselect is now correctly documented

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1563,9 +1563,9 @@ struct DPP_EXPORT poll {
 	poll& set_duration(uint32_t hours) noexcept;
 
 	/**
-	 * @brief Set the duration of the poll in hours
+	 * @brief Set if the poll should allow multi-selecting
 	 *
-	 * @param hours Duration of the poll in hours
+	 * @param allow Should allow multi-select?
 	 * @return self for method chaining
 	 */
 	poll& set_allow_multiselect(bool allow) noexcept;


### PR DESCRIPTION
This PR corrects the documentation for `set_allow_multiselect` as it had the same documentation as `set_duration`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
