### PR TITLE
feat: added warnings for certain events that require an intent

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -171,6 +171,22 @@ void cluster::start(bool return_after) {
 		this->terminating.wait(thread_lock);
 	};
 
+	if (on_guild_member_add && !(intents & dpp::i_guild_members)) {
+		log(ll_warning, "You have attached an event to cluster::on_guild_member_add() but have not specified the privileged intent dpp::i_guild_members. This event will not fire.");
+	}
+
+	if (on_guild_member_remove && !(intents & dpp::i_guild_members)) {
+		log(ll_warning, "You have attached an event to cluster::on_guild_member_remove() but have not specified the privileged intent dpp::i_guild_members. This event will not fire.");
+	}
+
+	if (on_guild_member_update && !(intents & dpp::i_guild_members)) {
+		log(ll_warning, "You have attached an event to cluster::on_guild_member_update() but have not specified the privileged intent dpp::i_guild_members. This event will not fire.");
+	}
+
+	if (on_presence_update && !(intents & dpp::i_guild_presences)) {
+		log(ll_warning, "You have attached an event to cluster::on_presence_update() but have not specified the privileged intent dpp::i_guild_presences. This event will not fire.");
+	}
+
 	/* Start up all shards */
 	gateway g;
 	try {


### PR DESCRIPTION
This PR adds warnings for some events (guild member events and presence update) if the user does not have the specific intent required.

As these events do not fire from Discord if the intent wasn't specified, I could not use the `set_warning_callback` feature.

This is to try and inform users about what went wrong and how they can fix it, to try be more user friendly as D++ is currently silent about it (see [link a](https://discord.com/channels/825407338755653642/825411707521728512/1235314587868594309) and [link b](https://discord.com/channels/825407338755653642/825411707521728512/1250187664632840293)).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
