### PR TITLE
docs: added a page for editing messages from a button click

### DIFF
--- a/docpages/example_code/editing_message_after_click.cpp
+++ b/docpages/example_code/editing_message_after_click.cpp
@@ -1,0 +1,53 @@
+#include <dpp/dpp.h>
+#include <dpp/unicode_emoji.h>
+
+int main() {
+	dpp::cluster bot("token");
+
+	bot.on_log(dpp::utility::cout_logger());
+
+	/* The event is fired when someone issues your commands */
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+		/* Check which command they ran */
+		if (event.command.get_command_name() == "button") {
+			/* Create a message */
+			dpp::message msg(event.command.channel_id, "this text has a button");
+			
+			/* Add an action row, and then a button within the action row. */
+			msg.add_component(
+				dpp::component().add_component(
+					dpp::component()
+						.set_label("Click me!")
+						.set_type(dpp::cot_button)
+						.set_emoji(dpp::unicode_emoji::smile)
+						.set_style(dpp::cos_danger)
+						.set_id("myid")
+				)
+			);
+
+			/* Reply to the user with our message. */
+			event.reply(msg);
+		}
+	});
+
+	/* When a user clicks your button, the on_button_click event will fire,
+	 * containing the custom_id you defined in your button.
+	 */
+	bot.on_button_click([&bot](const dpp::button_click_t& event) {
+		/* Instead of replying to the button click itself, 
+         * we want to update the message that had the buttons on it.
+         */
+		event.reply(dpp::ir_update_message, "You clicked: " + event.custom_id);
+	});
+
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("button", "Send a message with a button!", bot.me.id));
+		}
+	});
+
+	bot.start(dpp::st_wait);
+
+	return 0;
+}

