### PR TITLE
Add result_type member type to dpp::task

### DIFF
--- a/include/dpp/coro/async.h
+++ b/include/dpp/coro/async.h
@@ -415,6 +415,11 @@ public:
 	using detail::async::async_base<R>::await_ready; // expose await_ready as public
 
 	/**
+	 * @brief The return type of the API call. Defaults to confirmation_callback_t
+	 */
+	using result_type = R;
+
+	/**
 	 * @brief Construct an async object wrapping an object method, the call is made immediately by forwarding to <a href="https://en.cppreference.com/w/cpp/utility/functional/invoke">std::invoke</a> and can be awaited later to retrieve the result.
 	 *
 	 * @param obj The object to call the method on

--- a/include/dpp/coro/coroutine.h
+++ b/include/dpp/coro/coroutine.h
@@ -232,6 +232,10 @@ class coroutine : private detail::coroutine::coroutine_base<R> {
 	}
 
 public:
+	/**
+	 * @brief The type of the result produced by this coroutine.
+	 */
+	using result_type = R;
 #ifdef _DOXYGEN_ // :))))
 	/**
 	 * @brief Default constructor, creates an empty coroutine.
@@ -333,6 +337,11 @@ public:
 	using detail::coroutine::coroutine_base<void>::coroutine_base; // use coroutine_base's constructors
 	using detail::coroutine::coroutine_base<void>::operator=; // use coroutine_base's assignment operators
 	using detail::coroutine::coroutine_base<void>::await_ready; // expose await_ready as public
+
+	/**
+	 * @brief The type of the result produced by this coroutine.
+	 */
+	using result_type = void;
 
 	/**
 	 * @brief Suspend the current coroutine until the coroutine completes.

--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -293,11 +293,6 @@ class task : private detail::task::task_base<R> {
 	friend class detail::task::task_base<R>;
 
 	/**
- 	 * @brief The type of the result produced by this task.
-   	 */
-	using result_type = R;
-
-	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.
 	 *
 	 * @throw Throws any exception thrown or uncaught by the coroutine
@@ -340,6 +335,10 @@ class task : private detail::task::task_base<R> {
 	}
 
 public:
+	/**
+	 * @brief The type of the result produced by this task.
+	 */
+	using result_type = R;
 #ifdef _DOXYGEN_ // :)
 	/**
 	 * @brief Default constructor, creates a task not bound to a coroutine.
@@ -456,11 +455,6 @@ class task<void> : private detail::task::task_base<void> {
 	friend class detail::task::task_base<void>;
 
 	/**
- 	 * @brief The type of the result produced by this task.
-   	 */
-	using result_type = void;
-
-	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.
 	 *
 	 * @remark Do not call this manually, use the co_await keyword instead.
@@ -474,6 +468,11 @@ public:
 	using detail::task::task_base<void>::done; // expose done() as public
 	using detail::task::task_base<void>::cancel; // expose cancel() as public
 	using detail::task::task_base<void>::await_ready; // expose await_ready as public
+
+	/**
+	 * @brief The type of the result produced by this task
+	 */
+	using result_type = void;
 
 	/**
 	 * @brief Suspend the current coroutine until the task completes.

--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -293,6 +293,11 @@ class task : private detail::task::task_base<R> {
 	friend class detail::task::task_base<R>;
 
 	/**
+ 	 * @brief The type of the result produced by this task.
+   	 */
+	using result_type = R;
+
+	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.
 	 *
 	 * @throw Throws any exception thrown or uncaught by the coroutine
@@ -449,6 +454,11 @@ class task<void> : private detail::task::task_base<void> {
 	 * @see operator co_await()
 	 */
 	friend class detail::task::task_base<void>;
+
+	/**
+ 	 * @brief The type of the result produced by this task.
+   	 */
+	using result_type = void;
 
 	/**
 	 * @brief Function called by the standard library when the coroutine is resumed.


### PR DESCRIPTION
Pretty useful when working with templates (for example, [this code I wrote](https://github.com/BowDown097/dpp-command-handler/blob/master/dpp-command-handler/commandfunction.h), where I had to reproduce this with a false_type/true_type struct). Similar conveniences are part of quite a few STL template types too, namely std::function which I'd say is pretty similar.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
