### PR TITLE
Add result_type member type to dpp::task

### DIFF
--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -293,6 +293,11 @@ class task : private detail::task::task_base<R> {
 	friend class detail::task::task_base<R>;
 
 	/**
+ 	 * @brief The type of the result produced by this task.
+   	 */
+	using result_type = R;
+
+	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.
 	 *
 	 * @throw Throws any exception thrown or uncaught by the coroutine
@@ -449,6 +454,11 @@ class task<void> : private detail::task::task_base<void> {
 	 * @see operator co_await()
 	 */
 	friend class detail::task::task_base<void>;
+
+	/**
+ 	 * @brief The type of the result produced by this task.
+   	 */
+	using result_type = void;
 
 	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.


### PR DESCRIPTION
Pretty useful when working with templates (for example, [this code I wrote](https://github.com/BowDown097/dpp-command-handler/blob/master/dpp-command-handler/commandfunction.h), where I had to reproduce this with a false_type/true_type struct). Similar conveniences are part of quite a few STL template types too, namely std::function which I'd say is pretty similar.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