--- a/docpages/example_code/editing_message_after_click.cpp
+++ b/docpages/example_code/editing_message_after_click.cpp
@@ -34,9 +34,9 @@ int main() {
 	 * containing the custom_id you defined in your button.
 	 */
 	bot.on_button_click([&bot](const dpp::button_click_t& event) {
-		/* Instead of replying to the button click itself, 
-         * we want to update the message that had the buttons on it.
-         */
+		/* Instead of replying to the button click itself,
+		 * we want to update the message that had the buttons on it.
+		 */
 		event.reply(dpp::ir_update_message, "You clicked: " + event.custom_id);
 	});
 

--- a/docpages/example_code/editing_message_after_click2.cpp
+++ b/docpages/example_code/editing_message_after_click2.cpp
@@ -34,15 +34,15 @@ int main() {
 	 * containing the custom_id you defined in your button.
 	 */
 	bot.on_button_click([&bot](const dpp::button_click_t& event) {
-		/* Instead of replying to the button click itself, 
-         * we want to update the message that had the buttons on it.
-         */
+		/* Instead of replying to the button click itself,
+		 * we want to update the message that had the buttons on it.
+		 */
 		event.reply(dpp::ir_deferred_channel_message_with_source, "");
 
-        /* Pretend you're doing long calls here that may take longer than 3 seconds. */
+        	/* Pretend you're doing long calls here that may take longer than 3 seconds. */
 
-        /* Now, edit the response! */
-        event.edit_response("After a while, I can confirm you clicked: " + event.custom_id);
+        	/* Now, edit the response! */
+        	event.edit_response("After a while, I can confirm you clicked: " + event.custom_id);
 	});
 
 	bot.on_ready([&bot](const dpp::ready_t& event) {

--- a/docpages/example_code/editing_message_after_click2.cpp
+++ b/docpages/example_code/editing_message_after_click2.cpp
@@ -1,0 +1,58 @@
+#include <dpp/dpp.h>
+#include <dpp/unicode_emoji.h>
+
+int main() {
+	dpp::cluster bot("token");
+
+	bot.on_log(dpp::utility::cout_logger());
+
+	/* The event is fired when someone issues your commands */
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+		/* Check which command they ran */
+		if (event.command.get_command_name() == "button") {
+			/* Create a message */
+			dpp::message msg(event.command.channel_id, "this text has a button");
+			
+			/* Add an action row, and then a button within the action row. */
+			msg.add_component(
+				dpp::component().add_component(
+					dpp::component()
+						.set_label("Click me!")
+						.set_type(dpp::cot_button)
+						.set_emoji(dpp::unicode_emoji::smile)
+						.set_style(dpp::cos_danger)
+						.set_id("myid")
+				)
+			);
+
+			/* Reply to the user with our message. */
+			event.reply(msg);
+		}
+	});
+
+	/* When a user clicks your button, the on_button_click event will fire,
+	 * containing the custom_id you defined in your button.
+	 */
+	bot.on_button_click([&bot](const dpp::button_click_t& event) {
+		/* Instead of replying to the button click itself, 
+         * we want to update the message that had the buttons on it.
+         */
+		event.reply(dpp::ir_deferred_channel_message_with_source, "");
+
+        /* Pretend you're doing long calls here that may take longer than 3 seconds. */
+
+        /* Now, edit the response! */
+        event.edit_response("After a while, I can confirm you clicked: " + event.custom_id);
+	});
+
+	bot.on_ready([&bot](const dpp::ready_t& event) {
+		if (dpp::run_once<struct register_bot_commands>()) {
+			/* Create and register a command when the bot is ready */
+			bot.global_command_create(dpp::slashcommand("button", "Send a message with a button!", bot.me.id));
+		}
+	});
+
+	bot.start(dpp::st_wait);
+
+	return 0;
+}

--- a/docpages/example_programs/interactions_and_components/components-menu.md
+++ b/docpages/example_programs/interactions_and_components/components-menu.md
@@ -6,3 +6,4 @@ Components are anything that can be attached to a message or a \ref modal-dialog
 * \subpage components2
 * \subpage components3
 * \subpage default_select_value
+* \subpage editing_message_after_click

--- a/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
+++ b/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
@@ -14,6 +14,6 @@ However, if you're going to take longer than 3 seconds to respond, you need to t
 
 Instead, you want to do `event.reply(dpp::ir_deferred_channel_message_with_source, "");` to tell Discord that you intend on editing the message that the button click came from, but you need time. The user will be informed that you've processed the button click (as required) via a loading state and then you have 15 minutes to do everything you need. To then edit the message, you need to do `event.edit_response("new message!");`, like so:
 
-\note If you want to silently acknowledge the button click (no thinking message), replace `dpp::ir_deferred_channel_message_with_source` with `dpp::ir_deferred_update_message`. You will still have 15 minutes to make a response.
+\note If you want to silently acknowledge the button click (no thinking message), replace dpp::ir_deferred_channel_message_with_source with dpp::ir_deferred_update_message. You will still have 15 minutes to make a response.
 
 \include{cpp} editing_message_after_click2.cpp

--- a/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
+++ b/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
@@ -1,13 +1,19 @@
 \page editing_message_after_click Editing The Message From a Button Click
 
+\note This page expects you to be familiar with Button Clicks and extends from the \ref components page. Please visit the \ref components page if you are not already familiar with Button Clicks.
+
 Editing messages where you had a button click can be done in a couple ways.
 
-If you want to edit the message that had the buttons on, instead of doing `event.reply("message");`, you would do `event.reply(dpp::ir_update_message, "message");`!
+If you want to edit the message that had the buttons on, instead of doing `event.reply("message");`, you would do `event.reply(dpp::ir_update_message, "message");`, like so:
 
-\note You are still limited to the default interaction time (3 seconds) with button clicks. Read on if you need more time!
+\note You are still limited to the default interaction time (3 seconds) this way. Read on if you need more time!
 
-However, if you're going to take longer than 3 seconds to respond, you need to tell Discord to wait. The usual method is `event.thinking(true);` and then `event.edit_response("I have thought long and hard about my actions.");`, however, this creates a new response, meaning you can no longer respond to the original response as you already did a response!
+\include{cpp} editing_message_after_click.cpp
 
-Instead, you want to do `event.reply(dpp::ir_deferred_channel_message_with_source, "");` to tell Discord that you intend on editing the message that the button click came from, but you need time. The user will be informed that you've processed the button click (as required) via a loading state and then you have 15 minutes to do everything you need. To then edit the message, you need to do `event.edit_response("new message!");`.
+However, if you're going to take longer than 3 seconds to respond, you need to tell Discord to wait. The usual method is `event.thinking(true);` and then `event.edit_response("I have thought long and hard about my actions.");`, however, `event.thinking()` will create a new response if called from `on_button_click`, meaning you can no longer respond to the original response as you already did a response!
 
-You may also want to silently acknowledge the button click, to which you just need to do `event.reply(dpp::ir_deferred_update_message, "");` and then `event.edit_response("new message!");` when you're ready (you still only have 15 minutes).
+Instead, you want to do `event.reply(dpp::ir_deferred_channel_message_with_source, "");` to tell Discord that you intend on editing the message that the button click came from, but you need time. The user will be informed that you've processed the button click (as required) via a loading state and then you have 15 minutes to do everything you need. To then edit the message, you need to do `event.edit_response("new message!");`, like so:
+
+\note If you want to silently acknowledge the button click (no thinking message), replace `dpp::ir_deferred_channel_message_with_source` with `dpp::ir_deferred_update_message`. You will still have 15 minutes to make a response.
+
+\include{cpp} editing_message_after_click2.cpp

--- a/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
+++ b/docpages/example_programs/interactions_and_components/components/editing_message_after_click.md
@@ -1,0 +1,13 @@
+\page editing_message_after_click Editing The Message From a Button Click
+
+Editing messages where you had a button click can be done in a couple ways.
+
+If you want to edit the message that had the buttons on, instead of doing `event.reply("message");`, you would do `event.reply(dpp::ir_update_message, "message");`!
+
+\note You are still limited to the default interaction time (3 seconds) with button clicks. Read on if you need more time!
+
+However, if you're going to take longer than 3 seconds to respond, you need to tell Discord to wait. The usual method is `event.thinking(true);` and then `event.edit_response("I have thought long and hard about my actions.");`, however, this creates a new response, meaning you can no longer respond to the original response as you already did a response!
+
+Instead, you want to do `event.reply(dpp::ir_deferred_channel_message_with_source, "");` to tell Discord that you intend on editing the message that the button click came from, but you need time. The user will be informed that you've processed the button click (as required) via a loading state and then you have 15 minutes to do everything you need. To then edit the message, you need to do `event.edit_response("new message!");`.
+
+You may also want to silently acknowledge the button click, to which you just need to do `event.reply(dpp::ir_deferred_update_message, "");` and then `event.edit_response("new message!");` when you're ready (you still only have 15 minutes).


### PR DESCRIPTION
This PR adds a page to show people how to edit messages from a button click (using stuff like `dpp::ir_deferred_update_message`, etc).

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
