### PR TITLE
Update Docker image to Ubuntu 24.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM ubuntu:focal@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc
+FROM ubuntu:noble@sha256:e3f92abc0967a6c19d0dfa2d55838833e947b9d74edbcb0113e48535ad4be12a
 
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y libssl-dev zlib1g-dev libsodium-dev libopus-dev cmake pkg-config g++ gcc git make && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/DPP


### PR DESCRIPTION
Updated the Docker base DPP image to 24.04 and pinned it to a hash. [Here](https://hub.docker.com/layers/library/ubuntu/noble/images/sha256-c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6?context=explore) is a list of known vulnerabilities with 24.04 (although all of them have some vulnerabilities). Additionally removed the noninteractive line, since as of 23.04 it is patched (see [here](https://github.com/moby/moby/issues/4032) for the 10-year long papertrail!).

## Code change checklist

- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [X] I tested that my change works before raising the PR.
- [X] I have ensured that I did not break any existing API calls.
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
