### PR TITLE
Use string views

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -165,7 +165,7 @@ public:
 	 * @param _name name of command option choice in the specified language
 	 * @return command_option_choice& reference to self for fluent chaining
 	 */
-	command_option_choice& add_localization(const std::string& language, const std::string& _name);
+    command_option_choice& add_localization(std::string_view language, std::string_view _name);
 
 	/**
 	 * @brief Construct a new command option choice object
@@ -173,7 +173,7 @@ public:
 	 * @param n name to initialise with
 	 * @param v value to initialise with
 	 */
-	command_option_choice(const std::string &n, command_value v);
+    command_option_choice(std::string_view n, command_value v);
 };
 
 /**
@@ -305,7 +305,7 @@ public:
 	 * @param _description description of slash command option in the specified language (optional)
 	 * @return command_option& reference to self for fluent chaining
 	 */
-	command_option& add_localization(const std::string& language, const std::string& _name, const std::string& _description = "");
+    command_option& add_localization(std::string_view language, std::string_view _name, std::string_view _description = "");
 
 	/**
 	 * @brief Construct a new command option object
@@ -315,7 +315,7 @@ public:
 	 * @param description Option description
 	 * @param required True if this is a mandatory parameter
 	 */
-	command_option(command_option_type t, const std::string &name, const std::string &description, bool required = false);
+    command_option(command_option_type t, std::string_view name, std::string_view description, bool required = false);
 
 	/**
 	 * @brief Add a multiple choice option
@@ -602,7 +602,7 @@ public:
 	 * @param _title Title of the modal form. It will be truncated to the maximum length of 45 UTF-8 characters.
 	 * @param _components Components to add to the modal form
 	 */
-	interaction_modal_response(const std::string& _custom_id, const std::string& _title, const std::vector<component> _components = {});
+    interaction_modal_response(std::string_view _custom_id, std::string_view _title, const std::vector<component> _components = {});
 
 	/**
 	 * @brief Set the custom id
@@ -610,7 +610,7 @@ public:
 	 * @param _custom_id custom id to set
 	 * @return interaction_modal_response& Reference to self
 	 */
-	interaction_modal_response& set_custom_id(const std::string& _custom_id);
+    interaction_modal_response& set_custom_id(std::string_view _custom_id);
 
 	/**
 	 * @brief Set the title 
@@ -618,7 +618,7 @@ public:
 	 * @param _title title to set
 	 * @return interaction_modal_response& Reference to self
 	 */
-	interaction_modal_response& set_title(const std::string& _title);
+    interaction_modal_response& set_title(std::string_view _title);
 
 	/**
 	 * @brief Add a component to an interaction modal response
@@ -1445,7 +1445,7 @@ public:
 	 * @param _description Command description
 	 * @param _application_id Application id (usually the bot's user id)
 	 */
-	slashcommand(const std::string &_name, const std::string &_description, const dpp::snowflake _application_id);
+    slashcommand(std::string_view _name, std::string_view _description, const dpp::snowflake _application_id);
 
 	/**
 	 * @brief Construct a new slashcommand object
@@ -1454,7 +1454,7 @@ public:
 	 * @param _type Context menu type
 	 * @param _application_id Application id (usually the bot's user id)
 	 */
-	slashcommand(const std::string &_name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id);
+    slashcommand(std::string_view _name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id);
 
 	/**
 	 * @brief Destroy the slashcommand object
@@ -1469,7 +1469,7 @@ public:
 	 * @param _description description of slash command in the specified language (optional)
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
-	slashcommand& add_localization(const std::string& language, const std::string& _name, const std::string& _description = "");
+    slashcommand& add_localization(std::string_view language, std::string_view _name, std::string_view _description = "");
 
 	/**
 	 * @brief Set the dm permission for the command
@@ -1523,7 +1523,7 @@ public:
 	 * The command name will be set to lowercase when the type is the default dpp::ctxm_chat_input.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
-	slashcommand& set_name(const std::string &n);
+    slashcommand& set_name(std::string_view n);
 
 	/**
 	 * @brief Set the description of the command
@@ -1533,7 +1533,7 @@ public:
 	 * If your command description is longer than this, it will be truncated.
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
-	slashcommand& set_description(const std::string &d);
+    slashcommand& set_description(std::string_view d);
 
 	/**
 	 * @brief Set the application id of the command

--- a/include/dpp/bignum.h
+++ b/include/dpp/bignum.h
@@ -62,7 +62,7 @@ public:
 	 * @note Prefixing number_string with 0x will parse it as hexadecimal.
 	 * This is not case sensitive.
 	 */
-	bignumber(const std::string& number_string);
+    bignumber(std::string_view number_string);
 
 	/**
 	 * @brief Build a bignumber from a vector of 64 bit values.

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -316,7 +316,7 @@ public:
 	 *
 	 * @param name The name of the tag. It will be truncated to the maximum length of 20 UTF-8 characters.
 	 */
-	forum_tag(const std::string& name);
+    forum_tag(std::string_view name);
 
 	/** Destructor */
 	virtual ~forum_tag() = default;
@@ -329,7 +329,7 @@ public:
 	 *
 	 * @note name will be truncated to 20 chars, if longer
 	 */
-	forum_tag& set_name(const std::string& name);
+    forum_tag& set_name(std::string_view name);
 };
 
 /**
@@ -499,7 +499,7 @@ public:
 	 * @note name will be truncated to 100 chars, if longer
 	 * @throw dpp::length_exception if length < 1
 	 */
-	channel& set_name(const std::string& name);
+    channel& set_name(std::string_view name);
 
 	/**
 	 * @brief Set topic of this channel object
@@ -509,7 +509,7 @@ public:
 	 *
 	 * @note topic will be truncated to 1024 chars, if longer
 	 */
-	channel& set_topic(const std::string& topic);
+    channel& set_topic(std::string_view topic);
 
 	/**
 	 * @brief Set type of this channel object

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -216,7 +216,7 @@ public:
 	 * @param request_threads_raw The number of threads to allocate for making HTTP requests to sites outside of Discord. This defaults to 1. You can increase this at runtime via the object returned from get_raw_rest().
 	 * @throw dpp::exception Thrown on windows, if WinSock fails to initialise, or on any other system if a dpp::request_queue fails to construct
 	 */
-	cluster(const std::string& token, uint32_t intents = i_default_intents, uint32_t shards = 0, uint32_t cluster_id = 0, uint32_t maxclusters = 1, bool compressed = true, cache_policy_t policy = cache_policy::cpol_default, uint32_t request_threads = 12, uint32_t request_threads_raw = 1);
+    cluster(std::string_view token, uint32_t intents = i_default_intents, uint32_t shards = 0, uint32_t cluster_id = 0, uint32_t maxclusters = 1, bool compressed = true, cache_policy_t policy = cache_policy::cpol_default, uint32_t request_threads = 12, uint32_t request_threads_raw = 1);
 
 	/**
 	 * @brief dpp::cluster is non-copyable
@@ -288,7 +288,7 @@ public:
 	 * @param reason The reason to set for the next REST call on this thread
 	 * @return cluster& Reference to self for chaining.
 	 */
-	cluster& set_audit_reason(const std::string &reason);
+    cluster& set_audit_reason(std::string_view reason);
 
 	/**
 	 * @brief Clear the audit log reason for the next REST call to be made.
@@ -325,7 +325,7 @@ public:
 	 *
 	 * @return cluster& Reference to self for chaining.
 	 */
-	cluster& set_default_gateway(const std::string& default_gateway);
+    cluster& set_default_gateway(std::string_view default_gateway);
 
 	/**
 	 * @brief Log a message to whatever log the user is using.
@@ -334,7 +334,7 @@ public:
 	 * @param severity The log level from dpp::loglevel
 	 * @param msg The log message to output
 	 */
-	void log(dpp::loglevel severity, const std::string &msg) const;
+    void log(dpp::loglevel severity, std::string_view msg) const;
 
 	/**
 	 * @brief Start a timer. Every `frequency` seconds, the callback is called.
@@ -1375,7 +1375,7 @@ public:
 	 * @param filemimetype File content to post for POST requests (for uploading files)
 	 * @param protocol HTTP protocol to use (1.0 and 1.1 are supported)
 	 */
-	void post_rest(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "", const std::string& protocol = "1.1");
+    void post_rest(std::string_view endpoint, std::string_view major_parameters, std::string_view parameters, http_method method, std::string_view postdata, json_encode_t callback, std::string_view filename = "", std::string_view filecontent = "", std::string_view filemimetype = "", std::string_view protocol = "1.1");
 
 	/**
 	 * @brief Post a multipart REST request. Where possible use a helper method instead like message_create
@@ -1388,7 +1388,7 @@ public:
 	 * @param callback Function to call when the HTTP call completes. The callback parameter will contain amongst other things, the decoded json.
 	 * @param file_data List of files to post for POST requests (for uploading files)
 	 */
-	void post_rest_multipart(const std::string &endpoint, const std::string &major_parameters, const std::string &parameters, http_method method, const std::string &postdata, json_encode_t callback, const std::vector<message_file_data> &file_data = {});
+    void post_rest_multipart(std::string_view endpoint, std::string_view major_parameters, std::string_view parameters, http_method method, std::string_view postdata, json_encode_t callback, const std::vector<message_file_data> &file_data = {});
 
 	/**
 	 * @brief Make a HTTP(S) request. For use when wanting asynchronous access to HTTP APIs outside of Discord.
@@ -1401,7 +1401,7 @@ public:
 	 * @param headers Headers to send with the request
 	 * @param protocol HTTP protocol to use (1.1 and 1.0 are supported)
 	 */
-	void request(const std::string &url, http_method method, http_completion_event callback, const std::string &postdata = "", const std::string &mimetype = "text/plain", const std::multimap<std::string, std::string> &headers = {}, const std::string &protocol = "1.1");
+    void request(std::string_view url, http_method method, http_completion_event callback, std::string_view postdata = "", std::string_view mimetype = "text/plain", const std::multimap<std::string, std::string> &headers = {}, std::string_view protocol = "1.1");
 
 	/**
 	 * @brief Respond to a slash command
@@ -1413,7 +1413,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback = utility::log_error());
+    void interaction_response_create(snowflake interaction_id, std::string_view token, const interaction_response &r, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit response to a slash command
@@ -1424,7 +1424,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
+    void interaction_response_edit(std::string_view token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get the original response to a slash command
@@ -1434,7 +1434,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_response_get_original(const std::string &token, command_completion_event_t callback = utility::log_error());
+    void interaction_response_get_original(std::string_view token, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Create a followup message to a slash command
@@ -1445,7 +1445,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
+    void interaction_followup_create(std::string_view token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit original followup message to a slash command
@@ -1457,7 +1457,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
+    void interaction_followup_edit_original(std::string_view token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete the initial interaction response
@@ -1467,7 +1467,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_delete(const std::string &token, command_completion_event_t callback = utility::log_error());
+    void interaction_followup_delete(std::string_view token, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit followup message to a slash command
@@ -1479,7 +1479,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
+    void interaction_followup_edit(std::string_view token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get the followup message to a slash command
@@ -1490,7 +1490,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback);
+    void interaction_followup_get(std::string_view token, snowflake message_id, command_completion_event_t callback);
 	
 	/**
 	 * @brief Get the original followup message to a slash command
@@ -1501,7 +1501,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void interaction_followup_get_original(const std::string &token, command_completion_event_t callback = utility::log_error());
+    void interaction_followup_get_original(std::string_view token, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Create a global slash command (a bot can have a maximum of 100 of these).
@@ -1805,7 +1805,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_add_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_add_reaction(const struct message &m, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete own reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1816,7 +1816,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_own_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_own_reaction(const struct message &m, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a user's reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1828,7 +1828,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_reaction(const struct message &m, snowflake user_id, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get reactions on a message for a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1842,7 +1842,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
+    void message_get_reactions(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
 
 	/**
 	 * @brief Delete all reactions on a message
@@ -1863,7 +1863,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction_emoji(const struct message &m, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_reaction_emoji(const struct message &m, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Add a reaction to a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1875,7 +1875,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_add_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete own reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1887,7 +1887,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_own_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a user's reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1900,7 +1900,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get reactions on a message for a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1915,7 +1915,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
+    void message_get_reactions(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback);
 
 	/**
 	 * @brief Delete all reactions on a message by id
@@ -1938,7 +1938,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback = utility::log_error());
+    void message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Delete a message from a channel. The callback function is called when the message has been edited
@@ -2123,7 +2123,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::invite object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void invite_get(const std::string &invite_code, command_completion_event_t callback);
+    void invite_get(std::string_view invite_code, command_completion_event_t callback);
 
 	/**
 	 * @brief Delete an invite
@@ -2134,7 +2134,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::invite object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void invite_delete(const std::string &invite, command_completion_event_t callback = utility::log_error());
+    void invite_delete(std::string_view invite, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get invites for a channel
@@ -2176,7 +2176,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void gdm_add(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick, command_completion_event_t callback = utility::log_error());
+    void gdm_add(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Removes a recipient from a Group DM
@@ -2294,7 +2294,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::guild_member_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_search_members(snowflake guild_id, const std::string& query, uint16_t limit, command_completion_event_t callback);
+    void guild_search_members(snowflake guild_id, std::string_view query, uint16_t limit, command_completion_event_t callback);
 
 	/**
 	 * @brief Get all guild members
@@ -2326,7 +2326,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::guild_member object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_add_member(const guild_member& gm, const std::string &access_token, command_completion_event_t callback = utility::log_error());
+    void guild_add_member(const guild_member& gm, std::string_view access_token, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit the properties of an existing guild member
@@ -2373,7 +2373,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_set_nickname(snowflake guild_id, const std::string &nickname, command_completion_event_t callback = utility::log_error());
+    void guild_set_nickname(snowflake guild_id, std::string_view nickname, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Add role to guild member
@@ -2540,7 +2540,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::dtemplate object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void template_get(const std::string &code, command_completion_event_t callback);
+    void template_get(std::string_view code, command_completion_event_t callback);
 
 	/**
 	 * @brief Create a new guild based on a template.
@@ -2551,7 +2551,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::guild object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_create_from_template(const std::string &code, const std::string &name, command_completion_event_t callback = utility::log_error());
+    void guild_create_from_template(std::string_view code, std::string_view name, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get guild templates
@@ -2573,7 +2573,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::dtemplate object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_template_create(snowflake guild_id, const std::string &name, const std::string &description, command_completion_event_t callback = utility::log_error());
+    void guild_template_create(snowflake guild_id, std::string_view name, std::string_view description, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Syncs the template to the guild's current state.
@@ -2584,7 +2584,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::dtemplate object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_template_sync(snowflake guild_id, const std::string &code, command_completion_event_t callback = utility::log_error());
+    void guild_template_sync(snowflake guild_id, std::string_view code, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Modifies the template's metadata.
@@ -2597,7 +2597,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::dtemplate object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description, command_completion_event_t callback = utility::log_error());
+    void guild_template_modify(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Deletes the template
@@ -2608,7 +2608,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_template_delete(snowflake guild_id, const std::string &code, command_completion_event_t callback = utility::log_error());
+    void guild_template_delete(snowflake guild_id, std::string_view code, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Create a guild
@@ -2962,7 +2962,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::webhook object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void get_webhook_with_token(snowflake webhook_id, const std::string &token, command_completion_event_t callback);
+    void get_webhook_with_token(snowflake webhook_id, std::string_view token, command_completion_event_t callback);
 
 	/**
 	 * @brief Edit webhook
@@ -3001,7 +3001,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void delete_webhook_with_token(snowflake webhook_id, const std::string &token, command_completion_event_t callback = utility::log_error());
+    void delete_webhook_with_token(snowflake webhook_id, std::string_view token, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Execute webhook
@@ -3016,7 +3016,7 @@ public:
 	 * @note If the webhook channel is a forum channel, you must provide either `thread_id` or `thread_name`. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
 	 * On success the callback will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void execute_webhook(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, const std::string& thread_name = "", command_completion_event_t callback = utility::log_error());
+    void execute_webhook(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, std::string_view thread_name = "", command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get webhook message
@@ -3231,7 +3231,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_current_member_edit(snowflake guild_id, const std::string &nickname, command_completion_event_t callback = utility::log_error());
+    void guild_current_member_edit(snowflake guild_id, std::string_view nickname, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get current user's connections (linked accounts, e.g. steam, xbox).
@@ -3264,7 +3264,7 @@ public:
 	 * On success the callback will contain a dpp::user object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
 	 */
-	void current_user_edit(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png, command_completion_event_t callback = utility::log_error());
+    void current_user_edit(std::string_view nickname, std::string_view image_blob = "", const image_type type = i_png, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get current user DM channels
@@ -3306,7 +3306,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::thread object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void thread_create_in_forum(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {}, command_completion_event_t callback = utility::log_error());
+    void thread_create_in_forum(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {}, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Create a thread
@@ -3322,7 +3322,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::thread object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback = utility::log_error());
+    void thread_create(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Edit a thread
@@ -3347,7 +3347,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::thread object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void thread_create_with_message(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user, command_completion_event_t callback = utility::log_error());
+    void thread_create_with_message(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Join a thread
@@ -3810,7 +3810,7 @@ public:
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback = utility::log_error());
+    void channel_set_voice_status(snowflake channel_id, std::string_view status, command_completion_event_t callback = utility::log_error());
 
 #include <dpp/cluster_sync_calls.h>
 #ifdef DPP_CORO

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -254,7 +254,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_response_create(snowflake interaction_id, std::string_view token, const interaction_response &r);
 
 /**
  * @brief Edit response to a slash command
@@ -266,7 +266,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_response_edit(const std::string &token, const message &m);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_response_edit(std::string_view token, const message &m);
 
 /**
  * @brief Get the original response to a slash command
@@ -277,7 +277,7 @@
  * @return message returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_response_get_original(const std::string &token);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_response_get_original(std::string_view token);
 
 /**
  * @brief Create a followup message to a slash command
@@ -289,7 +289,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_create(const std::string &token, const message &m);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_create(std::string_view token, const message &m);
 
 /**
  * @brief Edit original followup message to a slash command
@@ -302,7 +302,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_edit_original(const std::string &token, const message &m);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_edit_original(std::string_view token, const message &m);
 
 /**
  * @brief Delete the initial interaction response
@@ -313,7 +313,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_delete(const std::string &token);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_delete(std::string_view token);
 
 /**
  * @brief Edit followup message to a slash command
@@ -326,7 +326,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_edit(const std::string &token, const message &m);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_edit(std::string_view token, const message &m);
 
 /**
  * @brief Get the followup message to a slash command
@@ -338,7 +338,7 @@
  * @return message returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_get(const std::string &token, snowflake message_id);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_get(std::string_view token, snowflake message_id);
 
 /**
  * @brief Get the original followup message to a slash command
@@ -350,7 +350,7 @@
  * @return message returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_get_original(const std::string &token);
+[[nodiscard]] async<confirmation_callback_t> co_interaction_followup_get_original(std::string_view token);
 
 /**
  * @brief Get all auto moderation rules for a guild
@@ -586,7 +586,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_channel_set_voice_status(snowflake channel_id, const std::string& status);
+[[nodiscard]] async<confirmation_callback_t> co_channel_set_voice_status(snowflake channel_id, std::string_view status);
 
 /**
  * @brief Create a dm channel
@@ -631,7 +631,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_gdm_add(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick);
+[[nodiscard]] async<confirmation_callback_t> co_gdm_add(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick);
 
 /**
  * @brief Removes a recipient from a Group DM
@@ -785,7 +785,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_current_member_edit(snowflake guild_id, const std::string &nickname);
+[[nodiscard]] async<confirmation_callback_t> co_guild_current_member_edit(snowflake guild_id, std::string_view nickname);
 
 /**
  * @brief Get the audit log for a guild
@@ -1055,7 +1055,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_set_nickname(snowflake guild_id, const std::string &nickname);
+[[nodiscard]] async<confirmation_callback_t> co_guild_set_nickname(snowflake guild_id, std::string_view nickname);
 
 /**
  * @brief Sync guild integration
@@ -1142,7 +1142,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_add_member(const guild_member& gm, const std::string &access_token);
+[[nodiscard]] async<confirmation_callback_t> co_guild_add_member(const guild_member& gm, std::string_view access_token);
 
 /**
  * @brief Edit the properties of an existing guild member
@@ -1323,7 +1323,7 @@
  * @return guild_member_map returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_search_members(snowflake guild_id, const std::string& query, uint16_t limit);
+[[nodiscard]] async<confirmation_callback_t> co_guild_search_members(snowflake guild_id, std::string_view query, uint16_t limit);
 
 /**
  * @brief Get guild invites
@@ -1339,7 +1339,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_guild_get_invites(snowflake guild_id);
 
 
-[[nodiscard]] async<confirmation_callback_t> co_invite_delete(const std::string &invitecode);
+[[nodiscard]] async<confirmation_callback_t> co_invite_delete(std::string_view invitecode);
 
 /**
  * @brief Get details about an invite
@@ -1350,7 +1350,7 @@
  * @return invite returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_invite_get(const std::string &invite_code);
+[[nodiscard]] async<confirmation_callback_t> co_invite_get(std::string_view invite_code);
 
 /**
  * @brief Add a reaction to a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1362,7 +1362,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_add_reaction(const struct message &m, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_add_reaction(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Add a reaction to a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1375,7 +1375,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_add_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Send a message to a channel. The callback function is called when the message has been sent
@@ -1461,7 +1461,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_own_reaction(const struct message &m, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_own_reaction(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Delete own reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1474,7 +1474,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_own_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Delete a user's reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1487,7 +1487,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction(const struct message &m, snowflake user_id, std::string_view reaction);
 
 /**
  * @brief Delete a user's reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1501,7 +1501,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1513,7 +1513,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction_emoji(const struct message &m, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction_emoji(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1526,7 +1526,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction);
+[[nodiscard]] async<confirmation_callback_t> co_message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Edit a message on a channel. The callback function is called when the message has been edited
@@ -1573,7 +1573,7 @@
  * @return user_map returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+[[nodiscard]] async<confirmation_callback_t> co_message_get_reactions(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Get reactions on a message for a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1589,7 +1589,7 @@
  * @return emoji_map returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+[[nodiscard]] async<confirmation_callback_t> co_message_get_reactions(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Pin a message
@@ -1991,7 +1991,7 @@
  * @return guild returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_create_from_template(const std::string &code, const std::string &name);
+[[nodiscard]] async<confirmation_callback_t> co_guild_create_from_template(std::string_view code, std::string_view name);
 
 /**
  * @brief Creates a template for the guild
@@ -2004,7 +2004,7 @@
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_template_create(snowflake guild_id, const std::string &name, const std::string &description);
+[[nodiscard]] async<confirmation_callback_t> co_guild_template_create(snowflake guild_id, std::string_view name, std::string_view description);
 
 /**
  * @brief Deletes the template
@@ -2016,7 +2016,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_template_delete(snowflake guild_id, const std::string &code);
+[[nodiscard]] async<confirmation_callback_t> co_guild_template_delete(snowflake guild_id, std::string_view code);
 
 /**
  * @brief Modifies the template's metadata.
@@ -2030,7 +2030,7 @@
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description);
+[[nodiscard]] async<confirmation_callback_t> co_guild_template_modify(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description);
 
 /**
  * @brief Get guild templates
@@ -2053,7 +2053,7 @@
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_template_sync(snowflake guild_id, const std::string &code);
+[[nodiscard]] async<confirmation_callback_t> co_guild_template_sync(snowflake guild_id, std::string_view code);
 
 /**
  * @brief Get a template
@@ -2063,7 +2063,7 @@
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_template_get(const std::string &code);
+[[nodiscard]] async<confirmation_callback_t> co_template_get(std::string_view code);
 
 /**
  * @brief Join a thread
@@ -2167,7 +2167,7 @@
  * @return thread returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_thread_create_in_forum(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
+[[nodiscard]] async<confirmation_callback_t> co_thread_create_in_forum(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
 
 /**
  * @brief Create a thread
@@ -2184,7 +2184,7 @@
  * @return thread returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
+[[nodiscard]] async<confirmation_callback_t> co_thread_create(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
 
 /**
  * @brief Edit a thread
@@ -2211,7 +2211,7 @@
  * @return thread returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_thread_create_with_message(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
+[[nodiscard]] async<confirmation_callback_t> co_thread_create_with_message(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
 
 /**
  * @brief Add a member to a thread
@@ -2259,7 +2259,7 @@
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_current_user_edit(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png);
+[[nodiscard]] async<confirmation_callback_t> co_current_user_edit(std::string_view nickname, std::string_view image_blob = "", const image_type type = i_png);
 
 /**
  * @brief Get current (bot) application
@@ -2452,7 +2452,7 @@
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_delete_webhook_with_token(snowflake webhook_id, const std::string &token);
+[[nodiscard]] async<confirmation_callback_t> co_delete_webhook_with_token(snowflake webhook_id, std::string_view token);
 
 /**
  * @brief Edit webhook
@@ -2508,7 +2508,7 @@
  * @note If the webhook channel is a forum channel, you must provide either `thread_id` or `thread_name`. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_execute_webhook(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, const std::string& thread_name = "");
+[[nodiscard]] async<confirmation_callback_t> co_execute_webhook(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, std::string_view thread_name = "");
 
 /**
  * @brief Get channel webhooks
@@ -2562,7 +2562,7 @@
  * @return webhook returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_get_webhook_with_token(snowflake webhook_id, const std::string &token);
+[[nodiscard]] async<confirmation_callback_t> co_get_webhook_with_token(snowflake webhook_id, std::string_view token);
 
 
 /* End of auto-generated definitions */

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -311,7 +311,7 @@ slashcommand_map guild_commands_get_sync(snowflake guild_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_response_create_sync(snowflake interaction_id, const std::string &token, const interaction_response &r);
+confirmation interaction_response_create_sync(snowflake interaction_id, std::string_view token, const interaction_response &r);
 
 /**
  * @brief Edit response to a slash command
@@ -326,7 +326,7 @@ confirmation interaction_response_create_sync(snowflake interaction_id, const st
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_response_edit_sync(const std::string &token, const message &m);
+confirmation interaction_response_edit_sync(std::string_view token, const message &m);
 
 /**
  * @brief Get the original response to a slash command
@@ -340,7 +340,7 @@ confirmation interaction_response_edit_sync(const std::string &token, const mess
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_response_get_original_sync(const std::string &token);
+message interaction_response_get_original_sync(std::string_view token);
 
 /**
  * @brief Create a followup message to a slash command
@@ -355,7 +355,7 @@ message interaction_response_get_original_sync(const std::string &token);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_create_sync(const std::string &token, const message &m);
+confirmation interaction_followup_create_sync(std::string_view token, const message &m);
 
 /**
  * @brief Edit original followup message to a slash command
@@ -371,7 +371,7 @@ confirmation interaction_followup_create_sync(const std::string &token, const me
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_edit_original_sync(const std::string &token, const message &m);
+confirmation interaction_followup_edit_original_sync(std::string_view token, const message &m);
 
 /**
  * @brief Delete the initial interaction response
@@ -385,7 +385,7 @@ confirmation interaction_followup_edit_original_sync(const std::string &token, c
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_delete_sync(const std::string &token);
+confirmation interaction_followup_delete_sync(std::string_view token);
 
 /**
  * @brief Edit followup message to a slash command
@@ -401,7 +401,7 @@ confirmation interaction_followup_delete_sync(const std::string &token);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_edit_sync(const std::string &token, const message &m);
+confirmation interaction_followup_edit_sync(std::string_view token, const message &m);
 
 /**
  * @brief Get the followup message to a slash command
@@ -416,7 +416,7 @@ confirmation interaction_followup_edit_sync(const std::string &token, const mess
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_followup_get_sync(const std::string &token, snowflake message_id);
+message interaction_followup_get_sync(std::string_view token, snowflake message_id);
 
 /**
  * @brief Get the original followup message to a slash command
@@ -431,7 +431,7 @@ message interaction_followup_get_sync(const std::string &token, snowflake messag
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_followup_get_original_sync(const std::string &token);
+message interaction_followup_get_original_sync(std::string_view token);
 
 /**
  * @brief Get all auto moderation rules for a guild
@@ -727,7 +727,7 @@ channel_map channels_get_sync(snowflake guild_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_set_voice_status_sync(snowflake channel_id, const std::string& status);
+confirmation channel_set_voice_status_sync(snowflake channel_id, std::string_view status);
 
 /**
  * @brief Create a dm channel
@@ -784,7 +784,7 @@ message direct_message_create_sync(snowflake user_id, const message &m);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation gdm_add_sync(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick);
+confirmation gdm_add_sync(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick);
 
 /**
  * @brief Removes a recipient from a Group DM
@@ -974,7 +974,7 @@ gateway get_gateway_bot_sync();
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_current_member_edit_sync(snowflake guild_id, const std::string &nickname);
+confirmation guild_current_member_edit_sync(snowflake guild_id, std::string_view nickname);
 
 /**
  * @brief Get the audit log for a guild
@@ -1295,7 +1295,7 @@ prune guild_begin_prune_sync(snowflake guild_id, const struct prune& pruneinfo);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_set_nickname_sync(snowflake guild_id, const std::string &nickname);
+confirmation guild_set_nickname_sync(snowflake guild_id, std::string_view nickname);
 
 /**
  * @brief Sync guild integration
@@ -1400,7 +1400,7 @@ dpp::welcome_screen guild_edit_welcome_screen_sync(snowflake guild_id, const str
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_add_member_sync(const guild_member& gm, const std::string &access_token);
+confirmation guild_add_member_sync(const guild_member& gm, std::string_view access_token);
 
 /**
  * @brief Edit the properties of an existing guild member
@@ -1617,7 +1617,7 @@ guild_member guild_member_move_sync(const snowflake channel_id, const snowflake 
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member_map guild_search_members_sync(snowflake guild_id, const std::string& query, uint16_t limit);
+guild_member_map guild_search_members_sync(snowflake guild_id, std::string_view query, uint16_t limit);
 
 /**
  * @brief Get guild invites
@@ -1636,7 +1636,7 @@ guild_member_map guild_search_members_sync(snowflake guild_id, const std::string
 invite_map guild_get_invites_sync(snowflake guild_id);
 
 
-invite invite_delete_sync(const std::string &invitecode);
+invite invite_delete_sync(std::string_view invitecode);
 
 /**
  * @brief Get details about an invite
@@ -1650,7 +1650,7 @@ invite invite_delete_sync(const std::string &invitecode);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite invite_get_sync(const std::string &invite_code);
+invite invite_get_sync(std::string_view invite_code);
 
 /**
  * @brief Add a reaction to a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1665,7 +1665,7 @@ invite invite_get_sync(const std::string &invite_code);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_add_reaction_sync(const struct message &m, const std::string &reaction);
+confirmation message_add_reaction_sync(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Add a reaction to a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1681,7 +1681,7 @@ confirmation message_add_reaction_sync(const struct message &m, const std::strin
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_add_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+confirmation message_add_reaction_sync(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Send a message to a channel. The callback function is called when the message has been sent
@@ -1788,7 +1788,7 @@ confirmation message_delete_sync(snowflake message_id, snowflake channel_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_own_reaction_sync(const struct message &m, const std::string &reaction);
+confirmation message_delete_own_reaction_sync(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Delete own reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1804,7 +1804,7 @@ confirmation message_delete_own_reaction_sync(const struct message &m, const std
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Delete a user's reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1820,7 +1820,7 @@ confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake ch
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_sync(const struct message &m, snowflake user_id, const std::string &reaction);
+confirmation message_delete_reaction_sync(const struct message &m, snowflake user_id, std::string_view reaction);
 
 /**
  * @brief Delete a user's reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1837,7 +1837,7 @@ confirmation message_delete_reaction_sync(const struct message &m, snowflake use
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction);
+confirmation message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1852,7 +1852,7 @@ confirmation message_delete_reaction_sync(snowflake message_id, snowflake channe
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_emoji_sync(const struct message &m, const std::string &reaction);
+confirmation message_delete_reaction_emoji_sync(const struct message &m, std::string_view reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1868,7 +1868,7 @@ confirmation message_delete_reaction_emoji_sync(const struct message &m, const s
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+confirmation message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, std::string_view reaction);
 
 /**
  * @brief Edit a message on a channel. The callback function is called when the message has been edited
@@ -1927,7 +1927,7 @@ message message_get_sync(snowflake message_id, snowflake channel_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_map message_get_reactions_sync(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+user_map message_get_reactions_sync(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Get reactions on a message for a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1946,7 +1946,7 @@ user_map message_get_reactions_sync(const struct message &m, const std::string &
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji_map message_get_reactions_sync(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+emoji_map message_get_reactions_sync(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Pin a message
@@ -2447,7 +2447,7 @@ sticker_pack_map sticker_packs_get_sync();
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild guild_create_from_template_sync(const std::string &code, const std::string &name);
+guild guild_create_from_template_sync(std::string_view code, std::string_view name);
 
 /**
  * @brief Creates a template for the guild
@@ -2463,7 +2463,7 @@ guild guild_create_from_template_sync(const std::string &code, const std::string
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_create_sync(snowflake guild_id, const std::string &name, const std::string &description);
+dtemplate guild_template_create_sync(snowflake guild_id, std::string_view name, std::string_view description);
 
 /**
  * @brief Deletes the template
@@ -2478,7 +2478,7 @@ dtemplate guild_template_create_sync(snowflake guild_id, const std::string &name
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_template_delete_sync(snowflake guild_id, const std::string &code);
+confirmation guild_template_delete_sync(snowflake guild_id, std::string_view code);
 
 /**
  * @brief Modifies the template's metadata.
@@ -2495,7 +2495,7 @@ confirmation guild_template_delete_sync(snowflake guild_id, const std::string &c
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_modify_sync(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description);
+dtemplate guild_template_modify_sync(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description);
 
 /**
  * @brief Get guild templates
@@ -2524,7 +2524,7 @@ dtemplate_map guild_templates_get_sync(snowflake guild_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_sync_sync(snowflake guild_id, const std::string &code);
+dtemplate guild_template_sync_sync(snowflake guild_id, std::string_view code);
 
 /**
  * @brief Get a template
@@ -2537,7 +2537,7 @@ dtemplate guild_template_sync_sync(snowflake guild_id, const std::string &code);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate template_get_sync(const std::string &code);
+dtemplate template_get_sync(std::string_view code);
 
 /**
  * @brief Join a thread
@@ -2668,7 +2668,7 @@ thread_member_map thread_members_get_sync(snowflake thread_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_in_forum_sync(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
+thread thread_create_in_forum_sync(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
 
 /**
  * @brief Create a thread
@@ -2688,7 +2688,7 @@ thread thread_create_in_forum_sync(const std::string& thread_name, snowflake cha
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_sync(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
+thread thread_create_sync(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
 
 /**
  * @brief Edit a thread
@@ -2721,7 +2721,7 @@ thread thread_edit_sync(const thread &t);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_with_message_sync(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
+thread thread_create_with_message_sync(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
 
 /**
  * @brief Add a member to a thread
@@ -2781,7 +2781,7 @@ thread thread_get_sync(snowflake thread_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user current_user_edit_sync(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png);
+user current_user_edit_sync(std::string_view nickname, std::string_view image_blob = "", const image_type type = i_png);
 
 /**
  * @brief Get current (bot) application
@@ -3016,7 +3016,7 @@ confirmation delete_webhook_message_sync(const class webhook &wh, snowflake mess
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation delete_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
+confirmation delete_webhook_with_token_sync(snowflake webhook_id, std::string_view token);
 
 /**
  * @brief Edit webhook
@@ -3084,7 +3084,7 @@ webhook edit_webhook_with_token_sync(const class webhook& wh);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message execute_webhook_sync(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, const std::string& thread_name = "");
+message execute_webhook_sync(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, std::string_view thread_name = "");
 
 /**
  * @brief Get channel webhooks
@@ -3153,7 +3153,7 @@ message get_webhook_message_sync(const class webhook &wh, snowflake message_id, 
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook get_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
+webhook get_webhook_with_token_sync(snowflake webhook_id, std::string_view token);
 
 
 /* End of auto-generated definitions */

--- a/include/dpp/commandhandler.h
+++ b/include/dpp/commandhandler.h
@@ -143,7 +143,7 @@ struct DPP_EXPORT param_info {
 	 * @param description The parameter description
 	 * @param opts The options for a multiple choice parameter
 	 */
-	param_info(parameter_type t, bool o, const std::string &description, const std::map<command_value, std::string> &opts = {});
+    param_info(parameter_type t, bool o, std::string_view description, const std::map<command_value, std::string> &opts = {});
 };
 
 /**
@@ -343,7 +343,7 @@ public:
 	 * @param prefix Prefix to be handled by the command handler
 	 * @return commandhandler& reference to self
 	 */
-	commandhandler& add_prefix(const std::string &prefix);
+    commandhandler& add_prefix(std::string_view prefix);
 
 	/**
 	 * @brief Add a command to the command handler
@@ -359,7 +359,7 @@ public:
 	 * @return commandhandler& reference to self
 	 * @throw dpp::logic_exception if application ID cannot be determined
 	 */
-	commandhandler& add_command(const std::string &command, const parameter_registration_t &parameters, command_handler handler, const std::string &description = "", snowflake guild_id = 0);
+    commandhandler& add_command(std::string_view command, const parameter_registration_t &parameters, command_handler handler, std::string_view description = "", snowflake guild_id = 0);
 
 	/**
 	 * @brief Register all slash commands with Discord

--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -373,7 +373,7 @@ public:
 	 * @param severity The log level from dpp::loglevel
 	 * @param msg The log message to output
 	 */
-	virtual void log(dpp::loglevel severity, const std::string &msg) const;
+    virtual void log(dpp::loglevel severity, std::string_view msg) const;
 
 	/**
 	 * @brief Handle an event (opcode 0)
@@ -381,7 +381,7 @@ public:
 	 * @param j JSON object for the event content
 	 * @param raw Raw JSON event string
 	 */
-	virtual void handle_event(const std::string &event, json &j, const std::string &raw);
+    virtual void handle_event(std::string_view event, json &j, std::string_view raw);
 
 	/**
 	 * @brief Get the Guild Count for this shard
@@ -415,7 +415,7 @@ public:
 	 * (this is for urgent messages such as heartbeat, presence, so they can take precedence over
 	 * chunk requests etc)
 	 */
-	void queue_message(const std::string &j, bool to_front = false);
+    void queue_message(std::string_view j, bool to_front = false);
 
 	/**
 	 * @brief Clear the outbound message queue
@@ -457,7 +457,7 @@ public:
 	 * 
 	 * @throws std::bad_alloc Passed up to the caller if any internal objects fail to allocate, after cleanup has completed
 	 */
-	discord_client(dpp::cluster* _cluster, uint32_t _shard_id, uint32_t _max_shards, const std::string &_token, uint32_t intents = 0, bool compressed = true, websocket_protocol_t ws_protocol = ws_json);
+    discord_client(dpp::cluster* _cluster, uint32_t _shard_id, uint32_t _max_shards, std::string_view _token, uint32_t intents = 0, bool compressed = true, websocket_protocol_t ws_protocol = ws_json);
 
 	/**
 	 * @brief Destroy the discord client object
@@ -475,7 +475,7 @@ public:
 	 * @param buffer The entire buffer content from the websocket client
 	 * @returns True if a frame has been handled
 	 */
-	virtual bool handle_frame(const std::string &buffer);
+    virtual bool handle_frame(std::string_view buffer);
 
 	/**
 	 * @brief Handle a websocket error.

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -461,7 +461,7 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * (this is for urgent messages such as heartbeat, presence, so they can take precedence over
 	 * chunk requests etc)
 	 */
-	void queue_message(const std::string &j, bool to_front = false);
+    void queue_message(std::string_view j, bool to_front = false);
 
 	/**
 	 * @brief Clear the outbound message queue
@@ -632,7 +632,7 @@ public:
 	 * @param severity The log level from dpp::loglevel
 	 * @param msg The log message to output
 	 */
-	virtual void log(dpp::loglevel severity, const std::string &msg) const;
+    virtual void log(dpp::loglevel severity, std::string_view msg) const;
 
 	/**
 	 * @brief Fires every second from the underlying socket I/O loop, used for sending heartbeats
@@ -678,7 +678,7 @@ public:
 	 * @param _host The voice server hostname to connect to (hostname:port format)
 	 * @throw dpp::voice_exception Sodium or Opus failed to initialise, or D++ is not compiled with voice support
 	 */
-	discord_voice_client(dpp::cluster* _cluster, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host);
+    discord_voice_client(dpp::cluster* _cluster, snowflake _channel_id, snowflake _server_id, std::string_view _token, std::string_view _session_id, std::string_view _host);
 
 	/**
 	 * @brief Destroy the discord voice client object
@@ -691,7 +691,7 @@ public:
 	 * @return bool True if a frame has been handled
 	 * @throw dpp::exception If there was an error processing the frame, or connection to UDP socket failed
 	 */
-	virtual bool handle_frame(const std::string &buffer);
+    virtual bool handle_frame(std::string_view buffer);
 
 	/**
 	 * @brief Handle a websocket error.
@@ -924,7 +924,7 @@ public:
 	 * track
 	 * @return reference to self
 	 */
-	discord_voice_client& insert_marker(const std::string& metadata = "");
+    discord_voice_client& insert_marker(std::string_view metadata = "");
 
 	/**
 	 * @brief Skip tp the next track marker,

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -119,15 +119,7 @@ public:
 	 * @param client The shard the event originated on. May be a nullptr, e.g. for voice events
 	 * @param raw Raw event data as JSON or ETF
 	 */
-	event_dispatch_t(discord_client* client, const std::string& raw);
-
-	/**
-	 * @brief Construct a new event_dispatch_t object
-	 *
-	 * @param client The shard the event originated on. May be a nullptr, e.g. for voice events
-	 * @param raw Raw event data as JSON or ETF
-	 */
-	event_dispatch_t(discord_client* client, std::string&& raw);
+    event_dispatch_t(discord_client* client, std::string_view raw);
 
 	/**
 	 * @brief Copy another event_dispatch_t object
@@ -489,7 +481,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param callback User function to execute when the api call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void reply(interaction_response_type t, const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
+    void reply(interaction_response_type t, std::string_view mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
 	 * @brief Send a reply for this interaction.
@@ -509,7 +501,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param callback User function to execute when the api call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void reply(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
+    void reply(std::string_view mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
 	 * @brief Reply to interaction with a dialog box
@@ -536,7 +528,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param callback User function to execute when the api call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void edit_response(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
+    void edit_response(std::string_view mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
 	 * @brief Set the bot to 'thinking' state where you have up to 15 minutes to respond
@@ -597,7 +589,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, const std::string& mt) const;
+    dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, std::string_view mt) const;
 
 	/**
 	 * @brief Send a reply for this interaction.
@@ -615,7 +607,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& mt) const;
+    dpp::async<dpp::confirmation_callback_t> co_reply(std::string_view mt) const;
 
 	/**
 	 * @brief Reply to interaction with a dialog box
@@ -639,7 +631,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_edit_response(const std::string& mt) const;
+    dpp::async<dpp::confirmation_callback_t> co_edit_response(std::string_view mt) const;
 
 	/**
 	 * @brief Set the bot to 'thinking' state where you have up to 15 minutes to respond
@@ -686,7 +678,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 *
 	 * @throw dpp::logic_exception if the interaction is not for a command
 	 */
-	virtual command_value get_parameter(const std::string& name) const;
+    virtual command_value get_parameter(std::string_view name) const;
 };
 
 /**
@@ -1646,7 +1638,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param callback User function to execute once the API call completes.
 	 * @note confirmation_callback_t::value contains a message object on success. On failure, value is undefined and confirmation_callback_t::is_error() is true.
 	 */
-	void send(const std::string& m, command_completion_event_t callback = utility::log_error()) const;
+    void send(std::string_view m, command_completion_event_t callback = utility::log_error()) const;
 	/**
 	 * @brief Send a message to the same channel as the channel_id in received event.
 	 * @param msg Message to send
@@ -1668,7 +1660,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param callback User function to execute once the API call completes.
 	 * @note confirmation_callback_t::value contains a message object on success. On failure, value is undefined and confirmation_callback_t::is_error() is true.
 	 */
-	void reply(const std::string& m, bool mention_replied_user = false, command_completion_event_t callback = utility::log_error()) const;
+    void reply(std::string_view m, bool mention_replied_user = false, command_completion_event_t callback = utility::log_error()) const;
 	/**
 	 * @brief Reply to the message received in the event.
 	 * @param msg Message to send as a reply.
@@ -2044,20 +2036,7 @@ struct DPP_EXPORT voice_receive_t : public event_dispatch_t {
 	 * @param pcm user audio to set
 	 * @param length length of user audio in bytes
 	 */
-	voice_receive_t(discord_client* client, const std::string& raw, class discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length);
-
-	/**
-	 * @brief Construct a new voice receive t object
-	 *
-	 * @param client The shard the event originated on.
-	 * WILL ALWAYS be NULL.
-	 * @param raw Raw event text as UDP packet.
-	 * @param vc owning voice client pointer
-	 * @param _user_id user id who is speaking, 0 for a mix of all user audio
-	 * @param pcm user audio to set
-	 * @param length length of user audio in bytes
-	 */
-	voice_receive_t(discord_client* client, std::string&& raw, class discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length);
+    voice_receive_t(discord_client* client, std::string_view raw, class discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length);
 
 	/**
 	 * @brief Voice client

--- a/include/dpp/dns.h
+++ b/include/dpp/dns.h
@@ -72,5 +72,5 @@ namespace dpp {
 	 * @return dns_cache_entry* First IP address associated with the hostname DNS record
 	 * @throw dpp::connection_exception On failure to resolve hostname
 	 */
-	const dns_cache_entry* resolve_hostname(const std::string& hostname, const std::string& port);
+    const dns_cache_entry* resolve_hostname(std::string_view hostname, std::string_view port);
 } // namespace dpp

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -119,7 +119,7 @@ public:
 	 * @param id ID, if it has one (unicode does not)
 	 * @param flags Emoji flags (emoji_flags)
 	 */
-	emoji(const std::string_view name, const snowflake id = 0, const uint8_t flags = 0);
+    emoji(std::string_view name, const snowflake id = 0, const uint8_t flags = 0);
 
 	/**
 	 * @brief Copy constructor, copies another emoji's data

--- a/include/dpp/etf.h
+++ b/include/dpp/etf.h
@@ -694,7 +694,7 @@ public:
 	 * @return nlohmann::json JSON data for use in the library
 	 * @throw dpp::exception Malformed or otherwise invalid ETF content
 	 */
-	nlohmann::json parse(const std::string& in);
+    nlohmann::json parse(std::string_view in);
 
 	/**
 	 * @brief Create ETF binary data from nlohmann::json

--- a/include/dpp/event.h
+++ b/include/dpp/event.h
@@ -25,7 +25,7 @@
 #include <dpp/json_fwd.h>
 
 #define event_decl(x,wstype) /** @brief Internal event handler for wstype websocket events. Called for each websocket message of this type. @internal */ \
-	class x : public event { public: virtual void handle(class dpp::discord_client* client, nlohmann::json &j, const std::string &raw); };
+    class x : public event { public: virtual void handle(class dpp::discord_client* client, nlohmann::json &j, std::string_view raw); };
 
 /**
  * @brief The events namespace holds the internal event handlers for each websocket event.
@@ -44,7 +44,7 @@ public:
 	 * @param j The json data of the event
 	 * @param raw The raw event json
 	 */
-	virtual void handle(class discord_client* client, nlohmann::json &j, const std::string &raw) = 0;
+    virtual void handle(class discord_client* client, nlohmann::json &j, std::string_view raw) = 0;
 };
 
 /* Internal logger */

--- a/include/dpp/exception.h
+++ b/include/dpp/exception.h
@@ -434,7 +434,7 @@ public:
 	 * 
 	 * @param what reason message
 	 */
-	explicit exception(const std::string& what) : msg(what), error_code(err_no_code_specified) { }
+    explicit exception(std::string_view what) : msg(what), error_code(err_no_code_specified) { }
 	
 	/**
 	 * @brief Construct a new exception object
@@ -442,7 +442,7 @@ public:
 	 * @param what reason message
 	 * @param code Exception code
 	 */
-	explicit exception(exception_error_code code, const std::string& what) : msg(what), error_code(code) { }
+    explicit exception(exception_error_code code, std::string_view what) : msg(what), error_code(code) { }
 	
 	/**
 	 * @brief Construct a new exception object
@@ -512,8 +512,8 @@ public:
 		explicit name(const char* what) : ancestor(what) { } \
 		explicit name(exception_error_code code, const char* what) : ancestor(code, what) { } \
 		name(const char* what, size_t len) : ancestor(what, len) { } \
-		explicit name(const std::string& what) : ancestor(what) { } \
-		explicit name(exception_error_code code, const std::string& what) : ancestor(code, what) { } \
+        explicit name(std::string_view what) : ancestor(what) { } \
+        explicit name(exception_error_code code, std::string_view what) : ancestor(code, what) { } \
 		explicit name(std::string&& what) : ancestor(what) { } \
 		explicit name(exception_error_code code, std::string&& what) : ancestor(code, what) { } \
 		name(const name&) = default; \

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -582,7 +582,7 @@ public:
 	 * 
 	 * @return guild_member& reference to self
 	 */
-	guild_member& set_nickname(const std::string& nick);
+    guild_member& set_nickname(std::string_view nick);
 
 	/**
 	 * @brief Get the nickname 
@@ -760,7 +760,7 @@ public:
 	 * @param _description The description to set
 	 * @return Reference to self, so these method calls may be chained
 	 */
-	welcome_channel& set_description(const std::string& _description);
+    welcome_channel& set_description(std::string_view _description);
 };
 
 
@@ -814,7 +814,7 @@ public:
 	 * @param s string The server description
 	 * @return Reference to self, so these method calls may be chained
 	 */
-	welcome_screen& set_description(const std::string& s);
+    welcome_screen& set_description(std::string_view s);
 };
 
 /**
@@ -1348,7 +1348,7 @@ public:
 	 * @return guild& reference to self
 	 * @throw dpp::length_exception if guild name is too short
 	 */
-	guild& set_name(const std::string& n);
+    guild& set_name(std::string_view n);
 
 	/**
 	 * @brief Remove the guild banner.
@@ -1836,7 +1836,7 @@ public:
 	 * @param _title The title to set
 	 * @return Reference to self, so these method calls may be chained
 	 */
-	onboarding_prompt_option& set_title(const std::string& _title);
+    onboarding_prompt_option& set_title(std::string_view _title);
 
 	/**
 	 * @brief Set the description of this onboarding prompt option object
@@ -1844,7 +1844,7 @@ public:
 	 * @param _description The description to set
 	 * @return Reference to self, so these method calls may be chained
 	 */
-	onboarding_prompt_option& set_description(const std::string& _description);
+    onboarding_prompt_option& set_description(std::string_view _description);
 };
 
 /**
@@ -1915,7 +1915,7 @@ public:
 	 * @param _title The title to set
 	 * @return Reference to self, so these method calls may be chained
 	 */
-	onboarding_prompt& set_title(const std::string& _title);
+    onboarding_prompt& set_title(std::string_view _title);
 
 	/**
 	 * @brief Indicates whether users are limited to selecting one option for the prompt

--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -251,7 +251,7 @@ public:
 	 * @param request_timeout How many seconds before the connection is considered failed if not finished
 	 * @param protocol Request HTTP protocol (default: 1.1)
 	 */
-        https_client(const std::string &hostname, uint16_t port = 443, const std::string &urlpath = "/", const std::string &verb = "GET", const std::string &req_body = "", const http_headers& extra_headers = {}, bool plaintext_connection = false, uint16_t request_timeout = 5, const std::string &protocol = "1.1");
+        https_client(std::string_view hostname, uint16_t port = 443, std::string_view urlpath = "/", std::string_view verb = "GET", std::string_view req_body = "", const http_headers& extra_headers = {}, bool plaintext_connection = false, uint16_t request_timeout = 5, std::string_view protocol = "1.1");
 
 	/**
 	 * @brief Destroy the https client object
@@ -267,7 +267,7 @@ public:
 	 * @param mimetypes MIME types of each of the files to send
 	 * @return multipart mime content and headers
 	 */
-	static multipart_content build_multipart(const std::string &json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {}, const std::vector<std::string>& mimetypes = {});
+        static multipart_content build_multipart(std::string_view json, const std::vector<std::string>& filenames = {}, const std::vector<std::string>& contents = {}, const std::vector<std::string>& mimetypes = {});
 
 	/**
 	 * @brief Processes incoming data from the SSL socket input buffer.
@@ -295,7 +295,7 @@ public:
 	 * @see get_header_count to determine if multiple are present
 	 * @see get_header_list to retrieve all entries of the same header_name
 	 */
-	const std::string get_header(std::string header_name) const;
+    const std::string get_header(std::string_view header_name) const;
 
 	/**
 	 * @brief Get the number of headers with the same header name
@@ -303,7 +303,7 @@ public:
 	 * @param header_name
 	 * @return the number of headers with this count
 	 */
-	size_t get_header_count(std::string header_name) const;
+    size_t get_header_count(std::string_view header_name) const;
 
 
 	/**
@@ -312,7 +312,7 @@ public:
 	 * @param header_name
 	 * @return A list of headers with the same name, or an empty list if not found
 	 */
-	const std::list<std::string> get_header_list(std::string header_name) const;
+    const std::list<std::string> get_header_list(std::string_view header_name) const;
 
 	/**
 	 * @brief Get all HTTP response headers
@@ -347,7 +347,7 @@ public:
 	 * @param url URL to break down
 	 * @return Split URL
 	 */
-	static http_connect_info get_host_info(std::string url);
+    static http_connect_info get_host_info(std::string_view url);
 
 };
 

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -280,7 +280,7 @@ public:
 	 * @param value Value of option
 	 * @param description Description of option
 	 */
-	select_option(const std::string &label, const std::string &value, const std::string &description = "");
+    select_option(std::string_view label, std::string_view value, std::string_view description = "");
 
 	/**
 	 * @brief Set the label
@@ -288,7 +288,7 @@ public:
 	 * @param l the user-facing name of the option. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_label(const std::string &l);
+    select_option& set_label(std::string_view l);
 
 	/**
 	 * @brief Set the value
@@ -296,7 +296,7 @@ public:
 	 * @param v value to set. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_value(const std::string &v);
+    select_option& set_value(std::string_view v);
 
 	/**
 	 * @brief Set the description
@@ -304,7 +304,7 @@ public:
 	 * @param d description to set. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_description(const std::string &d);
+    select_option& set_description(std::string_view d);
 
 	/**
 	 * @brief Set the emoji
@@ -314,7 +314,7 @@ public:
 	 * @param animated true if animated emoji
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_emoji(const std::string &n, dpp::snowflake id = 0, bool animated = false);
+    select_option& set_emoji(std::string_view n, dpp::snowflake id = 0, bool animated = false);
 
 	/**
 	 * @brief Set the option as default
@@ -529,7 +529,7 @@ public:
 	 * @param label Label text to set. It will be truncated to the maximum length of 80 UTF-8 characters.
 	 * @return component& Reference to self
 	 */
-	component& set_label(const std::string &label);
+    component& set_label(std::string_view label);
 
 	/**
 	 * @brief Set the default value of the text input component.
@@ -539,7 +539,7 @@ public:
 	 * @param val Value text to set. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @return component& Reference to self
 	 */
-	component& set_default_value(const std::string &val);
+    component& set_default_value(std::string_view val);
 
 	/**
 	 * @brief Set the url for dpp::cos_link types.
@@ -549,7 +549,7 @@ public:
 	 * @param url URL to set. It will be truncated to the maximum length of 512 UTF-8 characters.
 	 * @return component& reference to self.
 	 */
-	component& set_url(const std::string &url);
+    component& set_url(std::string_view url);
 
 	/**
 	 * @brief Set the style of the component, e.g. button colour.
@@ -572,7 +572,7 @@ public:
 	 * If your Custom ID is longer than this, it will be truncated.
 	 * @return component& Reference to self
 	 */
-	component& set_id(const std::string &id);
+    component& set_id(std::string_view id);
 
 	/**
 	 * @brief Set the component to disabled.
@@ -600,7 +600,7 @@ public:
 	 * characters for modals.
 	 * @return component& Reference to self
 	 */
-	component& set_placeholder(const std::string &placeholder);
+    component& set_placeholder(std::string_view placeholder);
 
 	/**
 	 * @brief Set the minimum number of items that must be chosen for a select menu
@@ -677,7 +677,7 @@ public:
 	 * @param animated True if the custom emoji is animated.
 	 * @return component& Reference to self
 	 */
-	component& set_emoji(const std::string& name, dpp::snowflake id = 0, bool animated = false);
+    component& set_emoji(std::string_view name, dpp::snowflake id = 0, bool animated = false);
 };
 
 /**
@@ -706,21 +706,21 @@ struct DPP_EXPORT embed_footer {
 	 * @param t string to set as footer text. It will be truncated to the maximum length of 2048 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_text(const std::string& t);
+    embed_footer& set_text(std::string_view t);
 
 	/**
 	 * @brief Set footer's icon url.
 	 * @param i url to set as footer icon url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_icon(const std::string& i);
+    embed_footer& set_icon(std::string_view i);
 
 	/**
 	 * @brief Set footer's proxied icon url.
 	 * @param p url to set as footer proxied icon url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_proxy(const std::string& p);
+    embed_footer& set_proxy(std::string_view p);
 };
 
 /**
@@ -908,14 +908,14 @@ struct DPP_EXPORT embed {
 	 * @param text The text of the title. It will be truncated to the maximum length of 256 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_title(const std::string &text);
+    embed& set_title(std::string_view text);
 
 	/**
 	 * @brief Set embed description.
 	 * @param text The text of the title. It will be truncated to the maximum length of 4096 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_description(const std::string &text);
+    embed& set_description(std::string_view text);
 
 	/**
 	 * @brief Set the footer of the embed.
@@ -930,7 +930,7 @@ struct DPP_EXPORT embed {
 	 * @param icon_url an url to set as footer icon url (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_footer(const std::string& text, const std::string& icon_url);
+    embed& set_footer(std::string_view text, std::string_view icon_url);
 
 	/**
 	 * @brief Set embed colour.
@@ -958,7 +958,7 @@ struct DPP_EXPORT embed {
 	 * @param url the url of the embed
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_url(const std::string &url);
+    embed& set_url(std::string_view url);
 
 	/**
 	 * @brief Add an embed field.
@@ -967,7 +967,7 @@ struct DPP_EXPORT embed {
 	 * @param is_inline Whether or not to display the field 'inline' or on its own line
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& add_field(const std::string& name, const std::string &value, bool is_inline = false);
+    embed& add_field(std::string_view name, std::string_view value, bool is_inline = false);
 
 	/**
 	 * @brief Set embed author.
@@ -983,7 +983,7 @@ struct DPP_EXPORT embed {
 	 * @param icon_url The icon URL of the author (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_author(const std::string& name, const std::string& url, const std::string& icon_url);
+    embed& set_author(std::string_view name, std::string_view url, std::string_view icon_url);
 
 	/**
 	 * @brief Set embed provider.
@@ -991,28 +991,28 @@ struct DPP_EXPORT embed {
 	 * @param url The provider url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_provider(const std::string& name, const std::string& url);
+    embed& set_provider(std::string_view name, std::string_view url);
 
 	/**
 	 * @brief Set embed image.
 	 * @param url The embed image URL (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_image(const std::string& url);
+    embed& set_image(std::string_view url);
 
 	/**
 	 * @brief Set embed video.
 	 * @param url The embed video url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_video(const std::string& url);
+    embed& set_video(std::string_view url);
 
 	/**
 	 * @brief Set embed thumbnail.
 	 * @param url The embed thumbnail url (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_thumbnail(const std::string& url);
+    embed& set_thumbnail(std::string_view url);
 };
 
 /**
@@ -1360,7 +1360,7 @@ public:
 	 * @param fn filename
 	 * @return message& reference to self
 	 */
-	sticker& set_filename(const std::string &fn);
+    sticker& set_filename(std::string_view fn);
 
 	/**
 	 * @brief Set the file content
@@ -1368,7 +1368,7 @@ public:
 	 * @param fc raw file content contained in std::string
 	 * @return message& reference to self
 	 */
-	sticker& set_file_content(const std::string &fc);
+    sticker& set_file_content(std::string_view fc);
 
 };
 
@@ -1575,7 +1575,7 @@ struct DPP_EXPORT poll {
 	 * @param text Text for the question
 	 * @return self for method chaining
 	 */
-	poll& set_question(const std::string& text);
+    poll& set_question(std::string_view text);
 
 	/**
 	 * @brief Set the duration of the poll in hours
@@ -1611,7 +1611,7 @@ struct DPP_EXPORT poll {
 	 * @param is_animated Whether the emoji is animated
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, snowflake emoji_id = 0, bool is_animated = false);
+    poll& add_answer(std::string_view text, snowflake emoji_id = 0, bool is_animated = false);
 
 	/**
 	 * @brief Add an answer to this poll
@@ -1621,7 +1621,7 @@ struct DPP_EXPORT poll {
 	 * @param emoji Optional emoji
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, const std::string& emoji);
+    poll& add_answer(std::string_view text, std::string_view emoji);
 
 	/**
 	 * @brief Add an answer to this poll
@@ -1631,7 +1631,7 @@ struct DPP_EXPORT poll {
 	 * @param e Optional emoji
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, const emoji& e);
+    poll& add_answer(std::string_view text, const emoji& e);
 
 	/**
 	 * @brief Helper to get the question text
@@ -1728,37 +1728,37 @@ namespace embed_type {
 	/**
 	 * @brief Rich text
 	 */
-	const std::string emt_rich = "rich";
+    constexpr std::string_view emt_rich = "rich";
 
 	/**
 	 * @brief Image
 	 */
-	const std::string emt_image = "image";
+    constexpr std::string_view emt_image = "image";
 
 	/**
 	 * @brief Video link
 	 */
-	const std::string emt_video = "video";
+    constexpr std::string_view emt_video = "video";
 
 	/**
 	 * @brief Animated gif
 	 */
-	const std::string emt_gifv = "gifv";
+    constexpr std::string_view emt_gifv = "gifv";
 
 	/**
 	 * @brief Article
 	 */
-	const std::string emt_article = "article";
+    constexpr std::string_view emt_article = "article";
 
 	/**
 	 * @brief Link URL
 	 */
-	const std::string emt_link = "link";
+    constexpr std::string_view emt_link = "link";
 
 	/**
 	 * @brief Auto moderation filter
 	 */
-	const std::string emt_automod = "auto_moderation_message";
+    constexpr std::string_view emt_automod = "auto_moderation_message";
 } // namespace embed_type
 
 /**
@@ -2286,7 +2286,7 @@ public:
 	 * @param content The content of the message. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @param type The message type to create
 	 */
-	message(snowflake channel_id, const std::string &content, message_type type = mt_default);
+    message(snowflake channel_id, std::string_view content, message_type type = mt_default);
 
 	/**
 	 * @brief Construct a new message object with content
@@ -2309,7 +2309,7 @@ public:
 	 * @param content The content of the message. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @param type The message type to create
 	 */
-	message(const std::string &content, message_type type = mt_default);
+    message(std::string_view content, message_type type = mt_default);
 
 	/**
 	 * @brief Destroy the message object
@@ -2516,7 +2516,7 @@ public:
 	 * @return message& reference to self
 	 * @deprecated Use message::add_file instead
 	 */
-	message& set_filename(const std::string &fn);
+    message& set_filename(std::string_view fn);
 
 	/**
 	 * @brief Set the file content of the last file in list
@@ -2525,7 +2525,7 @@ public:
 	 * @return message& reference to self
 	 * @deprecated Use message::add_file instead
 	 */
-	message& set_file_content(const std::string &fc);
+    message& set_file_content(std::string_view fc);
 
 	/**
 	 * @brief Add a file to the message
@@ -2535,7 +2535,7 @@ public:
 	 * @param filemimetype optional mime type of the file
 	 * @return message& reference to self
 	 */
-	message& add_file(const std::string &filename, const std::string &filecontent, const std::string &filemimetype = "");
+    message& add_file(std::string_view filename, std::string_view filecontent, std::string_view filemimetype = "");
 
 	/**
 	 * @brief Set the message content
@@ -2543,7 +2543,7 @@ public:
 	 * @param c message content. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @return message& reference to self
 	 */
-	message& set_content(const std::string &c);
+    message& set_content(std::string_view c);
 	
 	/**
 	 * @brief Set the channel id

--- a/include/dpp/presence.h
+++ b/include/dpp/presence.h
@@ -480,7 +480,7 @@ public:
 	 * @param stat State of the activity
 	 * @param url_ url of the activity, only works for certain sites, such as YouTube
 	 */
-	activity(const activity_type typ, const std::string& nam, const std::string& stat, const std::string& url_);
+    activity(const activity_type typ, std::string_view nam, std::string_view stat, std::string_view url_);
 };
 
 /**
@@ -540,7 +540,7 @@ public:
 	 * @param type Type of activity
 	 * @param activity_description Description of the activity
 	 */
-	presence(presence_status status, activity_type type, const std::string& activity_description);
+    presence(presence_status status, activity_type type, std::string_view activity_description);
 
 	/**
 	 * @brief Construct a new presence object with some parameters for sending to a websocket.

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -306,7 +306,7 @@ public:
 	 * @param filemimetype The MIME type of any uploaded file for the request
 	 * @param http_protocol HTTP protocol
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::string &filename = "", const std::string &filecontent = "", const std::string &filemimetype = "", const std::string &http_protocol = "1.1");
+    http_request(std::string_view _endpoint, std::string_view _parameters, http_completion_event completion, std::string_view _postdata = "", http_method method = m_get, std::string_view audit_reason = "", std::string_view filename = "", std::string_view filecontent = "", std::string_view filemimetype = "", std::string_view http_protocol = "1.1");
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
@@ -321,7 +321,7 @@ public:
 	 * @param filemimetypes The MIME type of any uploaded file for the request
 	 * @param http_protocol HTTP protocol
 	 */
-	http_request(const std::string &_endpoint, const std::string &_parameters, http_completion_event completion, const std::string &_postdata = "", http_method method = m_get, const std::string &audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {}, const std::vector<std::string> &filemimetypes = {}, const std::string &http_protocol = "1.1");
+    http_request(std::string_view _endpoint, std::string_view _parameters, http_completion_event completion, std::string_view _postdata = "", http_method method = m_get, std::string_view audit_reason = "", const std::vector<std::string> &filename = {}, const std::vector<std::string> &filecontent = {}, const std::vector<std::string> &filemimetypes = {}, std::string_view http_protocol = "1.1");
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().
@@ -333,7 +333,7 @@ public:
 	 * @param _headers HTTP headers to send
 	 * @param http_protocol HTTP protocol
 	 */
-	http_request(const std::string &_url, http_completion_event completion, http_method method = m_get, const std::string &_postdata = "", const std::string &_mimetype = "text/plain", const std::multimap<std::string, std::string> &_headers = {}, const std::string &http_protocol = "1.1");
+    http_request(std::string_view _url, http_completion_event completion, http_method method = m_get, std::string_view _postdata = "", std::string_view _mimetype = "text/plain", const std::multimap<std::string, std::string> &_headers = {}, std::string_view http_protocol = "1.1");
 
 	/**
 	 * @brief Destroy the http request object

--- a/include/dpp/restrequest.h
+++ b/include/dpp/restrequest.h
@@ -39,7 +39,7 @@ namespace dpp {
  * @param postdata Post data or empty string
  * @param callback Callback lambda
  */
-template<class T> inline void rest_request(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback) {
+template<class T> inline void rest_request(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(c, T().fill_from_json(&j), http));
@@ -59,7 +59,7 @@ template<class T> inline void rest_request(dpp::cluster* c, const char* basepath
  * @param postdata Post data or empty string
  * @param callback Callback lambda
  */
-template<> inline void rest_request<message>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback) {
+template<> inline void rest_request<message>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(c, message(c).fill_from_json(&j), http));
@@ -79,7 +79,7 @@ template<> inline void rest_request<message>(dpp::cluster* c, const char* basepa
  * @param postdata Post data or empty string
  * @param callback Callback lambda
  */
-template<> inline void rest_request<confirmation>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback) {
+template<> inline void rest_request<confirmation>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(c, confirmation(), http));
@@ -101,13 +101,14 @@ template<> inline void rest_request<confirmation>(dpp::cluster* c, const char* b
  * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<class T> inline void rest_request_list(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key = "id") {
+template<class T> inline void rest_request_list(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key = "id") {
 	c->post_rest(basepath, major, minor, method, postdata, [c, key, callback](json &j, const http_request_completion_t& http) {
 		std::unordered_map<snowflake, T> list;
 		confirmation_callback_t e(c, confirmation(), http);
+        std::string key_str(key);
 		if (!e.is_error()) {
 			for (auto & curr_item : j) {
-				list[snowflake_not_null(&curr_item, key.c_str())] = T().fill_from_json(&curr_item);
+                list[snowflake_not_null(&curr_item, key_str.c_str())] = T().fill_from_json(&curr_item);
 			}
 		}
 		if (callback) {
@@ -130,7 +131,7 @@ template<class T> inline void rest_request_list(dpp::cluster* c, const char* bas
  * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<> inline void rest_request_list<invite>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+template<> inline void rest_request_list<invite>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		invite_map list;
 		confirmation_callback_t e(c, confirmation(), http);
@@ -159,7 +160,7 @@ template<> inline void rest_request_list<invite>(dpp::cluster* c, const char* ba
  * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<> inline void rest_request_list<voiceregion>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+template<> inline void rest_request_list<voiceregion>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		voiceregion_map list;
 		confirmation_callback_t e(c, confirmation(), http);
@@ -188,7 +189,7 @@ template<> inline void rest_request_list<voiceregion>(dpp::cluster* c, const cha
  * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<> inline void rest_request_list<ban>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+template<> inline void rest_request_list<ban>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		std::unordered_map<snowflake, ban> list;
 		confirmation_callback_t e(c, confirmation(), http);
@@ -218,14 +219,15 @@ template<> inline void rest_request_list<ban>(dpp::cluster* c, const char* basep
  * @param key Key name of elements in the json list
  * @param callback Callback lambda
  */
-template<> inline void rest_request_list<sticker_pack>(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key) {
+template<> inline void rest_request_list<sticker_pack>(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, key, callback](json &j, const http_request_completion_t& http) {
 		std::unordered_map<snowflake, sticker_pack> list;
 		confirmation_callback_t e(c, confirmation(), http);
+        std::string key_str(key);
 		if (!e.is_error()) {
 			if (j.contains("sticker_packs")) {
 				for (auto &curr_item: j["sticker_packs"]) {
-					list[snowflake_not_null(&curr_item, key.c_str())] = sticker_pack().fill_from_json(&curr_item);
+                    list[snowflake_not_null(&curr_item, key_str.c_str())] = sticker_pack().fill_from_json(&curr_item);
 				}
 			}
 		}
@@ -250,13 +252,14 @@ template<> inline void rest_request_list<sticker_pack>(dpp::cluster* c, const ch
  * @param root Root element to look for
  * @param callback Callback lambda
  */
-template<class T> inline void rest_request_list(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback, const std::string& key, const std::string& root) {
+template<class T> inline void rest_request_list(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback, std::string_view key, std::string_view root) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, root, key, callback](json &j, const http_request_completion_t& http) {
 		std::unordered_map<snowflake, T> list;
 		confirmation_callback_t e(c, confirmation(), http);
+        std::string key_str(key);
 		if (!e.is_error()) {
 			for (auto & curr_item : j[root]) {
-				list[snowflake_not_null(&curr_item, key.c_str())] = T().fill_from_json(&curr_item);
+                list[snowflake_not_null(&curr_item, key_str.c_str())] = T().fill_from_json(&curr_item);
 			}
 		}
 		if (callback) {
@@ -278,7 +281,7 @@ template<class T> inline void rest_request_list(dpp::cluster* c, const char* bas
  * @param postdata Post data or empty string
  * @param callback Callback lambda
  */
-template<class T> inline void rest_request_vector(dpp::cluster* c, const char* basepath, const std::string &major, const std::string &minor, http_method method, const std::string& postdata, command_completion_event_t callback) {
+template<class T> inline void rest_request_vector(dpp::cluster* c, const char* basepath, std::string_view major, std::string_view minor, http_method method, std::string_view postdata, command_completion_event_t callback) {
 	c->post_rest(basepath, major, minor, method, postdata, [c, callback](json &j, const http_request_completion_t& http) {
 		std::vector<T> list;
 		confirmation_callback_t e(c, confirmation(), http);

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -215,7 +215,7 @@ public:
 	 * @return role& reference to self
 	 * @throw dpp::exception thrown if role length is less than 1 character
 	 */
-	role& set_name(const std::string& n);
+    role& set_name(std::string_view n);
 
 	/**
 	 * @brief Set the colour.

--- a/include/dpp/scheduled_event.h
+++ b/include/dpp/scheduled_event.h
@@ -239,7 +239,7 @@ public:
 	 * @return scheduled_event& reference to self
 	 * @throw dpp::length_error if length < 1
 	 */
-	scheduled_event& set_name(const std::string& n);
+    scheduled_event& set_name(std::string_view n);
 
 	/**
 	 * @brief Set the description of the event.
@@ -248,7 +248,7 @@ public:
 	 * @return scheduled_event& reference to self
 	 * @throw dpp::length_error if length < 1
 	 */
-	scheduled_event& set_description(const std::string& d);
+    scheduled_event& set_description(std::string_view d);
 
 	/**
 	 * @brief Clear the description of the event.
@@ -264,7 +264,7 @@ public:
 	 * @return scheduled_event& reference to self
 	 * @throw dpp::length_error if length < 1
 	 */
-	scheduled_event& set_location(const std::string& l);
+    scheduled_event& set_location(std::string_view l);
 
 	/**
 	 * @brief Set the voice channel id of the event.

--- a/include/dpp/sku.h
+++ b/include/dpp/sku.h
@@ -137,7 +137,7 @@ public:
 	 * @param flags Flags bitmap from dpp::sku_flags.
 	 *
 	 */
-	sku(const snowflake id, const sku_type type, const snowflake application_id, const std::string name, const std::string slug, const uint16_t flags);
+    sku(const snowflake id, const sku_type type, const snowflake application_id, std::string_view name, std::string_view slug, const uint16_t flags);
 
 	/**
 	 * @brief Get the type of SKU.

--- a/include/dpp/sslclient.h
+++ b/include/dpp/sslclient.h
@@ -216,7 +216,7 @@ public:
 	 * connection to non-Discord addresses such as within dpp::cluster::request().
 	 * @throw dpp::exception Failed to initialise connection
 	 */
-	ssl_client(const std::string &_hostname, const std::string &_port = "443", bool plaintext_downgrade = false, bool reuse = false);
+    ssl_client(std::string_view _hostname, std::string_view _port = "443", bool plaintext_downgrade = false, bool reuse = false);
 
 	/**
 	 * @brief Nonblocking I/O loop
@@ -242,7 +242,7 @@ public:
 	 * @param data Data to be written to the buffer
 	 * @note The data may not be written immediately and may be written at a later time to the socket.
 	 */
-	virtual void write(const std::string &data);
+    virtual void write(std::string_view data);
 
 	/**
 	 * @brief Close socket connection
@@ -254,7 +254,7 @@ public:
 	 * @param severity severity of log message
 	 * @param msg Log message to send
 	 */
-	virtual void log(dpp::loglevel severity, const std::string &msg) const;
+    virtual void log(dpp::loglevel severity, std::string_view msg) const;
 };
 
 } // namespace dpp

--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -31,7 +31,37 @@
 #include <iostream>
 #include <charconv>
 
+#ifdef __cpp_lib_spanstream
+#include <spanstream>
+#endif
+
 namespace dpp {
+
+#ifndef __cpp_lib_spanstream
+/**
+ * @brief streambuf for imemstream
+ * @note From https://stackoverflow.com/a/13059195
+ */
+struct membuf : std::streambuf
+{
+    membuf(const char* base, size_t size)
+    {
+        char* p(const_cast<char*>(base));
+        this->setg(p, p, p + size);
+    }
+};
+
+/**
+ * @brief An input stream over a raw character array. Superseded by std::ispanstream in C++23
+ * @note From https://stackoverflow.com/a/13059195
+ */
+struct imemstream : virtual membuf, std::istream
+{
+    imemstream(const char* base, size_t size)
+        : membuf(base, size), std::istream(static_cast<std::streambuf*>(this)) {}
+};
+#endif
+
 /**
  * @brief Convert a string to lowercase using tolower()
  * 
@@ -41,9 +71,23 @@ namespace dpp {
  */
 template <typename T> std::basic_string<T> lowercase(const std::basic_string<T>& s)
 {
-	std::basic_string<T> s2 = s;
+    std::basic_string<T> s2(s);
 	std::transform(s2.begin(), s2.end(), s2.begin(), tolower);
 	return s2;
+}
+
+/**
+ * @brief Convert a string to lowercase using tolower()
+ *
+ * @tparam T type of string
+ * @param s String_view to lowercase
+ * @return std::basic_string<T> lowercased string
+ */
+template <typename T> std::basic_string<T> lowercase(std::basic_string_view<T> s)
+{
+    std::basic_string<T> s2(s);
+    std::transform(s2.begin(), s2.end(), s2.begin(), tolower);
+    return s2;
 }
 
 /**
@@ -55,9 +99,23 @@ template <typename T> std::basic_string<T> lowercase(const std::basic_string<T>&
  */
 template <typename T> std::basic_string<T> uppercase(const std::basic_string<T>& s)
 {
-	std::basic_string<T> s2 = s;
+    std::basic_string<T> s2(s);
 	std::transform(s2.begin(), s2.end(), s2.begin(), toupper);
 	return s2;
+}
+
+/**
+ * @brief Convert a string to uppercase using toupper()
+ *
+ * @tparam T type of string
+ * @param s String_view to uppercase
+ * @return std::basic_string<T> uppercased string
+ */
+template <typename T> std::basic_string<T> uppercase(std::basic_string_view<T> s)
+{
+    std::basic_string<T> s2(s);
+    std::transform(s2.begin(), s2.end(), s2.begin(), toupper);
+    return s2;
 }
 
 /**
@@ -66,10 +124,11 @@ template <typename T> std::basic_string<T> uppercase(const std::basic_string<T>&
  * @param s String to trim
  * @return std::string trimmed string
  */
-inline std::string rtrim(std::string s)
+inline std::string rtrim(std::string_view s)
 {
-	s.erase(s.find_last_not_of(" \t\n\r\f\v") + 1);
-	return s;
+    std::string s_cpy(s);
+    s_cpy.erase(s_cpy.find_last_not_of(" \t\n\r\f\v") + 1);
+    return s_cpy;
 }
 
 /**
@@ -78,10 +137,11 @@ inline std::string rtrim(std::string s)
  * @param s string to trim
  * @return std::string trimmed string
  */
-inline std::string ltrim(std::string s)
+inline std::string ltrim(std::string_view s)
 {
-	s.erase(0, s.find_first_not_of(" \t\n\r\f\v"));
-	return s;
+    std::string s_cpy(s);
+    s_cpy.erase(0, s_cpy.find_first_not_of(" \t\n\r\f\v"));
+    return s_cpy;
 }
 
 /**
@@ -90,7 +150,7 @@ inline std::string ltrim(std::string s)
  * @param s string to trim 
  * @return std::string trimmed string
  */
-inline std::string trim(std::string s)
+inline std::string trim(std::string_view s)
 {
 	return ltrim(rtrim(s));
 }
@@ -120,11 +180,19 @@ template<class T> std::string comma(T value)
  * @param f Numeric base, e.g. `std::dec` or `std::hex`
  * @return T Returned numeric value
  */
-template <typename T> T from_string(const std::string &s, std::ios_base & (*f)(std::ios_base&))
+template <typename T> T from_string(std::string_view s, std::ios_base & (*f)(std::ios_base&))
 {
 	T t;
-	std::istringstream iss(s);
-	iss >> f, iss >> t;
+
+#ifdef __cpp_lib_spanstream
+    std::span<const char> span(s.begin(), s.end());
+    std::ispanstream iss(span);
+    iss >> f, iss >> t;
+#else
+    imemstream ims(s.data(), s.size());
+    ims >> f, ims >> t;
+#endif
+
 	return t;
 }
 
@@ -137,14 +205,23 @@ template <typename T> T from_string(const std::string &s, std::ios_base & (*f)(s
  *
  * @note Base 10 for numeric conversions.
  */
-template <typename T> T from_string(const std::string &s)
+template <typename T> T from_string(std::string_view s)
 {
 	if (s.empty()) {
 		return static_cast<T>(0);
 	}
+
 	T t;
-	std::istringstream iss(s);
-	iss >> t;
+
+#ifdef __cpp_lib_spanstream
+    std::span<const char> span(s.begin(), s.end());
+    std::ispanstream iss(span);
+    iss >> t;
+#else
+    imemstream ims(s.data(), s.size());
+    ims >> t;
+#endif
+
 	return t;
 }
 
@@ -155,9 +232,11 @@ template <typename T> T from_string(const std::string &s)
  * @param s string to convert 
  * @return uint64_t return value
  */
-template <uint64_t> uint64_t from_string(const std::string &s)
+template <uint64_t> uint64_t from_string(std::string_view s)
 {
-	return std::stoull(s, 0, 10);
+    uint64_t value{};
+    std::from_chars(s.data(), s.data() + s.size(), value);
+    return value;
 }
 
 /**
@@ -167,9 +246,11 @@ template <uint64_t> uint64_t from_string(const std::string &s)
  * @param s string to convert
  * @return uint32_t return value
  */
-template <uint32_t> uint32_t from_string(const std::string &s)
+template <uint32_t> uint32_t from_string(std::string_view s)
 {
-	return (uint32_t) std::stoul(s, 0, 10);
+    uint32_t value{};
+    std::from_chars(s.data(), s.data() + s.size(), value);
+    return value;
 }
 
 /**
@@ -179,9 +260,11 @@ template <uint32_t> uint32_t from_string(const std::string &s)
  * @param s string to convert
  * @return int return value
  */
-template <int> int from_string(const std::string &s)
+template <int> int from_string(std::string_view s)
 {
-	return std::stoi(s, 0, 10);
+    int value{};
+    std::from_chars(s.data(), s.data() + s.size(), value);
+    return value;
 }
 
 /**

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -67,7 +67,7 @@ namespace utility {
  * @param is_animated Whether the image is actually animated or not
  * @return std::string endpoint url or empty string
  */
-std::string DPP_EXPORT cdn_endpoint_url(const std::vector<image_type> &allowed_formats, const std::string &path_without_extension, const dpp::image_type format, uint16_t size, bool prefer_animated = false, bool is_animated = false);
+std::string DPP_EXPORT cdn_endpoint_url(const std::vector<image_type> &allowed_formats, std::string_view path_without_extension, const dpp::image_type format, uint16_t size, bool prefer_animated = false, bool is_animated = false);
 
 /**
  * @brief Helper function to easily create discord's cdn endpoint urls.
@@ -85,7 +85,7 @@ std::string DPP_EXPORT cdn_endpoint_url(const std::vector<image_type> &allowed_f
  * @param is_animated Whether the image is actually animated or not
  * @return std::string endpoint url or empty string
  */
-std::string DPP_EXPORT cdn_endpoint_url_hash(const std::vector<image_type> &allowed_formats, const std::string &path_without_extension, const std::string &hash, const dpp::image_type format, uint16_t size, bool prefer_animated = false, bool is_animated = false);
+std::string DPP_EXPORT cdn_endpoint_url_hash(const std::vector<image_type> &allowed_formats, std::string_view path_without_extension, std::string_view hash, const dpp::image_type format, uint16_t size, bool prefer_animated = false, bool is_animated = false);
 
 /**
  * @brief Helper function to easily create discord's cdn endpoint urls (specialised for stickers)
@@ -190,12 +190,12 @@ enum guild_navigation_type {
 /**
  * @brief The base URL for CDN content such as profile pictures and guild icons.
  */
-inline const std::string cdn_host = "https://cdn.discordapp.com"; 
+inline const std::string cdn_host = "https://cdn.discordapp.com";
 
 /**
  * @brief The base URL for message/user/channel links.
  */
-inline const std::string url_host = "https://discord.com"; 
+inline const std::string url_host = "https://discord.com";
 
 /**
  * @brief Callback for the results of a command executed via dpp::utility::exec
@@ -216,7 +216,7 @@ typedef std::function<void(const std::string& output)> cmd_result_t;
  * @param parameters Command line parameters. Each will be escaped using `std::quoted`.
  * @param callback The callback to call on completion.
  */
-void DPP_EXPORT exec(const std::string& cmd, std::vector<std::string> parameters = {}, cmd_result_t callback = {});
+void DPP_EXPORT exec(std::string_view cmd, std::vector<std::string> parameters = {}, cmd_result_t callback = {});
 
 /**
  * @brief Return a mentionable timestamp (used in a message). These timestamps will display the given timestamp in the user's timezone and locale.
@@ -272,7 +272,7 @@ struct DPP_EXPORT iconhash {
 	 * @param _first Leftmost portion of the hash value
 	 * @param _second Rightmost portion of the hash value
 	 */
-	iconhash(uint64_t _first = 0, uint64_t _second = 0) noexcept;
+    iconhash(uint64_t _first = 0, uint64_t _second = 0) noexcept;
 
 	/**
 	 * @brief Construct a new iconhash object
@@ -283,17 +283,17 @@ struct DPP_EXPORT iconhash {
 	 * @throws std::length_error if the provided
 	 * string is not exactly 32 characters long.
 	 */
-	iconhash(const std::string &hash);
+    iconhash(std::string_view hash);
 
 	/**
-	 * @brief Assign from std::string
+     * @brief Assign from std::string
 	 *
 	 * @param assignment string to assign from.
 	 *
 	 * @throws std::length_error if the provided
 	 * string is not exactly 32 characters long.
 	 */
-	iconhash& operator=(const std::string &assignment);
+    iconhash& operator=(std::string_view assignment);
 
 	/**
 	 * @brief Check if one iconhash is equal to another
@@ -312,7 +312,7 @@ struct DPP_EXPORT iconhash {
 	 * @throws std::length_error if the provided
 	 * string is not exactly 32 characters long.
 	 */
-	void set(const std::string &hash);
+    void set(std::string_view hash);
 
 	/**
 	 * @brief Convert iconhash back to 32 character
@@ -778,7 +778,7 @@ std::string DPP_EXPORT utf8substr(std::string_view str, size_t start, size_t len
  * @return std::string The file contents
  * @throw dpp::file_exception on failure to read the entire file
  */
-std::string DPP_EXPORT read_file(const std::string& filename);
+std::string DPP_EXPORT read_file(std::string_view filename);
 
 /**
  * @brief Validate a string value
@@ -792,7 +792,7 @@ std::string DPP_EXPORT read_file(const std::string& filename);
  * @return std::string Validated string, truncated if necessary.
  * @throw dpp::length_exception if value UTF8 length < _min
  */
-std::string DPP_EXPORT validate(const std::string& value, size_t _min, size_t _max, const std::string& exception_message);
+std::string DPP_EXPORT validate(std::string_view value, size_t _min, size_t _max, std::string_view exception_message);
 
 /**
  * @brief Get the url query parameter for the cdn endpoint. Internally used to build url getters.
@@ -809,7 +809,7 @@ std::string DPP_EXPORT avatar_size(uint32_t size);
  * @param sep Separator characters
  * @return std::vector<std::string> Tokenized strings 
  */
-std::vector<std::string> DPP_EXPORT tokenize(std::string const &in, const char* sep = "\r\n");
+std::vector<std::string> DPP_EXPORT tokenize(std::string_view in, const char* sep = "\r\n");
 
 /**
  * @brief Create a bot invite
@@ -831,7 +831,7 @@ std::string DPP_EXPORT bot_invite_url(const snowflake bot_id, const uint64_t per
  * character.
  * @return std::string The text with the markdown special characters escaped with a backslash
  */
-std::string DPP_EXPORT markdown_escape(const std::string& text, bool escape_code_blocks = false);
+std::string DPP_EXPORT markdown_escape(std::string_view text, bool escape_code_blocks = false);
 
 /**
  * @brief Encodes a url parameter similar to [php urlencode()](https://www.php.net/manual/en/function.urlencode.php)
@@ -839,7 +839,7 @@ std::string DPP_EXPORT markdown_escape(const std::string& text, bool escape_code
  * @param value String to encode
  * @return std::string URL encoded string
  */
-std::string DPP_EXPORT url_encode(const std::string &value);
+std::string DPP_EXPORT url_encode(std::string_view value);
 
 /**
  * @brief Create a mentionable slashcommand (used in a message).
@@ -848,7 +848,7 @@ std::string DPP_EXPORT url_encode(const std::string &value);
  * @param subcommand Optional: The subcommand name (for mentioning a subcommand)
  * @return std::string The formatted mention
  */
-std::string DPP_EXPORT slashcommand_mention(snowflake command_id, const std::string &command_name, const std::string &subcommand = "");
+std::string DPP_EXPORT slashcommand_mention(snowflake command_id, std::string_view command_name, std::string_view subcommand = "");
 
 /**
  * @brief Create a mentionable slashcommand (used in a message).
@@ -858,7 +858,7 @@ std::string DPP_EXPORT slashcommand_mention(snowflake command_id, const std::str
  * @param subcommand The subcommand name
  * @return std::string The formatted mention of the slashcommand with its subcommand
  */
-std::string DPP_EXPORT slashcommand_mention(snowflake command_id, const std::string &command_name, const std::string &subcommand_group, const std::string &subcommand);
+std::string DPP_EXPORT slashcommand_mention(snowflake command_id, std::string_view command_name, std::string_view subcommand_group, std::string_view subcommand);
 
 /**
  * @brief Create a mentionable user.
@@ -922,7 +922,14 @@ std::string DPP_EXPORT thread_url(const snowflake& guild_id, const snowflake& th
 */
 std::string DPP_EXPORT user_url(const snowflake& user_id);
 
-
+template<typename Map, typename K, typename M>
+std::pair<typename Map::iterator, bool> emplace_or_assign(Map& m, K&& k, M&& obj)
+{
+    auto res = m.emplace(std::forward<K>(k), std::forward<M>(obj));
+    if (!res.second)
+        res.first->second = std::forward<M>(obj);
+    return res;
+}
 
 #ifdef _DOXYGEN_
 /**
@@ -1016,7 +1023,7 @@ std::string DPP_EXPORT make_url_parameters(const std::map<std::string, uint64_t>
  * 
  * @param name New name to set
  */
-void DPP_EXPORT set_thread_name(const std::string& name);
+void DPP_EXPORT set_thread_name(std::string_view name);
 
 #ifdef __cpp_concepts // if c++20
 /**

--- a/include/dpp/webhook.h
+++ b/include/dpp/webhook.h
@@ -169,7 +169,7 @@ public:
 	 * @param webhook_url a fully qualified web address of an existing webhook
 	 * @throw logic_exception if the webhook url could not be parsed
 	 */
-	webhook(const std::string& webhook_url);
+    webhook(std::string_view webhook_url);
 
 	/**
 	 * @brief Construct a new webhook object using the webhook ID and the webhook token
@@ -177,7 +177,7 @@ public:
 	 * @param webhook_id id taken from a link of an existing webhook
 	 * @param webhook_token token taken from a link of an existing webhook
 	 */
-	webhook(const snowflake webhook_id, const std::string& webhook_token);
+    webhook(const snowflake webhook_id, std::string_view webhook_token);
 
 	/**
 	 * @brief Base64 encode image data and allocate it to image_data
@@ -188,7 +188,7 @@ public:
 	 * @return webhook& Reference to self
 	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
 	 */
-	webhook& load_image(const std::string &image_blob, const image_type type, bool is_base64_encoded = false);
+    webhook& load_image(std::string_view image_blob, const image_type type, bool is_base64_encoded = false);
 };
 
 /**

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -155,7 +155,7 @@ class DPP_EXPORT websocket_client : public ssl_client {
 	 * @param ping True if this is a ping, false if it is a pong 
 	 * @param payload The ping payload, to be returned as-is for a ping
 	 */
-	void handle_ping_pong(bool ping, const std::string &payload);
+    void handle_ping_pong(bool ping, std::string_view payload);
 
 protected:
 
@@ -181,7 +181,7 @@ public:
 	 * @note Voice websockets only support OP_TEXT, and other websockets must be
 	 * OP_BINARY if you are going to send ETF.
 	 */
-        websocket_client(const std::string &hostname, const std::string &port = "443", const std::string &urlpath = "", ws_opcode opcode = OP_BINARY);
+        websocket_client(std::string_view hostname, std::string_view port = "443", std::string_view urlpath = "", ws_opcode opcode = OP_BINARY);
 
 	/**
 	 * @brief Destroy the websocket client object
@@ -192,7 +192,7 @@ public:
 	 * @brief Write to websocket. Encapsulates data in frames if the status is CONNECTED.
 	 * @param data The data to send.
 	 */
-        virtual void write(const std::string &data);
+        virtual void write(std::string_view data);
 
 	/**
 	 * @brief Processes incoming frames from the SSL socket input buffer.
@@ -211,7 +211,7 @@ public:
 	 * @param buffer The buffer contents
 	 * @return True if the frame was successfully handled. False if no valid frame is in the buffer.
 	 */
-	virtual bool handle_frame(const std::string &buffer);
+    virtual bool handle_frame(std::string_view buffer);
 
 	/**
 	 * @brief Called upon error frame.

--- a/src/dpp/bignum.cpp
+++ b/src/dpp/bignum.cpp
@@ -47,11 +47,11 @@ struct openssl_bignum {
 	}
 };
 
-bignumber::bignumber(const std::string& number_string) : ssl_bn(std::make_shared<openssl_bignum>()) {
+bignumber::bignumber(std::string_view number_string) : ssl_bn(std::make_shared<openssl_bignum>()) {
 	if (dpp::lowercase(number_string.substr(0, 2)) == "0x") {
-		BN_hex2bn(&ssl_bn->bn, number_string.substr(2, number_string.length() - 2).c_str());
+        BN_hex2bn(&ssl_bn->bn, std::string(number_string.substr(2)).c_str());
 	} else {
-		BN_dec2bn(&ssl_bn->bn, number_string.c_str());
+        BN_dec2bn(&ssl_bn->bn, std::string(number_string).c_str());
 	}
 }
 

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -47,7 +47,7 @@ permission_overwrite::permission_overwrite(snowflake id, uint64_t allow, uint64_
 
 forum_tag::forum_tag() : managed(), moderated(false) {}
 
-forum_tag::forum_tag(const std::string& name) : forum_tag() {
+forum_tag::forum_tag(std::string_view name) : forum_tag() {
 	this->set_name(name);
 }
 
@@ -80,7 +80,7 @@ json forum_tag::to_json_impl(bool with_id) const {
 	return j;
 }
 
-forum_tag &forum_tag::set_name(const std::string &name) {
+forum_tag &forum_tag::set_name(std::string_view name) {
 	this->name = utility::utf8substr(name, 0, 20);
 	return *this;
 }
@@ -124,12 +124,12 @@ std::string channel::get_mention() const {
 	return utility::channel_mention(id);
 }
 
-channel& channel::set_name(const std::string& name) {
+channel& channel::set_name(std::string_view name) {
 	this->name = utility::validate(name, 1, 100, "name must be at least 1 character");
 	return *this;
 }
 
-channel& channel::set_topic(const std::string& topic) {
+channel& channel::set_topic(std::string_view topic) {
 	this->topic = utility::utf8substr(topic, 0, 1024);
 	return *this;
 }

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -135,7 +135,7 @@ void cluster::guild_commands_get(snowflake guild_id, command_completion_event_t 
 	rest_request_list<slashcommand>(this, API_PATH "/applications", std::to_string(me.id), "/guilds/" + std::to_string(guild_id) + "/commands", m_get, "", callback);
 }
 
-void cluster::interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r, command_completion_event_t callback) {
+void cluster::interaction_response_create(snowflake interaction_id, std::string_view token, const interaction_response &r, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/interactions", std::to_string(interaction_id), utility::url_encode(token) + "/callback", m_post, r.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
@@ -143,7 +143,7 @@ void cluster::interaction_response_create(snowflake interaction_id, const std::s
 	}, r.msg.file_data);
 }
 
-void cluster::interaction_response_edit(const std::string &token, const message &m, command_completion_event_t callback) {
+void cluster::interaction_response_edit(std::string_view token, const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
@@ -151,11 +151,11 @@ void cluster::interaction_response_edit(const std::string &token, const message 
 	}, m.file_data);
 }
 
-void cluster::interaction_response_get_original(const std::string &token, command_completion_event_t callback) {
+void cluster::interaction_response_get_original(std::string_view token, command_completion_event_t callback) {
 	rest_request<message>(this, API_PATH "/webhooks",std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_get, "", callback);
 }
 
-void cluster::interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback) {
+void cluster::interaction_followup_create(std::string_view token, const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token), m_post, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
@@ -163,7 +163,7 @@ void cluster::interaction_followup_create(const std::string &token, const messag
 	}, m.file_data);
 }
 
-void cluster::interaction_followup_edit_original(const std::string &token, const message &m, command_completion_event_t callback) {
+void cluster::interaction_followup_edit_original(std::string_view token, const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
@@ -171,11 +171,11 @@ void cluster::interaction_followup_edit_original(const std::string &token, const
 	}, m.file_data);
 }
 
-void cluster::interaction_followup_delete(const std::string &token, command_completion_event_t callback) {
+void cluster::interaction_followup_delete(std::string_view token, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/webhooks",std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_delete, "", callback);
 }
 
-void cluster::interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback) {
+void cluster::interaction_followup_edit(std::string_view token, const message &m, command_completion_event_t callback) {
 	this->post_rest_multipart(API_PATH "/webhooks", std::to_string(me.id), utility::url_encode(token) + "/messages/" + std::to_string(m.id), m_patch, m.build_json(), [this, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, confirmation(), http));
@@ -183,11 +183,11 @@ void cluster::interaction_followup_edit(const std::string &token, const message 
 	}, m.file_data);
 }
 
-void cluster::interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback) {
+void cluster::interaction_followup_get(std::string_view token, snowflake message_id, command_completion_event_t callback) {
 	rest_request<message>(this, API_PATH "/webhooks",std::to_string(me.id), utility::url_encode(token) + "/messages/" + std::to_string(message_id), m_get, "", callback);
 }
 
-void cluster::interaction_followup_get_original(const std::string &token, command_completion_event_t callback) {
+void cluster::interaction_followup_get_original(std::string_view token, command_completion_event_t callback) {
 	rest_request<message>(this, API_PATH "/webhooks",std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_get, "", callback);
 }
 

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -96,7 +96,7 @@ void cluster::channels_get(snowflake guild_id, command_completion_event_t callba
 	rest_request_list<channel>(this, API_PATH "/guilds", std::to_string(guild_id), "channels", m_get, "", callback);
 }
 
-void cluster::channel_set_voice_status(snowflake channel_id, const std::string& status, command_completion_event_t callback) {
+void cluster::channel_set_voice_status(snowflake channel_id, std::string_view status, command_completion_event_t callback) {
 	json j({ {"status", status} });
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }

--- a/src/dpp/cluster/confirmation.cpp
+++ b/src/dpp/cluster/confirmation.cpp
@@ -74,7 +74,7 @@ bool confirmation_callback_t::is_error() const {
 
 namespace {
 
-std::vector<error_detail> find_errors_in_object(const std::string& obj, const std::string& current_field, const json &j) {
+std::vector<error_detail> find_errors_in_object(std::string_view obj, std::string_view current_field, const json &j) {
 	std::vector<error_detail> ret;
 
 	if (auto errors = j.find("_errors"); errors != j.end()) {
@@ -93,7 +93,7 @@ std::vector<error_detail> find_errors_in_object(const std::string& obj, const st
 
 			if (obj.empty()) {
 				field = current_field;
-			} else if (isdigit(*current_field.c_str())) {
+            } else if (isdigit(current_field.front())) {
 				/* An element of an array, e.g. an element of a slash command vector for global_bulk_slash_command_create */
 				field = obj;
 				field += '[';

--- a/src/dpp/cluster/dm.cpp
+++ b/src/dpp/cluster/dm.cpp
@@ -52,7 +52,7 @@ void cluster::direct_message_create(snowflake user_id, const message &m, command
 	}
 }
 
-void cluster::gdm_add(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick, command_completion_event_t callback) {
+void cluster::gdm_add(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick, command_completion_event_t callback) {
 	json params;
 	params["access_token"] = access_token;
 	params["nick"] = nick;

--- a/src/dpp/cluster/entitlement.cpp
+++ b/src/dpp/cluster/entitlement.cpp
@@ -62,7 +62,7 @@ void cluster::entitlements_get(snowflake user_id, const std::vector<snowflake>& 
 
 	j["exclude_ended"] = exclude_ended;
 
-	rest_request_list<entitlement>(this, API_PATH "/applications", me.id.str(), "entitlements", m_get, j, callback);
+    rest_request_list<entitlement>(this, API_PATH "/applications", me.id.str(), "entitlements", m_get, std::string(j), callback);
 }
 
 void cluster::entitlement_test_create(const class entitlement& new_entitlement, command_completion_event_t callback) {
@@ -70,7 +70,7 @@ void cluster::entitlement_test_create(const class entitlement& new_entitlement, 
 	j["sku_id"] = new_entitlement.sku_id.str();
 	j["owner_id"] = new_entitlement.guild_id.empty() ? new_entitlement.guild_id.str() : new_entitlement.user_id.str();
 	j["owner_type"] = new_entitlement.type;
-	rest_request<entitlement>(this, API_PATH "/applications", me.id.str(), "entitlements", m_post, j, callback);
+    rest_request<entitlement>(this, API_PATH "/applications", me.id.str(), "entitlements", m_post, std::string(j), callback);
 }
 
 void cluster::entitlement_test_delete(const class snowflake entitlement_id, command_completion_event_t callback) {

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -23,7 +23,7 @@
 
 namespace dpp {
 
-void cluster::guild_current_member_edit(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
+void cluster::guild_current_member_edit(snowflake guild_id, std::string_view nickname, command_completion_event_t callback) {
 	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::replace);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, o, callback);
 }
@@ -139,7 +139,7 @@ void cluster::guild_begin_prune(snowflake guild_id, const struct prune& pruneinf
 }
 
 
-void cluster::guild_set_nickname(snowflake guild_id, const std::string &nickname, command_completion_event_t callback) {
+void cluster::guild_set_nickname(snowflake guild_id, std::string_view nickname, command_completion_event_t callback) {
 	std::string o = (nickname.empty() ? json({{"nick", json::value_t::null }}) : json({{"nick", nickname }})).dump(-1, ' ', false, json::error_handler_t::replace);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me/nick", m_patch, o, callback);
 }

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -22,7 +22,7 @@
 
 namespace dpp {
 
-void cluster::guild_add_member(const guild_member& gm, const std::string &access_token, command_completion_event_t callback) {
+void cluster::guild_add_member(const guild_member& gm, std::string_view access_token, command_completion_event_t callback) {
 	json j = gm.to_json();
 	j["access_token"] = access_token;
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
@@ -130,9 +130,9 @@ void cluster::guild_member_move(const snowflake channel_id, const snowflake guil
 }
 
 
-void cluster::guild_search_members(snowflake guild_id, const std::string& query, uint16_t limit, command_completion_event_t callback) {
+void cluster::guild_search_members(snowflake guild_id, std::string_view query, uint16_t limit, command_completion_event_t callback) {
 	std::string parameters = utility::make_url_parameters({
-		{"query", query},
+        {"query", std::string(query)},
 		{"limit", std::to_string(limit)},
 	});
 	this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "members/search" + parameters, m_get, "", [this, callback, guild_id] (json &j, const http_request_completion_t& http) {

--- a/src/dpp/cluster/invite.cpp
+++ b/src/dpp/cluster/invite.cpp
@@ -26,12 +26,12 @@ void cluster::guild_get_invites(snowflake guild_id, command_completion_event_t c
 	rest_request_list<invite>(this, API_PATH "/guilds", std::to_string(guild_id), "invites", m_get, "", callback, "code");
 }
 
-void cluster::invite_delete(const std::string &invitecode, command_completion_event_t callback) {
+void cluster::invite_delete(std::string_view invitecode, command_completion_event_t callback) {
 	rest_request<invite>(this, API_PATH "/invites", utility::url_encode(invitecode), "", m_delete, "", callback);
 }
 
 
-void cluster::invite_get(const std::string &invite_code, command_completion_event_t callback) {
+void cluster::invite_get(std::string_view invite_code, command_completion_event_t callback) {
 	rest_request<invite>(this, API_PATH "/invites", utility::url_encode(invite_code) + "?with_counts=true&with_expiration=true", "", m_get, "", callback);
 }
 

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -23,11 +23,11 @@
 
 namespace dpp {
 
-void cluster::message_add_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_add_reaction(const struct message &m, std::string_view reaction, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/@me", m_put, "", callback);
 }
 
-void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_add_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	message_add_reaction(m, reaction, callback);
@@ -75,11 +75,11 @@ void cluster::message_delete(snowflake message_id, snowflake channel_id, command
 }
 
 
-void cluster::message_delete_own_reaction(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_own_reaction(const struct message &m, std::string_view reaction, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/@me", m_delete, "", callback);
 }
 
-void cluster::message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_own_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
@@ -87,11 +87,11 @@ void cluster::message_delete_own_reaction(snowflake message_id, snowflake channe
 }
 
 
-void cluster::message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction(const struct message &m, snowflake user_id, std::string_view reaction, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + "/" + std::to_string(user_id), m_delete, "", callback);
 }
 
-void cluster::message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
@@ -99,11 +99,11 @@ void cluster::message_delete_reaction(snowflake message_id, snowflake channel_id
 }
 
 
-void cluster::message_delete_reaction_emoji(const struct message &m, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction_emoji(const struct message &m, std::string_view reaction, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction), m_delete, "", callback);
 }
 
-void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction, command_completion_event_t callback) {
+void cluster::message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, std::string_view reaction, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;
@@ -135,7 +135,7 @@ void cluster::message_get(snowflake message_id, snowflake channel_id, command_co
 }
 
 
-void cluster::message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
+void cluster::message_get_reactions(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
 	std::string parameters = utility::make_url_parameters({
 		{"before", before},
 		{"after", after},
@@ -144,7 +144,7 @@ void cluster::message_get_reactions(const struct message &m, const std::string &
 	rest_request_list<user>(this, API_PATH "/channels", std::to_string(m.channel_id), "messages/" + std::to_string(m.id) + "/reactions/" + utility::url_encode(reaction) + parameters, m_get, "", callback);
 }
 
-void cluster::message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
+void cluster::message_get_reactions(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit, command_completion_event_t callback) {
 	message m(channel_id, "");
 	m.id = message_id;
 	m.owner = this;

--- a/src/dpp/cluster/template.cpp
+++ b/src/dpp/cluster/template.cpp
@@ -23,26 +23,26 @@
 
 namespace dpp {
 
-void cluster::guild_create_from_template(const std::string &code, const std::string &name, command_completion_event_t callback) {
+void cluster::guild_create_from_template(std::string_view code, std::string_view name, command_completion_event_t callback) {
 	json params({{"name", name}});
 	rest_request<guild>(this, API_PATH "/guilds", "templates", code, m_post, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
-void cluster::guild_template_create(snowflake guild_id, const std::string &name, const std::string &description, command_completion_event_t callback) {
+void cluster::guild_template_create(snowflake guild_id, std::string_view name, std::string_view description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
 	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates", m_post, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
-void cluster::guild_template_delete(snowflake guild_id, const std::string &code, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_delete, "", callback);
+void cluster::guild_template_delete(snowflake guild_id, std::string_view code, command_completion_event_t callback) {
+    rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + std::string(code), m_delete, "", callback);
 }
 
 
-void cluster::guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description, command_completion_event_t callback) {
+void cluster::guild_template_modify(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description, command_completion_event_t callback) {
 	json params({{"name", name}, {"description", description}});
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_patch, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
+    rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + std::string(code), m_patch, params.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
 
@@ -51,12 +51,12 @@ void cluster::guild_templates_get(snowflake guild_id, command_completion_event_t
 }
 
 
-void cluster::guild_template_sync(snowflake guild_id, const std::string &code, command_completion_event_t callback) {
-	rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + code, m_put, "", callback);
+void cluster::guild_template_sync(snowflake guild_id, std::string_view code, command_completion_event_t callback) {
+    rest_request<dtemplate>(this, API_PATH "/guilds", std::to_string(guild_id), "templates/" + std::string(code), m_put, "", callback);
 }
 
 
-void cluster::template_get(const std::string &code, command_completion_event_t callback) {
+void cluster::template_get(std::string_view code, command_completion_event_t callback) {
 	rest_request<dtemplate>(this, API_PATH "/guilds", "templates", code, m_get, "", callback);
 }
 

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -115,7 +115,7 @@ void cluster::thread_members_get(snowflake thread_id, command_completion_event_t
 	rest_request_list<thread_member>(this, API_PATH "/channels", std::to_string(thread_id), "/thread-members", m_get, "", callback, "user_id");
 }
 
-void cluster::thread_create_in_forum(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags, command_completion_event_t callback)
+void cluster::thread_create_in_forum(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags, command_completion_event_t callback)
 {
 	json j({
 		{"name",                  thread_name},
@@ -152,7 +152,7 @@ void cluster::thread_create_in_forum(const std::string& thread_name, snowflake c
 	}, msg.file_data);
 }
 
-void cluster::thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)
+void cluster::thread_create(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user, command_completion_event_t callback)
 {
 	json j({
 		{"name", thread_name},
@@ -169,7 +169,7 @@ void cluster::thread_edit(const thread &t, command_completion_event_t callback)
 	rest_request<thread>(this, API_PATH "/channels", std::to_string(t.id), "", m_patch, t.build_json(), callback);
 }
 
-void cluster::thread_create_with_message(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user, command_completion_event_t callback)
+void cluster::thread_create_with_message(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user, command_completion_event_t callback)
 {
 	json j({
 		{"name", thread_name},

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -24,7 +24,7 @@
 
 namespace dpp {
 
-void cluster::current_user_edit(const std::string &nickname, const std::string& image_blob, const image_type type, command_completion_event_t callback) {
+void cluster::current_user_edit(std::string_view nickname, std::string_view image_blob, const image_type type, command_completion_event_t callback) {
 	json j = json::parse("{\"nickname\": null}");
 	if (!nickname.empty()) {
 		j["nickname"] = nickname;

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -38,7 +38,7 @@ void cluster::delete_webhook_message(const class webhook &wh, snowflake message_
 	rest_request<confirmation>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(message_id) + parameters, m_delete, "", callback);
 }
 
-void cluster::delete_webhook_with_token(snowflake webhook_id, const std::string &token, command_completion_event_t callback) {
+void cluster::delete_webhook_with_token(snowflake webhook_id, std::string_view token, command_completion_event_t callback) {
 	rest_request<confirmation>(this, API_PATH "/webhooks", std::to_string(webhook_id), utility::url_encode(token), m_delete, "", callback);
 }
 
@@ -66,7 +66,7 @@ void cluster::edit_webhook_with_token(const class webhook& wh, command_completio
 	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(wh.token), m_patch, jwh.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
-void cluster::execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, const std::string& thread_name, command_completion_event_t callback) {
+void cluster::execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, std::string_view thread_name, command_completion_event_t callback) {
 	std::string parameters = utility::make_url_parameters({
 		{"wait", wait},
 		{"thread_id", thread_id},
@@ -113,7 +113,7 @@ void cluster::get_webhook_message(const class webhook &wh, snowflake message_id,
 	rest_request<message>(this, API_PATH "/webhooks", std::to_string(wh.id), utility::url_encode(!wh.token.empty() ? wh.token: token) + "/messages/" + std::to_string(message_id) + parameters, m_get, "", callback);
 }
 
-void cluster::get_webhook_with_token(snowflake webhook_id, const std::string &token, command_completion_event_t callback) {
+void cluster::get_webhook_with_token(snowflake webhook_id, std::string_view token, command_completion_event_t callback) {
 	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(webhook_id), utility::url_encode(token), m_get, "", callback);
 }
 

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -107,40 +107,40 @@ async<confirmation_callback_t> cluster::co_guild_commands_get(snowflake guild_id
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_commands_get), guild_id };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_response_create(snowflake interaction_id, const std::string &token, const interaction_response &r) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const interaction_response &, command_completion_event_t)>(&cluster::interaction_response_create), interaction_id, token, r };
+async<confirmation_callback_t> cluster::co_interaction_response_create(snowflake interaction_id, std::string_view token, const interaction_response &r) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, const interaction_response &, command_completion_event_t)>(&cluster::interaction_response_create), interaction_id, token, r };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_response_edit(const std::string &token, const message &m) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_response_edit), token, m };
+async<confirmation_callback_t> cluster::co_interaction_response_edit(std::string_view token, const message &m) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_response_edit), token, m };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_response_get_original(const std::string &token) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_response_get_original), token };
+async<confirmation_callback_t> cluster::co_interaction_response_get_original(std::string_view token) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_response_get_original), token };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_create(const std::string &token, const message &m) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_create), token, m };
+async<confirmation_callback_t> cluster::co_interaction_followup_create(std::string_view token, const message &m) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_create), token, m };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_edit_original(const std::string &token, const message &m) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit_original), token, m };
+async<confirmation_callback_t> cluster::co_interaction_followup_edit_original(std::string_view token, const message &m) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit_original), token, m };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_delete(const std::string &token) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_followup_delete), token };
+async<confirmation_callback_t> cluster::co_interaction_followup_delete(std::string_view token) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_followup_delete), token };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_edit(const std::string &token, const message &m) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit), token, m };
+async<confirmation_callback_t> cluster::co_interaction_followup_edit(std::string_view token, const message &m) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit), token, m };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_get(const std::string &token, snowflake message_id) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, snowflake, command_completion_event_t)>(&cluster::interaction_followup_get), token, message_id };
+async<confirmation_callback_t> cluster::co_interaction_followup_get(std::string_view token, snowflake message_id) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, snowflake, command_completion_event_t)>(&cluster::interaction_followup_get), token, message_id };
 }
 
-async<confirmation_callback_t> cluster::co_interaction_followup_get_original(const std::string &token) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_followup_get_original), token };
+async<confirmation_callback_t> cluster::co_interaction_followup_get_original(std::string_view token) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_followup_get_original), token };
 }
 
 async<confirmation_callback_t> cluster::co_automod_rules_get(snowflake guild_id) {
@@ -219,8 +219,8 @@ async<confirmation_callback_t> cluster::co_channels_get(snowflake guild_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channels_get), guild_id };
 }
 
-async<confirmation_callback_t> cluster::co_channel_set_voice_status(snowflake channel_id, const std::string& status) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string&, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status };
+async<confirmation_callback_t> cluster::co_channel_set_voice_status(snowflake channel_id, std::string_view status) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status };
 }
 
 async<confirmation_callback_t> cluster::co_create_dm_channel(snowflake user_id) {
@@ -235,8 +235,8 @@ async<confirmation_callback_t> cluster::co_direct_message_create(snowflake user_
 	return async{ this, static_cast<void (cluster::*)(snowflake, const message &, command_completion_event_t)>(&cluster::direct_message_create), user_id, m };
 }
 
-async<confirmation_callback_t> cluster::co_gdm_add(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, const std::string &, command_completion_event_t)>(&cluster::gdm_add), channel_id, user_id, access_token, nick };
+async<confirmation_callback_t> cluster::co_gdm_add(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, std::string_view, command_completion_event_t)>(&cluster::gdm_add), channel_id, user_id, access_token, nick };
 }
 
 async<confirmation_callback_t> cluster::co_gdm_remove(snowflake channel_id, snowflake user_id) {
@@ -283,8 +283,8 @@ async<confirmation_callback_t> cluster::co_get_gateway_bot() {
 	return async{ this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::get_gateway_bot) };
 }
 
-async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string &nickname) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname };
+async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, std::string_view nickname) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname };
 }
 
 async<confirmation_callback_t> cluster::co_guild_auditlog_get(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit) {
@@ -359,8 +359,8 @@ async<confirmation_callback_t> cluster::co_guild_begin_prune(snowflake guild_id,
 	return async{ this, static_cast<void (cluster::*)(snowflake, const struct prune&, command_completion_event_t)>(&cluster::guild_begin_prune), guild_id, pruneinfo };
 }
 
-async<confirmation_callback_t> cluster::co_guild_set_nickname(snowflake guild_id, const std::string &nickname) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_set_nickname), guild_id, nickname };
+async<confirmation_callback_t> cluster::co_guild_set_nickname(snowflake guild_id, std::string_view nickname) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_set_nickname), guild_id, nickname };
 }
 
 async<confirmation_callback_t> cluster::co_guild_sync_integration(snowflake guild_id, snowflake integration_id) {
@@ -383,8 +383,8 @@ async<confirmation_callback_t> cluster::co_guild_edit_welcome_screen(snowflake g
 	return async{ this, static_cast<void (cluster::*)(snowflake, const struct welcome_screen&, bool, command_completion_event_t)>(&cluster::guild_edit_welcome_screen), guild_id, welcome_screen, enabled };
 }
 
-async<confirmation_callback_t> cluster::co_guild_add_member(const guild_member& gm, const std::string &access_token) {
-	return async{ this, static_cast<void (cluster::*)(const guild_member&, const std::string &, command_completion_event_t)>(&cluster::guild_add_member), gm, access_token };
+async<confirmation_callback_t> cluster::co_guild_add_member(const guild_member& gm, std::string_view access_token) {
+	return async{ this, static_cast<void (cluster::*)(const guild_member&, std::string_view, command_completion_event_t)>(&cluster::guild_add_member), gm, access_token };
 }
 
 async<confirmation_callback_t> cluster::co_guild_edit_member(const guild_member& gm) {
@@ -431,28 +431,28 @@ async<confirmation_callback_t> cluster::co_guild_member_move(const snowflake cha
 	return async{ this, static_cast<void (cluster::*)(const snowflake, const snowflake, const snowflake, command_completion_event_t)>(&cluster::guild_member_move), channel_id, guild_id, user_id };
 }
 
-async<confirmation_callback_t> cluster::co_guild_search_members(snowflake guild_id, const std::string& query, uint16_t limit) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string&, uint16_t, command_completion_event_t)>(&cluster::guild_search_members), guild_id, query, limit };
+async<confirmation_callback_t> cluster::co_guild_search_members(snowflake guild_id, std::string_view query, uint16_t limit) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, uint16_t, command_completion_event_t)>(&cluster::guild_search_members), guild_id, query, limit };
 }
 
 async<confirmation_callback_t> cluster::co_guild_get_invites(snowflake guild_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_get_invites), guild_id };
 }
 
-async<confirmation_callback_t> cluster::co_invite_delete(const std::string &invitecode) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::invite_delete), invitecode };
+async<confirmation_callback_t> cluster::co_invite_delete(std::string_view invitecode) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::invite_delete), invitecode };
 }
 
-async<confirmation_callback_t> cluster::co_invite_get(const std::string &invite_code) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::invite_get), invite_code };
+async<confirmation_callback_t> cluster::co_invite_get(std::string_view invite_code) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::invite_get), invite_code };
 }
 
-async<confirmation_callback_t> cluster::co_message_add_reaction(const struct message &m, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_add_reaction), m, reaction };
+async<confirmation_callback_t> cluster::co_message_add_reaction(const struct message &m, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_add_reaction), m, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_add_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_add_reaction), message_id, channel_id, reaction };
+async<confirmation_callback_t> cluster::co_message_add_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_add_reaction), message_id, channel_id, reaction };
 }
 
 async<confirmation_callback_t> cluster::co_message_create(const message &m) {
@@ -479,28 +479,28 @@ async<confirmation_callback_t> cluster::co_message_delete(snowflake message_id, 
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_delete), message_id, channel_id };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_own_reaction(const struct message &m, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_delete_own_reaction), m, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_own_reaction(const struct message &m, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_delete_own_reaction), m, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_own_reaction(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_own_reaction), message_id, channel_id, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_own_reaction(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_own_reaction), message_id, channel_id, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_reaction(const struct message &m, snowflake user_id, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(const struct message &, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction), m, user_id, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_reaction(const struct message &m, snowflake user_id, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(const struct message &, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction), m, user_id, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction), message_id, channel_id, user_id, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_reaction(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction), message_id, channel_id, user_id, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_reaction_emoji(const struct message &m, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), m, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_reaction_emoji(const struct message &m, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), m, reaction };
 }
 
-async<confirmation_callback_t> cluster::co_message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), message_id, channel_id, reaction };
+async<confirmation_callback_t> cluster::co_message_delete_reaction_emoji(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), message_id, channel_id, reaction };
 }
 
 async<confirmation_callback_t> cluster::co_message_edit(const message &m) {
@@ -515,12 +515,12 @@ async<confirmation_callback_t> cluster::co_message_get(snowflake message_id, sno
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_get), message_id, channel_id };
 }
 
-async<confirmation_callback_t> cluster::co_message_get_reactions(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit) {
-	return async{ this, static_cast<void (cluster::*)(const struct message &, const std::string &, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), m, reaction, before, after, limit };
+async<confirmation_callback_t> cluster::co_message_get_reactions(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit) {
+	return async{ this, static_cast<void (cluster::*)(const struct message &, std::string_view, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), m, reaction, before, after, limit };
 }
 
-async<confirmation_callback_t> cluster::co_message_get_reactions(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), message_id, channel_id, reaction, before, after, limit };
+async<confirmation_callback_t> cluster::co_message_get_reactions(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), message_id, channel_id, reaction, before, after, limit };
 }
 
 async<confirmation_callback_t> cluster::co_message_pin(snowflake channel_id, snowflake message_id) {
@@ -659,32 +659,32 @@ async<confirmation_callback_t> cluster::co_sticker_packs_get() {
 	return async{ this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::sticker_packs_get) };
 }
 
-async<confirmation_callback_t> cluster::co_guild_create_from_template(const std::string &code, const std::string &name) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_create_from_template), code, name };
+async<confirmation_callback_t> cluster::co_guild_create_from_template(std::string_view code, std::string_view name) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_create_from_template), code, name };
 }
 
-async<confirmation_callback_t> cluster::co_guild_template_create(snowflake guild_id, const std::string &name, const std::string &description) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_template_create), guild_id, name, description };
+async<confirmation_callback_t> cluster::co_guild_template_create(snowflake guild_id, std::string_view name, std::string_view description) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_template_create), guild_id, name, description };
 }
 
-async<confirmation_callback_t> cluster::co_guild_template_delete(snowflake guild_id, const std::string &code) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_template_delete), guild_id, code };
+async<confirmation_callback_t> cluster::co_guild_template_delete(snowflake guild_id, std::string_view code) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_template_delete), guild_id, code };
 }
 
-async<confirmation_callback_t> cluster::co_guild_template_modify(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_template_modify), guild_id, code, name, description };
+async<confirmation_callback_t> cluster::co_guild_template_modify(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_template_modify), guild_id, code, name, description };
 }
 
 async<confirmation_callback_t> cluster::co_guild_templates_get(snowflake guild_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_templates_get), guild_id };
 }
 
-async<confirmation_callback_t> cluster::co_guild_template_sync(snowflake guild_id, const std::string &code) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_template_sync), guild_id, code };
+async<confirmation_callback_t> cluster::co_guild_template_sync(snowflake guild_id, std::string_view code) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_template_sync), guild_id, code };
 }
 
-async<confirmation_callback_t> cluster::co_template_get(const std::string &code) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::template_get), code };
+async<confirmation_callback_t> cluster::co_template_get(std::string_view code) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::template_get), code };
 }
 
 async<confirmation_callback_t> cluster::co_current_user_join_thread(snowflake thread_id) {
@@ -719,20 +719,20 @@ async<confirmation_callback_t> cluster::co_thread_members_get(snowflake thread_i
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_members_get), thread_id };
 }
 
-async<confirmation_callback_t> cluster::co_thread_create_in_forum(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags) {
-	return async{ this, static_cast<void (cluster::*)(const std::string&, snowflake, const message&, auto_archive_duration_t, uint16_t, std::vector<snowflake>, command_completion_event_t)>(&cluster::thread_create_in_forum), thread_name, channel_id, msg, auto_archive_duration, rate_limit_per_user, applied_tags };
+async<confirmation_callback_t> cluster::co_thread_create_in_forum(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, snowflake, const message&, auto_archive_duration_t, uint16_t, std::vector<snowflake>, command_completion_event_t)>(&cluster::thread_create_in_forum), thread_name, channel_id, msg, auto_archive_duration, rate_limit_per_user, applied_tags };
 }
 
-async<confirmation_callback_t> cluster::co_thread_create(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user) {
-	return async{ this, static_cast<void (cluster::*)(const std::string&, snowflake, uint16_t, channel_type, bool, uint16_t, command_completion_event_t)>(&cluster::thread_create), thread_name, channel_id, auto_archive_duration, thread_type, invitable, rate_limit_per_user };
+async<confirmation_callback_t> cluster::co_thread_create(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, snowflake, uint16_t, channel_type, bool, uint16_t, command_completion_event_t)>(&cluster::thread_create), thread_name, channel_id, auto_archive_duration, thread_type, invitable, rate_limit_per_user };
 }
 
 async<confirmation_callback_t> cluster::co_thread_edit(const thread &t) {
 	return async{ this, static_cast<void (cluster::*)(const thread &, command_completion_event_t)>(&cluster::thread_edit), t };
 }
 
-async<confirmation_callback_t> cluster::co_thread_create_with_message(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user) {
-	return async{ this, static_cast<void (cluster::*)(const std::string&, snowflake, snowflake, uint16_t, uint16_t, command_completion_event_t)>(&cluster::thread_create_with_message), thread_name, channel_id, message_id, auto_archive_duration, rate_limit_per_user };
+async<confirmation_callback_t> cluster::co_thread_create_with_message(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, snowflake, snowflake, uint16_t, uint16_t, command_completion_event_t)>(&cluster::thread_create_with_message), thread_name, channel_id, message_id, auto_archive_duration, rate_limit_per_user };
 }
 
 async<confirmation_callback_t> cluster::co_thread_member_add(snowflake thread_id, snowflake user_id) {
@@ -747,8 +747,8 @@ async<confirmation_callback_t> cluster::co_thread_get(snowflake thread_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_get), thread_id };
 }
 
-async<confirmation_callback_t> cluster::co_current_user_edit(const std::string &nickname, const std::string& image_blob, const image_type type) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type };
+async<confirmation_callback_t> cluster::co_current_user_edit(std::string_view nickname, std::string_view image_blob, const image_type type) {
+	return async{ this, static_cast<void (cluster::*)(std::string_view, std::string_view, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type };
 }
 
 async<confirmation_callback_t> cluster::co_current_application_get() {
@@ -807,8 +807,8 @@ async<confirmation_callback_t> cluster::co_delete_webhook_message(const class we
 	return async{ this, static_cast<void (cluster::*)(const class webhook &, snowflake, snowflake, command_completion_event_t)>(&cluster::delete_webhook_message), wh, message_id, thread_id };
 }
 
-async<confirmation_callback_t> cluster::co_delete_webhook_with_token(snowflake webhook_id, const std::string &token) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::delete_webhook_with_token), webhook_id, token };
+async<confirmation_callback_t> cluster::co_delete_webhook_with_token(snowflake webhook_id, std::string_view token) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::delete_webhook_with_token), webhook_id, token };
 }
 
 async<confirmation_callback_t> cluster::co_edit_webhook(const class webhook& wh) {
@@ -823,8 +823,8 @@ async<confirmation_callback_t> cluster::co_edit_webhook_with_token(const class w
 	return async{ this, static_cast<void (cluster::*)(const class webhook&, command_completion_event_t)>(&cluster::edit_webhook_with_token), wh };
 }
 
-async<confirmation_callback_t> cluster::co_execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, const std::string& thread_name) {
-	return async{ this, static_cast<void (cluster::*)(const class webhook &, const struct message&, bool, snowflake, const std::string&, command_completion_event_t)>(&cluster::execute_webhook), wh, m, wait, thread_id, thread_name };
+async<confirmation_callback_t> cluster::co_execute_webhook(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, std::string_view thread_name) {
+	return async{ this, static_cast<void (cluster::*)(const class webhook &, const struct message&, bool, snowflake, std::string_view, command_completion_event_t)>(&cluster::execute_webhook), wh, m, wait, thread_id, thread_name };
 }
 
 async<confirmation_callback_t> cluster::co_get_channel_webhooks(snowflake channel_id) {
@@ -843,8 +843,8 @@ async<confirmation_callback_t> cluster::co_get_webhook_message(const class webho
 	return async{ this, static_cast<void (cluster::*)(const class webhook &, snowflake, snowflake, command_completion_event_t)>(&cluster::get_webhook_message), wh, message_id, thread_id };
 }
 
-async<confirmation_callback_t> cluster::co_get_webhook_with_token(snowflake webhook_id, const std::string &token) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::get_webhook_with_token), webhook_id, token };
+async<confirmation_callback_t> cluster::co_get_webhook_with_token(snowflake webhook_id, std::string_view token) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::get_webhook_with_token), webhook_id, token };
 }
 
 

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -105,40 +105,40 @@ slashcommand_map cluster::guild_commands_get_sync(snowflake guild_id) {
 	return dpp::sync<slashcommand_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_commands_get), guild_id);
 }
 
-confirmation cluster::interaction_response_create_sync(snowflake interaction_id, const std::string &token, const interaction_response &r) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string &, const interaction_response &, command_completion_event_t)>(&cluster::interaction_response_create), interaction_id, token, r);
+confirmation cluster::interaction_response_create_sync(snowflake interaction_id, std::string_view token, const interaction_response &r) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, const interaction_response &, command_completion_event_t)>(&cluster::interaction_response_create), interaction_id, token, r);
 }
 
-confirmation cluster::interaction_response_edit_sync(const std::string &token, const message &m) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_response_edit), token, m);
+confirmation cluster::interaction_response_edit_sync(std::string_view token, const message &m) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_response_edit), token, m);
 }
 
-message cluster::interaction_response_get_original_sync(const std::string &token) {
-	return dpp::sync<message>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_response_get_original), token);
+message cluster::interaction_response_get_original_sync(std::string_view token) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_response_get_original), token);
 }
 
-confirmation cluster::interaction_followup_create_sync(const std::string &token, const message &m) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_create), token, m);
+confirmation cluster::interaction_followup_create_sync(std::string_view token, const message &m) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_create), token, m);
 }
 
-confirmation cluster::interaction_followup_edit_original_sync(const std::string &token, const message &m) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit_original), token, m);
+confirmation cluster::interaction_followup_edit_original_sync(std::string_view token, const message &m) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit_original), token, m);
 }
 
-confirmation cluster::interaction_followup_delete_sync(const std::string &token) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_followup_delete), token);
+confirmation cluster::interaction_followup_delete_sync(std::string_view token) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_followup_delete), token);
 }
 
-confirmation cluster::interaction_followup_edit_sync(const std::string &token, const message &m) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const std::string &, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit), token, m);
+confirmation cluster::interaction_followup_edit_sync(std::string_view token, const message &m) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(std::string_view, const message &, command_completion_event_t)>(&cluster::interaction_followup_edit), token, m);
 }
 
-message cluster::interaction_followup_get_sync(const std::string &token, snowflake message_id) {
-	return dpp::sync<message>(this, static_cast<void (cluster::*)(const std::string &, snowflake, command_completion_event_t)>(&cluster::interaction_followup_get), token, message_id);
+message cluster::interaction_followup_get_sync(std::string_view token, snowflake message_id) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(std::string_view, snowflake, command_completion_event_t)>(&cluster::interaction_followup_get), token, message_id);
 }
 
-message cluster::interaction_followup_get_original_sync(const std::string &token) {
-	return dpp::sync<message>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::interaction_followup_get_original), token);
+message cluster::interaction_followup_get_original_sync(std::string_view token) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::interaction_followup_get_original), token);
 }
 
 automod_rule_map cluster::automod_rules_get_sync(snowflake guild_id) {
@@ -217,8 +217,8 @@ channel_map cluster::channels_get_sync(snowflake guild_id) {
 	return dpp::sync<channel_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channels_get), guild_id);
 }
 
-confirmation cluster::channel_set_voice_status_sync(snowflake channel_id, const std::string& status) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string&, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status);
+confirmation cluster::channel_set_voice_status_sync(snowflake channel_id, std::string_view status) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::channel_set_voice_status), channel_id, status);
 }
 
 channel cluster::create_dm_channel_sync(snowflake user_id) {
@@ -233,8 +233,8 @@ message cluster::direct_message_create_sync(snowflake user_id, const message &m)
 	return dpp::sync<message>(this, static_cast<void (cluster::*)(snowflake, const message &, command_completion_event_t)>(&cluster::direct_message_create), user_id, m);
 }
 
-confirmation cluster::gdm_add_sync(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, const std::string &, command_completion_event_t)>(&cluster::gdm_add), channel_id, user_id, access_token, nick);
+confirmation cluster::gdm_add_sync(snowflake channel_id, snowflake user_id, std::string_view access_token, std::string_view nick) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, std::string_view, command_completion_event_t)>(&cluster::gdm_add), channel_id, user_id, access_token, nick);
 }
 
 confirmation cluster::gdm_remove_sync(snowflake channel_id, snowflake user_id) {
@@ -281,8 +281,8 @@ gateway cluster::get_gateway_bot_sync() {
 	return dpp::sync<gateway>(this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::get_gateway_bot));
 }
 
-confirmation cluster::guild_current_member_edit_sync(snowflake guild_id, const std::string &nickname) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname);
+confirmation cluster::guild_current_member_edit_sync(snowflake guild_id, std::string_view nickname) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname);
 }
 
 auditlog cluster::guild_auditlog_get_sync(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit) {
@@ -357,8 +357,8 @@ prune cluster::guild_begin_prune_sync(snowflake guild_id, const struct prune& pr
 	return dpp::sync<prune>(this, static_cast<void (cluster::*)(snowflake, const struct prune&, command_completion_event_t)>(&cluster::guild_begin_prune), guild_id, pruneinfo);
 }
 
-confirmation cluster::guild_set_nickname_sync(snowflake guild_id, const std::string &nickname) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_set_nickname), guild_id, nickname);
+confirmation cluster::guild_set_nickname_sync(snowflake guild_id, std::string_view nickname) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_set_nickname), guild_id, nickname);
 }
 
 confirmation cluster::guild_sync_integration_sync(snowflake guild_id, snowflake integration_id) {
@@ -381,8 +381,8 @@ dpp::welcome_screen cluster::guild_edit_welcome_screen_sync(snowflake guild_id, 
 	return dpp::sync<dpp::welcome_screen>(this, static_cast<void (cluster::*)(snowflake, const struct welcome_screen&, bool, command_completion_event_t)>(&cluster::guild_edit_welcome_screen), guild_id, welcome_screen, enabled);
 }
 
-confirmation cluster::guild_add_member_sync(const guild_member& gm, const std::string &access_token) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const guild_member&, const std::string &, command_completion_event_t)>(&cluster::guild_add_member), gm, access_token);
+confirmation cluster::guild_add_member_sync(const guild_member& gm, std::string_view access_token) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const guild_member&, std::string_view, command_completion_event_t)>(&cluster::guild_add_member), gm, access_token);
 }
 
 guild_member cluster::guild_edit_member_sync(const guild_member& gm) {
@@ -429,28 +429,28 @@ guild_member cluster::guild_member_move_sync(const snowflake channel_id, const s
 	return dpp::sync<guild_member>(this, static_cast<void (cluster::*)(const snowflake, const snowflake, const snowflake, command_completion_event_t)>(&cluster::guild_member_move), channel_id, guild_id, user_id);
 }
 
-guild_member_map cluster::guild_search_members_sync(snowflake guild_id, const std::string& query, uint16_t limit) {
-	return dpp::sync<guild_member_map>(this, static_cast<void (cluster::*)(snowflake, const std::string&, uint16_t, command_completion_event_t)>(&cluster::guild_search_members), guild_id, query, limit);
+guild_member_map cluster::guild_search_members_sync(snowflake guild_id, std::string_view query, uint16_t limit) {
+	return dpp::sync<guild_member_map>(this, static_cast<void (cluster::*)(snowflake, std::string_view, uint16_t, command_completion_event_t)>(&cluster::guild_search_members), guild_id, query, limit);
 }
 
 invite_map cluster::guild_get_invites_sync(snowflake guild_id) {
 	return dpp::sync<invite_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_get_invites), guild_id);
 }
 
-invite cluster::invite_delete_sync(const std::string &invitecode) {
-	return dpp::sync<invite>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::invite_delete), invitecode);
+invite cluster::invite_delete_sync(std::string_view invitecode) {
+	return dpp::sync<invite>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::invite_delete), invitecode);
 }
 
-invite cluster::invite_get_sync(const std::string &invite_code) {
-	return dpp::sync<invite>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::invite_get), invite_code);
+invite cluster::invite_get_sync(std::string_view invite_code) {
+	return dpp::sync<invite>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::invite_get), invite_code);
 }
 
-confirmation cluster::message_add_reaction_sync(const struct message &m, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_add_reaction), m, reaction);
+confirmation cluster::message_add_reaction_sync(const struct message &m, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_add_reaction), m, reaction);
 }
 
-confirmation cluster::message_add_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_add_reaction), message_id, channel_id, reaction);
+confirmation cluster::message_add_reaction_sync(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_add_reaction), message_id, channel_id, reaction);
 }
 
 message cluster::message_create_sync(const message &m) {
@@ -477,28 +477,28 @@ confirmation cluster::message_delete_sync(snowflake message_id, snowflake channe
 	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_delete), message_id, channel_id);
 }
 
-confirmation cluster::message_delete_own_reaction_sync(const struct message &m, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_delete_own_reaction), m, reaction);
+confirmation cluster::message_delete_own_reaction_sync(const struct message &m, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_delete_own_reaction), m, reaction);
 }
 
-confirmation cluster::message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_own_reaction), message_id, channel_id, reaction);
+confirmation cluster::message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_own_reaction), message_id, channel_id, reaction);
 }
 
-confirmation cluster::message_delete_reaction_sync(const struct message &m, snowflake user_id, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction), m, user_id, reaction);
+confirmation cluster::message_delete_reaction_sync(const struct message &m, snowflake user_id, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction), m, user_id, reaction);
 }
 
-confirmation cluster::message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction), message_id, channel_id, user_id, reaction);
+confirmation cluster::message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction), message_id, channel_id, user_id, reaction);
 }
 
-confirmation cluster::message_delete_reaction_emoji_sync(const struct message &m, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), m, reaction);
+confirmation cluster::message_delete_reaction_emoji_sync(const struct message &m, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const struct message &, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), m, reaction);
 }
 
-confirmation cluster::message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, const std::string &reaction) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), message_id, channel_id, reaction);
+confirmation cluster::message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, std::string_view reaction) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, command_completion_event_t)>(&cluster::message_delete_reaction_emoji), message_id, channel_id, reaction);
 }
 
 message cluster::message_edit_sync(const message &m) {
@@ -513,12 +513,12 @@ message cluster::message_get_sync(snowflake message_id, snowflake channel_id) {
 	return dpp::sync<message>(this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_get), message_id, channel_id);
 }
 
-user_map cluster::message_get_reactions_sync(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit) {
-	return dpp::sync<user_map>(this, static_cast<void (cluster::*)(const struct message &, const std::string &, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), m, reaction, before, after, limit);
+user_map cluster::message_get_reactions_sync(const struct message &m, std::string_view reaction, snowflake before, snowflake after, snowflake limit) {
+	return dpp::sync<user_map>(this, static_cast<void (cluster::*)(const struct message &, std::string_view, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), m, reaction, before, after, limit);
 }
 
-emoji_map cluster::message_get_reactions_sync(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit) {
-	return dpp::sync<emoji_map>(this, static_cast<void (cluster::*)(snowflake, snowflake, const std::string &, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), message_id, channel_id, reaction, before, after, limit);
+emoji_map cluster::message_get_reactions_sync(snowflake message_id, snowflake channel_id, std::string_view reaction, snowflake before, snowflake after, snowflake limit) {
+	return dpp::sync<emoji_map>(this, static_cast<void (cluster::*)(snowflake, snowflake, std::string_view, snowflake, snowflake, snowflake, command_completion_event_t)>(&cluster::message_get_reactions), message_id, channel_id, reaction, before, after, limit);
 }
 
 confirmation cluster::message_pin_sync(snowflake channel_id, snowflake message_id) {
@@ -657,32 +657,32 @@ sticker_pack_map cluster::sticker_packs_get_sync() {
 	return dpp::sync<sticker_pack_map>(this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::sticker_packs_get));
 }
 
-guild cluster::guild_create_from_template_sync(const std::string &code, const std::string &name) {
-	return dpp::sync<guild>(this, static_cast<void (cluster::*)(const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_create_from_template), code, name);
+guild cluster::guild_create_from_template_sync(std::string_view code, std::string_view name) {
+	return dpp::sync<guild>(this, static_cast<void (cluster::*)(std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_create_from_template), code, name);
 }
 
-dtemplate cluster::guild_template_create_sync(snowflake guild_id, const std::string &name, const std::string &description) {
-	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_template_create), guild_id, name, description);
+dtemplate cluster::guild_template_create_sync(snowflake guild_id, std::string_view name, std::string_view description) {
+	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_template_create), guild_id, name, description);
 }
 
-confirmation cluster::guild_template_delete_sync(snowflake guild_id, const std::string &code) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_template_delete), guild_id, code);
+confirmation cluster::guild_template_delete_sync(snowflake guild_id, std::string_view code) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_template_delete), guild_id, code);
 }
 
-dtemplate cluster::guild_template_modify_sync(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description) {
-	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string &, const std::string &, command_completion_event_t)>(&cluster::guild_template_modify), guild_id, code, name, description);
+dtemplate cluster::guild_template_modify_sync(snowflake guild_id, std::string_view code, std::string_view name, std::string_view description) {
+	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, std::string_view, std::string_view, std::string_view, command_completion_event_t)>(&cluster::guild_template_modify), guild_id, code, name, description);
 }
 
 dtemplate_map cluster::guild_templates_get_sync(snowflake guild_id) {
 	return dpp::sync<dtemplate_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::guild_templates_get), guild_id);
 }
 
-dtemplate cluster::guild_template_sync_sync(snowflake guild_id, const std::string &code) {
-	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_template_sync), guild_id, code);
+dtemplate cluster::guild_template_sync_sync(snowflake guild_id, std::string_view code) {
+	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::guild_template_sync), guild_id, code);
 }
 
-dtemplate cluster::template_get_sync(const std::string &code) {
-	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(const std::string &, command_completion_event_t)>(&cluster::template_get), code);
+dtemplate cluster::template_get_sync(std::string_view code) {
+	return dpp::sync<dtemplate>(this, static_cast<void (cluster::*)(std::string_view, command_completion_event_t)>(&cluster::template_get), code);
 }
 
 confirmation cluster::current_user_join_thread_sync(snowflake thread_id) {
@@ -717,20 +717,20 @@ thread_member_map cluster::thread_members_get_sync(snowflake thread_id) {
 	return dpp::sync<thread_member_map>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_members_get), thread_id);
 }
 
-thread cluster::thread_create_in_forum_sync(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags) {
-	return dpp::sync<thread>(this, static_cast<void (cluster::*)(const std::string&, snowflake, const message&, auto_archive_duration_t, uint16_t, std::vector<snowflake>, command_completion_event_t)>(&cluster::thread_create_in_forum), thread_name, channel_id, msg, auto_archive_duration, rate_limit_per_user, applied_tags);
+thread cluster::thread_create_in_forum_sync(std::string_view thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags) {
+	return dpp::sync<thread>(this, static_cast<void (cluster::*)(std::string_view, snowflake, const message&, auto_archive_duration_t, uint16_t, std::vector<snowflake>, command_completion_event_t)>(&cluster::thread_create_in_forum), thread_name, channel_id, msg, auto_archive_duration, rate_limit_per_user, applied_tags);
 }
 
-thread cluster::thread_create_sync(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user) {
-	return dpp::sync<thread>(this, static_cast<void (cluster::*)(const std::string&, snowflake, uint16_t, channel_type, bool, uint16_t, command_completion_event_t)>(&cluster::thread_create), thread_name, channel_id, auto_archive_duration, thread_type, invitable, rate_limit_per_user);
+thread cluster::thread_create_sync(std::string_view thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user) {
+	return dpp::sync<thread>(this, static_cast<void (cluster::*)(std::string_view, snowflake, uint16_t, channel_type, bool, uint16_t, command_completion_event_t)>(&cluster::thread_create), thread_name, channel_id, auto_archive_duration, thread_type, invitable, rate_limit_per_user);
 }
 
 thread cluster::thread_edit_sync(const thread &t) {
 	return dpp::sync<thread>(this, static_cast<void (cluster::*)(const thread &, command_completion_event_t)>(&cluster::thread_edit), t);
 }
 
-thread cluster::thread_create_with_message_sync(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user) {
-	return dpp::sync<thread>(this, static_cast<void (cluster::*)(const std::string&, snowflake, snowflake, uint16_t, uint16_t, command_completion_event_t)>(&cluster::thread_create_with_message), thread_name, channel_id, message_id, auto_archive_duration, rate_limit_per_user);
+thread cluster::thread_create_with_message_sync(std::string_view thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user) {
+	return dpp::sync<thread>(this, static_cast<void (cluster::*)(std::string_view, snowflake, snowflake, uint16_t, uint16_t, command_completion_event_t)>(&cluster::thread_create_with_message), thread_name, channel_id, message_id, auto_archive_duration, rate_limit_per_user);
 }
 
 confirmation cluster::thread_member_add_sync(snowflake thread_id, snowflake user_id) {
@@ -745,8 +745,8 @@ thread cluster::thread_get_sync(snowflake thread_id) {
 	return dpp::sync<thread>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_get), thread_id);
 }
 
-user cluster::current_user_edit_sync(const std::string &nickname, const std::string& image_blob, const image_type type) {
-	return dpp::sync<user>(this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type);
+user cluster::current_user_edit_sync(std::string_view nickname, std::string_view image_blob, const image_type type) {
+	return dpp::sync<user>(this, static_cast<void (cluster::*)(std::string_view, std::string_view, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type);
 }
 
 application cluster::current_application_get_sync() {
@@ -805,8 +805,8 @@ confirmation cluster::delete_webhook_message_sync(const class webhook &wh, snowf
 	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(const class webhook &, snowflake, snowflake, command_completion_event_t)>(&cluster::delete_webhook_message), wh, message_id, thread_id);
 }
 
-confirmation cluster::delete_webhook_with_token_sync(snowflake webhook_id, const std::string &token) {
-	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::delete_webhook_with_token), webhook_id, token);
+confirmation cluster::delete_webhook_with_token_sync(snowflake webhook_id, std::string_view token) {
+	return dpp::sync<confirmation>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::delete_webhook_with_token), webhook_id, token);
 }
 
 webhook cluster::edit_webhook_sync(const class webhook& wh) {
@@ -821,8 +821,8 @@ webhook cluster::edit_webhook_with_token_sync(const class webhook& wh) {
 	return dpp::sync<webhook>(this, static_cast<void (cluster::*)(const class webhook&, command_completion_event_t)>(&cluster::edit_webhook_with_token), wh);
 }
 
-message cluster::execute_webhook_sync(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, const std::string& thread_name) {
-	return dpp::sync<message>(this, static_cast<void (cluster::*)(const class webhook &, const struct message&, bool, snowflake, const std::string&, command_completion_event_t)>(&cluster::execute_webhook), wh, m, wait, thread_id, thread_name);
+message cluster::execute_webhook_sync(const class webhook &wh, const struct message& m, bool wait, snowflake thread_id, std::string_view thread_name) {
+	return dpp::sync<message>(this, static_cast<void (cluster::*)(const class webhook &, const struct message&, bool, snowflake, std::string_view, command_completion_event_t)>(&cluster::execute_webhook), wh, m, wait, thread_id, thread_name);
 }
 
 webhook_map cluster::get_channel_webhooks_sync(snowflake channel_id) {
@@ -841,8 +841,8 @@ message cluster::get_webhook_message_sync(const class webhook &wh, snowflake mes
 	return dpp::sync<message>(this, static_cast<void (cluster::*)(const class webhook &, snowflake, snowflake, command_completion_event_t)>(&cluster::get_webhook_message), wh, message_id, thread_id);
 }
 
-webhook cluster::get_webhook_with_token_sync(snowflake webhook_id, const std::string &token) {
-	return dpp::sync<webhook>(this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::get_webhook_with_token), webhook_id, token);
+webhook cluster::get_webhook_with_token_sync(snowflake webhook_id, std::string_view token) {
+	return dpp::sync<webhook>(this, static_cast<void (cluster::*)(snowflake, std::string_view, command_completion_event_t)>(&cluster::get_webhook_with_token), webhook_id, token);
 }
 
 

--- a/src/dpp/commandhandler.cpp
+++ b/src/dpp/commandhandler.cpp
@@ -27,7 +27,7 @@
 
 namespace dpp {
 
-param_info::param_info(parameter_type t, bool o, const std::string &d, const std::map<command_value, std::string> &opts) : type(t), optional(o), description(d), choices(opts)
+param_info::param_info(parameter_type t, bool o, std::string_view d, const std::map<command_value, std::string> &opts) : type(t), optional(o), description(d), choices(opts)
 {
 }
 
@@ -71,7 +71,7 @@ commandhandler::~commandhandler()
 	}
 }
 
-commandhandler& commandhandler::add_prefix(const std::string &prefix)
+commandhandler& commandhandler::add_prefix(std::string_view prefix)
 {
 	prefixes.emplace_back(prefix);
 	if (prefix == "/") {
@@ -81,13 +81,15 @@ commandhandler& commandhandler::add_prefix(const std::string &prefix)
 	return *this;
 }
 
-commandhandler& commandhandler::add_command(const std::string &command, const parameter_registration_t &parameters, command_handler handler, const std::string &description, snowflake guild_id)
+commandhandler& commandhandler::add_command(std::string_view command, const parameter_registration_t &parameters, command_handler handler, std::string_view description, snowflake guild_id)
 {
 	command_info_t i;
 	i.func = std::move(handler);
 	i.guild_id = guild_id;
 	i.parameters = parameters;
-	commands[lowercase(command)] = i;
+
+    std::string command_lower = lowercase(command);
+    commands[command_lower] = i;
 	if (slash_commands_enabled) {
 		if (this->app_id.empty()) {
 			if (owner->me.id.empty()) {
@@ -98,7 +100,7 @@ commandhandler& commandhandler::add_command(const std::string &command, const pa
 		}
 		dpp::slashcommand newcommand;
 		/* Create a new global command on ready event */
-		newcommand.set_name(lowercase(command)).set_description(description).set_application_id(this->app_id);
+        newcommand.set_name(command_lower).set_description(description).set_application_id(this->app_id);
 
 		for (auto& parameter : parameters) {
 			command_option_type cot = co_string;

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -422,9 +422,10 @@ static const std::map<std::string, dpp::events::event*> event_map = {
 	{ "ENTITLEMENT_DELETE", make_static_event<dpp::events::entitlement_delete>() },
 };
 
-void discord_client::handle_event(const std::string &event, json &j, const std::string &raw)
+void discord_client::handle_event(std::string_view event, json &j, std::string_view raw)
 {
-	auto ev_iter = event_map.find(event);
+    std::string event_str(event);
+    auto ev_iter = event_map.find(event_str);
 	if (ev_iter != event_map.end()) {
 		/* A handler with nullptr is silently ignored. We don't plan to make a handler for it
 		 * so this usually some user-only thing that's crept into the API and shown to bots
@@ -434,7 +435,7 @@ void discord_client::handle_event(const std::string &event, json &j, const std::
 			ev_iter->second->handle(this, j, raw);
 		}
 	} else {
-		log(dpp::ll_debug, "Unhandled event: " + event + ", " + j.dump(-1, ' ', false, json::error_handler_t::replace));
+        log(dpp::ll_debug, "Unhandled event: " + event_str + ", " + j.dump(-1, ' ', false, json::error_handler_t::replace));
 	}
 }
 

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -31,9 +31,7 @@
 
 namespace dpp {
 
-event_dispatch_t::event_dispatch_t(discord_client* client, const std::string& raw) : raw_event(raw), from(client) {}
-
-event_dispatch_t::event_dispatch_t(discord_client* client, std::string&& raw) : raw_event(std::move(raw)), from(client) {}
+event_dispatch_t::event_dispatch_t(discord_client* client, std::string_view raw) : raw_event(raw), from(client) {}
 
 const event_dispatch_t& event_dispatch_t::cancel_event() const {
 	cancelled = true;
@@ -68,7 +66,7 @@ user_context_menu_t& user_context_menu_t::set_user(const user& u) {
 }
 
 
-void message_create_t::send(const std::string& m, command_completion_event_t callback) const {
+void message_create_t::send(std::string_view m, command_completion_event_t callback) const {
 	this->send(dpp::message(m), std::move(callback));
 }
 
@@ -81,7 +79,7 @@ void message_create_t::send(message&& msg, command_completion_event_t callback) 
 	this->from->creator->message_create(std::move(msg), std::move(callback));
 }
 
-void message_create_t::reply(const std::string& m, bool mention_replied_user, command_completion_event_t callback) const {
+void message_create_t::reply(std::string_view m, bool mention_replied_user, command_completion_event_t callback) const {
 	this->reply(dpp::message{m}, mention_replied_user, std::move(callback));
 }
 
@@ -137,11 +135,11 @@ void interaction_create_t::dialog(const interaction_modal_response& mr, command_
 	from->creator->interaction_response_create(this->command.id, this->command.token, mr, std::move(callback));
 }
 
-void interaction_create_t::reply(interaction_response_type t, const std::string& mt, command_completion_event_t callback) const {
+void interaction_create_t::reply(interaction_response_type t, std::string_view mt, command_completion_event_t callback) const {
 	this->reply(t, dpp::message(this->command.channel_id, mt, mt_application_command), std::move(callback));
 }
 
-void interaction_create_t::reply(const std::string& mt, command_completion_event_t callback) const {
+void interaction_create_t::reply(std::string_view mt, command_completion_event_t callback) const {
 	this->reply(ir_channel_message_with_source, dpp::message(this->command.channel_id, mt, mt_application_command), callback);
 }
 
@@ -149,7 +147,7 @@ void interaction_create_t::edit_response(const message& m, command_completion_ev
 	from->creator->interaction_response_edit(this->command.token, m, std::move(callback));
 }
 
-void interaction_create_t::edit_response(const std::string& mt, command_completion_event_t callback) const {
+void interaction_create_t::edit_response(std::string_view mt, command_completion_event_t callback) const {
 	this->edit_response(dpp::message(this->command.channel_id, mt, mt_application_command), std::move(callback));
 }
 
@@ -197,7 +195,7 @@ async<confirmation_callback_t> interaction_create_t::co_reply(interaction_respon
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(t, m, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, const std::string& mt) const {
+async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, std::string_view mt) const {
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(t, mt, std::forward<T>(cb)); }};
 }
 
@@ -205,7 +203,7 @@ async<confirmation_callback_t> interaction_create_t::co_reply(const message& m) 
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(m, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(const std::string& mt) const {
+async<confirmation_callback_t> interaction_create_t::co_reply(std::string_view mt) const {
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
 }
 
@@ -217,7 +215,7 @@ async<confirmation_callback_t> interaction_create_t::co_edit_response(const mess
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->edit_response(m, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_edit_response(const std::string& mt) const {
+async<confirmation_callback_t> interaction_create_t::co_edit_response(std::string_view mt) const {
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->edit_response(mt, std::forward<T>(cb)); }};
 }
 
@@ -238,7 +236,7 @@ async<confirmation_callback_t> interaction_create_t::co_delete_original_response
 }
 #endif /* DPP_CORO */
 
-command_value interaction_create_t::get_parameter(const std::string& name) const {
+command_value interaction_create_t::get_parameter(std::string_view name) const {
 	const command_interaction ci = command.get_command_interaction();
 
 	for (const auto &option : ci.options) {
@@ -267,11 +265,7 @@ command_value interaction_create_t::get_parameter(const std::string& name) const
 	return {};
 }
 
-voice_receive_t::voice_receive_t(discord_client* client, const std::string& raw, discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length) : event_dispatch_t(client, raw), voice_client(vc), user_id(_user_id) {
-	reassign(vc, _user_id, pcm, length);
-}
-
-voice_receive_t::voice_receive_t(discord_client* client, std::string&& raw, discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length) : event_dispatch_t(client, std::move(raw)), voice_client(vc), user_id(_user_id) {
+voice_receive_t::voice_receive_t(discord_client* client, std::string_view raw, discord_voice_client* vc, snowflake _user_id, const uint8_t* pcm, size_t length) : event_dispatch_t(client, raw), voice_client(vc), user_id(_user_id) {
 	reassign(vc, _user_id, pcm, length);
 }
 

--- a/src/dpp/emoji.cpp
+++ b/src/dpp/emoji.cpp
@@ -28,7 +28,7 @@ namespace dpp {
 
 using json = nlohmann::json;
 
-emoji::emoji(const std::string_view n, const snowflake i, const uint8_t f) : managed(i), name(n), flags(f) {}
+emoji::emoji(std::string_view n, const snowflake i, const uint8_t f) : managed(i), name(n), flags(f) {}
 
 std::string emoji::get_mention(std::string_view name, snowflake id, bool is_animated) {
 	return utility::emoji_mention(name,id,is_animated);

--- a/src/dpp/etf.cpp
+++ b/src/dpp/etf.cpp
@@ -630,7 +630,7 @@ json etf_parser::inner_parse() {
 	}
 }
 
-json etf_parser::parse(const std::string& in) {
+json etf_parser::parse(std::string_view in) {
 	/* Recursively decode multiple values from ETF to JSON */
 	offset = 0;
 	size = in.size();

--- a/src/dpp/events/automod_rule_create.cpp
+++ b/src/dpp/events/automod_rule_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void automod_rule_create::handle(discord_client* client, json &j, const std::string &raw) {
+void automod_rule_create::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_automod_rule_create.empty()) {
 		json& d = j["d"];
 		automod_rule_create_t arc(client, raw);

--- a/src/dpp/events/automod_rule_delete.cpp
+++ b/src/dpp/events/automod_rule_delete.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void automod_rule_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void automod_rule_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_automod_rule_create.empty()) {
 		json& d = j["d"];
 		automod_rule_delete_t ard(client, raw);

--- a/src/dpp/events/automod_rule_execute.cpp
+++ b/src/dpp/events/automod_rule_execute.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void automod_rule_execute::handle(discord_client* client, json &j, const std::string &raw) {
+void automod_rule_execute::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_automod_rule_execute.empty()) {
 		json& d = j["d"];
 		automod_rule_execute_t are(client, raw);

--- a/src/dpp/events/automod_rule_update.cpp
+++ b/src/dpp/events/automod_rule_update.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void automod_rule_update::handle(discord_client* client, json &j, const std::string &raw) {
+void automod_rule_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_automod_rule_update.empty()) {
 		json& d = j["d"];
 		automod_rule_update_t aru(client, raw);

--- a/src/dpp/events/channel_create.cpp
+++ b/src/dpp/events/channel_create.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void channel_create::handle(discord_client* client, json &j, const std::string &raw) {
+void channel_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::channel newchannel;
 	dpp::channel* c = nullptr;

--- a/src/dpp/events/channel_delete.cpp
+++ b/src/dpp/events/channel_delete.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void channel_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void channel_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	const channel c = channel().fill_from_json(&d);
 	guild* g = find_guild(c.guild_id);

--- a/src/dpp/events/channel_pins_update.cpp
+++ b/src/dpp/events/channel_pins_update.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void channel_pins_update::handle(discord_client* client, json &j, const std::string &raw) {
+void channel_pins_update::handle(discord_client* client, json &j, std::string_view raw) {
 
 	if (!client->creator->on_channel_pins_update.empty()) {
 		json& d = j["d"];

--- a/src/dpp/events/channel_update.cpp
+++ b/src/dpp/events/channel_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void channel_update::handle(discord_client* client, json &j, const std::string &raw) {
+void channel_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	channel newchannel;
 	channel* c = nullptr;

--- a/src/dpp/events/entitlement_create.cpp
+++ b/src/dpp/events/entitlement_create.cpp
@@ -32,7 +32,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void entitlement_create::handle(discord_client* client, json &j, const std::string &raw) {
+void entitlement_create::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_entitlement_create.empty()) {
 		dpp::entitlement ent;
 		json& d = j["d"];

--- a/src/dpp/events/entitlement_delete.cpp
+++ b/src/dpp/events/entitlement_delete.cpp
@@ -32,7 +32,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void entitlement_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void entitlement_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_entitlement_delete.empty()) {
 		dpp::entitlement ent;
 		json& d = j["d"];

--- a/src/dpp/events/entitlement_update.cpp
+++ b/src/dpp/events/entitlement_update.cpp
@@ -32,7 +32,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void entitlement_update::handle(discord_client* client, json &j, const std::string &raw) {
+void entitlement_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_entitlement_update.empty()) {
 		dpp::entitlement ent;
 		json& d = j["d"];

--- a/src/dpp/events/guild_audit_log_entry_create.cpp
+++ b/src/dpp/events/guild_audit_log_entry_create.cpp
@@ -32,7 +32,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_audit_log_entry_create::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_audit_log_entry_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_audit_log_entry_create.empty()) {
 		dpp::guild_audit_log_entry_create_t ec(client, raw);

--- a/src/dpp/events/guild_ban_add.cpp
+++ b/src/dpp/events/guild_ban_add.cpp
@@ -38,7 +38,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_ban_add::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_ban_add::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_guild_ban_add.empty()) {
 		json &d = j["d"];
 		dpp::guild_ban_add_t gba(client, raw);

--- a/src/dpp/events/guild_ban_remove.cpp
+++ b/src/dpp/events/guild_ban_remove.cpp
@@ -38,7 +38,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_ban_remove::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_ban_remove::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_guild_ban_remove.empty()) {
 		json &d = j["d"];
 		dpp::guild_ban_remove_t gbr(client, raw);

--- a/src/dpp/events/guild_create.cpp
+++ b/src/dpp/events/guild_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_create::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::guild newguild;
 	dpp::guild* g = nullptr;

--- a/src/dpp/events/guild_delete.cpp
+++ b/src/dpp/events/guild_delete.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::guild* g = dpp::find_guild(snowflake_not_null(&d, "id"));
 	dpp::guild guild_del;

--- a/src/dpp/events/guild_emojis_update.cpp
+++ b/src/dpp/events/guild_emojis_update.cpp
@@ -39,7 +39,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_emojis_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_emojis_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/events/guild_integrations_update.cpp
+++ b/src/dpp/events/guild_integrations_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_integrations_update::handle(class discord_client* client, json &j, const std::string &raw) {
+void guild_integrations_update::handle(class discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_guild_integrations_update.empty()) {
 		json& d = j["d"];
 		dpp::guild_integrations_update_t giu(client, raw);

--- a/src/dpp/events/guild_join_request_delete.cpp
+++ b/src/dpp/events/guild_join_request_delete.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_join_request_delete::handle(class discord_client* client, json &j, const std::string &raw) {
+void guild_join_request_delete::handle(class discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_guild_join_request_delete.empty()) {
 		json& d = j["d"];
 		dpp::guild_join_request_delete_t grd(client, raw);

--- a/src/dpp/events/guild_member_add.cpp
+++ b/src/dpp/events/guild_member_add.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_member_add::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_member_add::handle(discord_client* client, json &j, std::string_view raw) {
 	json d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/events/guild_member_remove.cpp
+++ b/src/dpp/events/guild_member_remove.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_member_remove::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_member_remove::handle(discord_client* client, json &j, std::string_view raw) {
 	json d = j["d"];
 
 	dpp::guild_member_remove_t gmr(client, raw);

--- a/src/dpp/events/guild_member_update.cpp
+++ b/src/dpp/events/guild_member_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_member_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_member_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/events/guild_members_chunk.cpp
+++ b/src/dpp/events/guild_members_chunk.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_members_chunk::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_members_chunk::handle(discord_client* client, json &j, std::string_view raw) {
 	json &d = j["d"];
 	dpp::guild_member_map um;
 	dpp::guild* g = dpp::find_guild(snowflake_not_null(&d, "guild_id"));

--- a/src/dpp/events/guild_role_create.cpp
+++ b/src/dpp/events/guild_role_create.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_role_create::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_role_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json &d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/events/guild_role_delete.cpp
+++ b/src/dpp/events/guild_role_delete.cpp
@@ -37,7 +37,7 @@ using json = nlohmann::json;
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_role_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_role_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	json &d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::snowflake role_id = snowflake_not_null(&d, "role_id");

--- a/src/dpp/events/guild_role_update.cpp
+++ b/src/dpp/events/guild_role_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_role_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_role_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json &d = j["d"];
 	dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
 	dpp::guild* g = dpp::find_guild(guild_id);

--- a/src/dpp/events/guild_scheduled_event_create.cpp
+++ b/src/dpp/events/guild_scheduled_event_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_scheduled_event_create::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_scheduled_event_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_scheduled_event_create.empty()) {
 		dpp::guild_scheduled_event_create_t ec(client, raw);

--- a/src/dpp/events/guild_scheduled_event_delete.cpp
+++ b/src/dpp/events/guild_scheduled_event_delete.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_scheduled_event_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_scheduled_event_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_scheduled_event_delete.empty()) {
 		dpp::guild_scheduled_event_delete_t ed(client, raw);

--- a/src/dpp/events/guild_scheduled_event_update.cpp
+++ b/src/dpp/events/guild_scheduled_event_update.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_scheduled_event_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_scheduled_event_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_scheduled_event_update.empty()) {
 		dpp::guild_scheduled_event_update_t eu(client, raw);

--- a/src/dpp/events/guild_scheduled_event_user_add.cpp
+++ b/src/dpp/events/guild_scheduled_event_user_add.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_scheduled_event_user_add::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_scheduled_event_user_add::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_scheduled_event_user_add.empty()) {
 		dpp::guild_scheduled_event_user_add_t eua(client, raw);

--- a/src/dpp/events/guild_scheduled_event_user_remove.cpp
+++ b/src/dpp/events/guild_scheduled_event_user_remove.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_scheduled_event_user_remove::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_scheduled_event_user_remove::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_scheduled_event_user_remove.empty()) {
 		dpp::guild_scheduled_event_user_remove_t eur(client, raw);

--- a/src/dpp/events/guild_stickers_update.cpp
+++ b/src/dpp/events/guild_stickers_update.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_stickers_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_stickers_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	if (!client->creator->on_guild_stickers_update.empty()) {
 		dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");

--- a/src/dpp/events/guild_update.cpp
+++ b/src/dpp/events/guild_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void guild_update::handle(discord_client* client, json &j, const std::string &raw) {
+void guild_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	guild newguild;
 	dpp::guild* g = nullptr;

--- a/src/dpp/events/integration_create.cpp
+++ b/src/dpp/events/integration_create.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void integration_create::handle(discord_client* client, json &j, const std::string &raw) {
+void integration_create::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_integration_create.empty()) {
 		json& d = j["d"];
 		dpp::integration_create_t ic(client, raw);

--- a/src/dpp/events/integration_delete.cpp
+++ b/src/dpp/events/integration_delete.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void integration_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void integration_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_integration_delete.empty()) {
 		json& d = j["d"];
 		dpp::integration_delete_t id(client, raw);

--- a/src/dpp/events/integration_update.cpp
+++ b/src/dpp/events/integration_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void integration_update::handle(discord_client* client, json &j, const std::string &raw) {
+void integration_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_integration_update.empty()) {
 		json& d = j["d"];
 		dpp::integration_update_t iu(client, raw);

--- a/src/dpp/events/interaction_create.cpp
+++ b/src/dpp/events/interaction_create.cpp
@@ -82,7 +82,7 @@ void fill_options(dpp::json option_json, std::vector<dpp::command_option>& optio
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void interaction_create::handle(discord_client* client, json &j, const std::string &raw) {
+void interaction_create::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 	dpp::interaction i;
 	/* We must set here because we cant pass it through the nlohmann from_json() */

--- a/src/dpp/events/invite_create.cpp
+++ b/src/dpp/events/invite_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void invite_create::handle(discord_client* client, json &j, const std::string &raw) {
+void invite_create::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_invite_create.empty()) {
 		json& d = j["d"];
 		dpp::invite_create_t ci(client, raw);

--- a/src/dpp/events/invite_delete.cpp
+++ b/src/dpp/events/invite_delete.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void invite_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void invite_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_invite_delete.empty()) {
 		json& d = j["d"];
 		dpp::invite_delete_t cd(client, raw);

--- a/src/dpp/events/logger.cpp
+++ b/src/dpp/events/logger.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void logger::handle(discord_client* client, json &j, const std::string &raw) {
+void logger::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_log.empty()) {
 		dpp::log_t logmsg(client, raw);
 		logmsg.severity = (dpp::loglevel)from_string<uint32_t>(raw.substr(0, raw.find(';')));

--- a/src/dpp/events/message_create.cpp
+++ b/src/dpp/events/message_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_create::handle(discord_client* client, json &j, const std::string &raw) {
+void message_create::handle(discord_client* client, json &j, std::string_view raw) {
 
 	if (!client->creator->on_message_create.empty()) {
 		json d = j["d"];

--- a/src/dpp/events/message_delete.cpp
+++ b/src/dpp/events/message_delete.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void message_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_delete.empty()) {
 		json d = j["d"];
 		dpp::message_delete_t msg(client, raw);

--- a/src/dpp/events/message_delete_bulk.cpp
+++ b/src/dpp/events/message_delete_bulk.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_delete_bulk::handle(discord_client* client, json &j, const std::string &raw) {
+void message_delete_bulk::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_delete_bulk.empty()) {
 		json& d = j["d"];
 		dpp::message_delete_bulk_t msg(client, raw);

--- a/src/dpp/events/message_poll_vote_add.cpp
+++ b/src/dpp/events/message_poll_vote_add.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_poll_vote_add::handle(discord_client* client, json &j, const std::string &raw) {
+void message_poll_vote_add::handle(discord_client* client, json &j, std::string_view raw) {
 
 	if (!client->creator->on_message_poll_vote_add.empty()) {
 		json d = j["d"];

--- a/src/dpp/events/message_poll_vote_remove.cpp
+++ b/src/dpp/events/message_poll_vote_remove.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_poll_vote_remove::handle(discord_client* client, json &j, const std::string &raw) {
+void message_poll_vote_remove::handle(discord_client* client, json &j, std::string_view raw) {
 
 	if (!client->creator->on_message_poll_vote_add.empty()) {
 		json d = j["d"];

--- a/src/dpp/events/message_reaction_add.cpp
+++ b/src/dpp/events/message_reaction_add.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_reaction_add::handle(discord_client* client, json &j, const std::string &raw) {
+void message_reaction_add::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_reaction_add.empty()) {
 		json &d = j["d"];
 		dpp::message_reaction_add_t mra(client, raw);

--- a/src/dpp/events/message_reaction_remove.cpp
+++ b/src/dpp/events/message_reaction_remove.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_reaction_remove::handle(discord_client* client, json &j, const std::string &raw) {
+void message_reaction_remove::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_reaction_remove.empty()) {
 		json &d = j["d"];
 		dpp::message_reaction_remove_t mrr(client, raw);

--- a/src/dpp/events/message_reaction_remove_all.cpp
+++ b/src/dpp/events/message_reaction_remove_all.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_reaction_remove_all::handle(discord_client* client, json &j, const std::string &raw) {
+void message_reaction_remove_all::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_reaction_remove_all.empty()) {
 		json &d = j["d"];
 		dpp::message_reaction_remove_all_t mrra(client, raw);

--- a/src/dpp/events/message_reaction_remove_emoji.cpp
+++ b/src/dpp/events/message_reaction_remove_emoji.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_reaction_remove_emoji::handle(discord_client* client, json &j, const std::string &raw) {
+void message_reaction_remove_emoji::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_reaction_remove_emoji.empty()) {
 		json &d = j["d"];
 		dpp::message_reaction_remove_emoji_t mrre(client, raw);

--- a/src/dpp/events/message_update.cpp
+++ b/src/dpp/events/message_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void message_update::handle(discord_client* client, json &j, const std::string &raw) {
+void message_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_message_update.empty()) {
 		json d = j["d"];
 		dpp::message_update_t msg(client, raw);

--- a/src/dpp/events/presence_update.cpp
+++ b/src/dpp/events/presence_update.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void presence_update::handle(discord_client* client, json &j, const std::string &raw) {
+void presence_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_presence_update.empty()) {
 		json& d = j["d"];
 		dpp::presence_update_t pu(client, raw);

--- a/src/dpp/events/ready.cpp
+++ b/src/dpp/events/ready.cpp
@@ -39,7 +39,7 @@ std::mutex protect_the_loot;
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void ready::handle(discord_client* client, json &j, const std::string &raw) {
+void ready::handle(discord_client* client, json &j, std::string_view raw) {
 	client->log(dpp::ll_info, "Shard id " + std::to_string(client->shard_id) + " (" + std::to_string(client->shard_id + 1) + "/" + std::to_string(client->max_shards) + ") ready!");
 	client->sessionid = j["d"]["session_id"].get<std::string>();
 	/* Session-specific gateway resume url

--- a/src/dpp/events/resumed.cpp
+++ b/src/dpp/events/resumed.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void resumed::handle(discord_client* client, json &j, const std::string &raw) {
+void resumed::handle(discord_client* client, json &j, std::string_view raw) {
 	client->log(dpp::ll_debug, std::string("Successfully resumed session id ") + client->sessionid);
 
 	client->ready = true;

--- a/src/dpp/events/stage_instance_create.cpp
+++ b/src/dpp/events/stage_instance_create.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void stage_instance_create::handle(discord_client* client, json &j, const std::string &raw) {
+void stage_instance_create::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_stage_instance_create.empty()) {
 		json& d = j["d"];
 		dpp::stage_instance_create_t sic(client, raw);

--- a/src/dpp/events/stage_instance_delete.cpp
+++ b/src/dpp/events/stage_instance_delete.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void stage_instance_delete::handle(discord_client* client, json &j, const std::string &raw) {
+void stage_instance_delete::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_stage_instance_delete.empty()) {
 		json& d = j["d"];
 		dpp::stage_instance_delete_t sid(client, raw);

--- a/src/dpp/events/stage_instance_update.cpp
+++ b/src/dpp/events/stage_instance_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void stage_instance_update::handle(discord_client* client, json &j, const std::string &raw) {
+void stage_instance_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_stage_instance_update.empty()) {
 		json& d = j["d"];
 		dpp::stage_instance_update_t siu(client, raw);

--- a/src/dpp/events/thread_create.cpp
+++ b/src/dpp/events/thread_create.cpp
@@ -29,7 +29,7 @@
 namespace dpp::events {
 
 
-void thread_create::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_create::handle(discord_client* client, json& j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::thread t;

--- a/src/dpp/events/thread_delete.cpp
+++ b/src/dpp/events/thread_delete.cpp
@@ -29,7 +29,7 @@
 namespace dpp::events {
 
 
-void thread_delete::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_delete::handle(discord_client* client, json& j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::thread t;

--- a/src/dpp/events/thread_list_sync.cpp
+++ b/src/dpp/events/thread_list_sync.cpp
@@ -28,7 +28,7 @@
 
 
 namespace dpp::events {
-void thread_list_sync::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_list_sync::handle(discord_client* client, json& j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::guild* g = dpp::find_guild(snowflake_not_null(&d, "guild_id"));

--- a/src/dpp/events/thread_member_update.cpp
+++ b/src/dpp/events/thread_member_update.cpp
@@ -29,7 +29,7 @@
 namespace dpp::events {
 
 
-void thread_member_update::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_member_update::handle(discord_client* client, json& j, std::string_view raw) {
 	if (!client->creator->on_thread_member_update.empty()) {
 		json& d = j["d"];
 		dpp::thread_member_update_t tm(client, raw);

--- a/src/dpp/events/thread_members_update.cpp
+++ b/src/dpp/events/thread_members_update.cpp
@@ -29,7 +29,7 @@
 namespace dpp::events {
 
 
-void thread_members_update::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_members_update::handle(discord_client* client, json& j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::guild* g = dpp::find_guild(snowflake_not_null(&d, "guild_id"));

--- a/src/dpp/events/thread_update.cpp
+++ b/src/dpp/events/thread_update.cpp
@@ -28,7 +28,7 @@
 
 
 namespace dpp::events {
-void thread_update::handle(discord_client* client, json& j, const std::string& raw) {
+void thread_update::handle(discord_client* client, json& j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::thread t;

--- a/src/dpp/events/typing_start.cpp
+++ b/src/dpp/events/typing_start.cpp
@@ -34,7 +34,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void typing_start::handle(discord_client* client, json &j, const std::string &raw) {
+void typing_start::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_typing_start.empty()) {
 		json& d = j["d"];
 		dpp::typing_start_t ts(client, raw);

--- a/src/dpp/events/user_update.cpp
+++ b/src/dpp/events/user_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void user_update::handle(discord_client* client, json &j, const std::string &raw) {
+void user_update::handle(discord_client* client, json &j, std::string_view raw) {
 	json& d = j["d"];
 
 	dpp::snowflake user_id = snowflake_not_null(&d, "id");

--- a/src/dpp/events/voice_server_update.cpp
+++ b/src/dpp/events/voice_server_update.cpp
@@ -36,7 +36,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void voice_server_update::handle(discord_client* client, json &j, const std::string &raw) {
+void voice_server_update::handle(discord_client* client, json &j, std::string_view raw) {
 
 	json &d = j["d"];
 	dpp::voice_server_update_t vsu(client, raw);

--- a/src/dpp/events/voice_state_update.cpp
+++ b/src/dpp/events/voice_state_update.cpp
@@ -37,7 +37,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void voice_state_update::handle(discord_client* client, json &j, const std::string &raw) {
+void voice_state_update::handle(discord_client* client, json &j, std::string_view raw) {
 
 	json& d = j["d"];
 	dpp::voice_state_update_t vsu(client, raw);

--- a/src/dpp/events/webhooks_update.cpp
+++ b/src/dpp/events/webhooks_update.cpp
@@ -35,7 +35,7 @@ namespace dpp::events {
  * @param j JSON data for the event
  * @param raw Raw JSON string
  */
-void webhooks_update::handle(discord_client* client, json &j, const std::string &raw) {
+void webhooks_update::handle(discord_client* client, json &j, std::string_view raw) {
 	if (!client->creator->on_webhooks_update.empty()) {
 		json& d = j["d"];
 		dpp::webhooks_update_t wu(client, raw);

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -110,7 +110,7 @@ std::string guild_member::get_mention() const {
 	return "<@" + std::to_string(user_id) + ">";
 }
 
-guild_member& guild_member::set_nickname(const std::string& nick) {
+guild_member& guild_member::set_nickname(std::string_view nick) {
 	this->nickname = nick;
 	this->flags |= gm_nickname_action;
 	return *this;
@@ -262,7 +262,7 @@ json guild_member::to_json_impl(bool with_id) const {
 	return j;
 }
 
-guild& guild::set_name(const std::string& n) {
+guild& guild::set_name(std::string_view n) {
 	this->name = utility::validate(trim(n), 2, 100, "Guild names cannot be less than 2 characters");
 	return *this;
 }
@@ -394,7 +394,7 @@ welcome_channel &welcome_channel::set_channel_id(const snowflake _channel_id) {
 	return *this;
 }
 
-welcome_channel &welcome_channel::set_description(const std::string &_description) {
+welcome_channel &welcome_channel::set_description(std::string_view _description) {
 	this->description = _description;
 	return *this;
 }
@@ -422,7 +422,7 @@ json welcome_screen::to_json_impl(bool with_id) const {
 	return j;
 }
 
-welcome_screen &welcome_screen::set_description(const std::string &s){
+welcome_screen &welcome_screen::set_description(std::string_view s){
 	this->description = s;
 	return *this;
 }
@@ -663,11 +663,11 @@ guild& guild::fill_from_json(discord_client* shard, nlohmann::json* d) {
 				_icon = _icon.substr(2, _icon.length());
 				this->flags |= g_has_animated_icon;
 			}
-			this->icon = _icon;
+            this->icon = utility::iconhash(_icon);
 		}
 		std::string _dsplash = string_not_null(d, "discovery_splash");
 		if (!_dsplash.empty()) {
-			this->discovery_splash = _dsplash;
+            this->discovery_splash = utility::iconhash(_dsplash);
 		}
 		set_snowflake_not_null(d, "owner_id", this->owner_id);
 
@@ -747,7 +747,7 @@ guild& guild::fill_from_json(discord_client* shard, nlohmann::json* d) {
 			if (_banner.length() > 2 && _banner.substr(0, 2) == "a_") {
 				this->flags |= dpp::g_has_animated_banner;
 			}
-			this->banner = _banner;
+            this->banner = utility::iconhash(_banner);
 		}
 		this->premium_tier = (guild_premium_tier_t)int8_not_null(d, "premium_tier");
 		set_int16_not_null(d, "premium_subscription_count", this->premium_subscription_count);
@@ -1084,12 +1084,12 @@ onboarding_prompt_option &onboarding_prompt_option::set_emoji(const dpp::emoji &
 	return *this;
 }
 
-onboarding_prompt_option &onboarding_prompt_option::set_title(const std::string &_title) {
+onboarding_prompt_option &onboarding_prompt_option::set_title(std::string_view _title) {
 	this->title = _title;
 	return *this;
 }
 
-onboarding_prompt_option &onboarding_prompt_option::set_description(const std::string &_description) {
+onboarding_prompt_option &onboarding_prompt_option::set_description(std::string_view _description) {
 	this->description = _description;
 	return *this;
 }
@@ -1142,7 +1142,7 @@ onboarding_prompt &onboarding_prompt::set_type(const onboarding_prompt_type _typ
 	return *this;
 }
 
-onboarding_prompt &onboarding_prompt::set_title(const std::string& _title) {
+onboarding_prompt &onboarding_prompt::set_title(std::string_view _title) {
 	this->title = _title;
 	return *this;
 }

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -132,7 +132,7 @@ component& component::set_type(component_type ct)
 	return *this;
 }
 
-component& component::set_label(const std::string &l)
+component& component::set_label(std::string_view l)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -147,7 +147,7 @@ component& component::set_label(const std::string &l)
 	return *this;
 }
 
-component& component::set_default_value(const std::string &val)
+component& component::set_default_value(std::string_view val)
 {
 	if (type == cot_action_row) {
 		set_type(cot_text);
@@ -170,7 +170,7 @@ component& component::set_text_style(text_style_type ts)
 	return *this;
 }
 
-component& component::set_url(const std::string& u)
+component& component::set_url(std::string_view u)
 {
 	set_type(cot_button);
 	set_style(cos_link);
@@ -178,7 +178,7 @@ component& component::set_url(const std::string& u)
 	return *this;
 }
 
-component& component::set_id(const std::string &id)
+component& component::set_id(std::string_view id)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -205,7 +205,7 @@ component& component::set_required(bool require)
 	return *this;
 }
 
-component& component::set_emoji(const std::string& name, dpp::snowflake id, bool animated)
+component& component::set_emoji(std::string_view name, dpp::snowflake id, bool animated)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -404,10 +404,10 @@ void to_json(json& j, const component& cp) {
 select_option::select_option() : is_default(false) {
 }
 
-select_option::select_option(const std::string &_label, const std::string &_value, const std::string &_description) : label(_label), value(_value), description(_description), is_default(false) {
+select_option::select_option(std::string_view _label, std::string_view _value, std::string_view _description) : label(_label), value(_value), description(_description), is_default(false) {
 }
 
-select_option& select_option::set_label(const std::string &l) {
+select_option& select_option::set_label(std::string_view l) {
 	label = dpp::utility::utf8substr(l, 0, 100);
 	return *this;
 }
@@ -417,17 +417,17 @@ select_option& select_option::set_default(bool def) {
 	return *this;
 }
 
-select_option& select_option::set_value(const std::string &v) {
+select_option& select_option::set_value(std::string_view v) {
 	value = dpp::utility::utf8substr(v, 0, 100);
 	return *this;
 }
 
-select_option& select_option::set_description(const std::string &d) {
+select_option& select_option::set_description(std::string_view d) {
 	description = dpp::utility::utf8substr(d, 0, 100);
 	return *this;
 }
 
-select_option& select_option::set_emoji(const std::string &n, dpp::snowflake id, bool animated) {
+select_option& select_option::set_emoji(std::string_view n, dpp::snowflake id, bool animated) {
 	emoji.name = n;
 	emoji.id = id;
 	emoji.animated = animated;
@@ -453,7 +453,7 @@ select_option& select_option::fill_from_json_impl(nlohmann::json* j) {
 	return *this;
 }
 
-component& component::set_placeholder(const std::string &_placeholder) {
+component& component::set_placeholder(std::string_view _placeholder) {
 	if (type == cot_text) {
 		placeholder = dpp::utility::utf8substr(_placeholder, 0, 100);
 	} else if (type == cot_selectmenu || type == cot_user_selectmenu || type == cot_role_selectmenu || type == cot_mentionable_selectmenu || type == cot_channel_selectmenu) {
@@ -573,7 +573,7 @@ void to_json(json& j, const poll &p) {
 	j["layout_type"] = static_cast<uint32_t>(p.layout_type);
 }
 
-poll& poll::set_question(const std::string& text) {
+poll& poll::set_question(std::string_view text) {
 	question.text = text;
 	return *this;
 }
@@ -599,16 +599,16 @@ poll& poll::add_answer(const poll_media& media) {
 	return *this;
 }
 
-poll& poll::add_answer(const std::string& text, snowflake emoji_id, bool is_animated) {
-	return add_answer(poll_media{text, partial_emoji{{}, emoji_id, is_animated}});
+poll& poll::add_answer(std::string_view text, snowflake emoji_id, bool is_animated) {
+    return add_answer(poll_media{std::string(text), partial_emoji{{}, emoji_id, is_animated}});
 }
 
-poll& poll::add_answer(const std::string& text, const std::string& emoji) {
-	return add_answer(poll_media{text, partial_emoji{emoji, {}, false}});
+poll& poll::add_answer(std::string_view text, std::string_view emoji) {
+    return add_answer(poll_media{std::string(text), partial_emoji{std::string(emoji), {}, false}});
 }
 
-poll& poll::add_answer(const std::string& text, const emoji& e) {
-	return add_answer(poll_media{text, partial_emoji{e.name, e.id, e.is_animated()}});
+poll& poll::add_answer(std::string_view text, const emoji& e) {
+    return add_answer(poll_media{std::string(text), partial_emoji{e.name, e.id, e.is_animated()}});
 }
 
 const std::string& poll::get_question_text() const noexcept {
@@ -682,7 +682,7 @@ message& message::set_allowed_mentions(bool _parse_users, bool _parse_roles, boo
 	return *this;
 }
 
-message::message(snowflake _channel_id, const std::string &_content, message_type t) : message() {
+message::message(snowflake _channel_id, std::string_view _content, message_type t) : message() {
 	channel_id = _channel_id;
 	content = utility::utf8substr(_content, 0, 4000);
 	type = t;
@@ -718,7 +718,7 @@ message& message::set_type(message_type t) {
 	return *this;
 }
 
-message& message::set_filename(const std::string &fn) {
+message& message::set_filename(std::string_view fn) {
 	if (file_data.empty()) {
 		message_file_data data;
 		data.name = fn;
@@ -731,7 +731,7 @@ message& message::set_filename(const std::string &fn) {
 	return *this;
 }
 
-message& message::set_file_content(const std::string &fc) {
+message& message::set_file_content(std::string_view fc) {
 	if (file_data.empty()) {
 		message_file_data data;
 		data.content = fc;
@@ -744,7 +744,7 @@ message& message::set_file_content(const std::string &fc) {
 	return *this;
 }
 
-message& message::add_file(const std::string &fn, const std::string &fc, const std::string &fm) {
+message& message::add_file(std::string_view fn, std::string_view fc, std::string_view fm) {
 	message_file_data data;
 	data.name = fn;
 	data.content = fc;
@@ -754,7 +754,7 @@ message& message::add_file(const std::string &fn, const std::string &fc, const s
 	return *this;
 }
 
-message& message::set_content(const std::string &c)
+message& message::set_content(std::string_view c)
 {
 	content = utility::utf8substr(c, 0, 4000);
 	return *this;
@@ -783,7 +783,7 @@ bool message::has_poll() const noexcept {
 	return attached_poll.has_value();
 }
 
-message::message(const std::string &_content, message_type t) : message() {
+message::message(std::string_view _content, message_type t) : message() {
 	content = utility::utf8substr(_content, 0, 4000);
 	type = t;
 }
@@ -859,7 +859,7 @@ embed::embed(json* j) : embed() {
 	}
 }
 
-embed& embed::add_field(const std::string& name, const std::string &value, bool is_inline) {
+embed& embed::add_field(std::string_view name, std::string_view value, bool is_inline) {
 	if (fields.size() < 25) {
 		embed_field f;
 		f.name = utility::utf8substr(name, 0, 256);
@@ -882,7 +882,7 @@ embed& embed::set_timestamp(time_t tstamp)
 	return *this;
 }
 
-embed& embed::set_author(const std::string& name, const std::string& url, const std::string& icon_url) {
+embed& embed::set_author(std::string_view name, std::string_view url, std::string_view icon_url) {
 	dpp::embed_author a;
 	a.name = utility::utf8substr(name, 0, 256);
 	a.url = url;
@@ -896,7 +896,7 @@ embed& embed::set_footer(const embed_footer& f) {
 	return *this;
 }
 
-embed& embed::set_footer(const std::string& text, const std::string& icon_url) {
+embed& embed::set_footer(std::string_view text, std::string_view icon_url) {
 	dpp::embed_footer f;
 	f.set_text(text);
 	f.set_icon(icon_url);
@@ -904,7 +904,7 @@ embed& embed::set_footer(const std::string& text, const std::string& icon_url) {
 	return *this;
 }
 
-embed& embed::set_provider(const std::string& name, const std::string& url) {
+embed& embed::set_provider(std::string_view name, std::string_view url) {
 	dpp::embed_provider p;
 	p.name = utility::utf8substr(name, 0, 256);
 	p.url = url;
@@ -912,33 +912,33 @@ embed& embed::set_provider(const std::string& name, const std::string& url) {
 	return *this;
 }
 
-embed& embed::set_image(const std::string& url) {
+embed& embed::set_image(std::string_view url) {
 	dpp::embed_image i;
 	i.url = url;
 	image = i;
 	return *this;
 }
 
-embed& embed::set_video(const std::string& url) {
+embed& embed::set_video(std::string_view url) {
 	dpp::embed_image v;
 	v.url = url;
 	video = v;
 	return *this;
 }
 
-embed& embed::set_thumbnail(const std::string& url) {
+embed& embed::set_thumbnail(std::string_view url) {
 	dpp::embed_image t;
 	t.url = url;
 	thumbnail = t;
 	return *this;
 }
 
-embed& embed::set_title(const std::string &text) {
+embed& embed::set_title(std::string_view text) {
 	title = utility::utf8substr(text, 0, 256);
 	return *this;
 }
 
-embed& embed::set_description(const std::string &text) {
+embed& embed::set_description(std::string_view text) {
 	description = utility::utf8substr(text, 0, 4096);
 	return *this;
 }
@@ -953,22 +953,22 @@ embed& embed::set_colour(uint32_t col) {
 	return this->set_color(col);
 }
 
-embed& embed::set_url(const std::string &u) {
+embed& embed::set_url(std::string_view u) {
 	url = u;
 	return *this;
 }
 
-embed_footer& embed_footer::set_text(const std::string& t){
+embed_footer& embed_footer::set_text(std::string_view t){
 	text = utility::utf8substr(t, 0, 2048);
 	return *this;
 }
 
-embed_footer& embed_footer::set_icon(const std::string& i){
+embed_footer& embed_footer::set_icon(std::string_view i){
 	icon_url = i;
 	return *this;
 }
 
-embed_footer& embed_footer::set_proxy(const std::string& p){
+embed_footer& embed_footer::set_proxy(std::string_view p){
 	proxy_url = p;
 	return *this;
 }
@@ -1515,12 +1515,12 @@ std::string sticker::get_url() const {
 	return utility::cdn_endpoint_url_sticker(this->id, this->format_type);
 }
 
-sticker& sticker::set_filename(const std::string &fn) {
+sticker& sticker::set_filename(std::string_view fn) {
 	filename = fn;
 	return *this;
 }
 
-sticker& sticker::set_file_content(const std::string &fc) {
+sticker& sticker::set_file_content(std::string_view fc) {
 	filecontent = fc;
 	return *this;
 }

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -57,7 +57,7 @@ activity_party::activity_party() : id(0), current_size(0), maximum_size(0)
 {
 }
 
-activity::activity(const activity_type typ, const std::string& nam, const std::string& stat, const std::string& url_) :
+activity::activity(const activity_type typ, std::string_view nam, std::string_view stat, std::string_view url_) :
 	 name(nam), state(stat), url(url_), type(typ), created_at(0), start(0), end(0), application_id(0), flags(0), is_instance(false)
 {
 }
@@ -70,7 +70,7 @@ presence::presence() : user_id(0), guild_id(0), flags(0)
 {
 }
 
-presence::presence(presence_status status, activity_type type, const std::string& activity_description) {
+presence::presence(presence_status status, activity_type type, std::string_view activity_description) {
 	dpp::activity a;
 
 	/* Even if type is custom, a name is still required.

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -345,7 +345,7 @@ bool role::has_use_clyde_ai() const {
 	return has_administrator() || permissions.has(p_use_clyde_ai);
 }
 
-role& role::set_name(const std::string& n) {
+role& role::set_name(std::string_view n) {
 	name = utility::validate(n, 1, 100, "Role name too short");
 	return *this;
 }

--- a/src/dpp/scheduled_event.cpp
+++ b/src/dpp/scheduled_event.cpp
@@ -43,12 +43,12 @@ scheduled_event::scheduled_event() :
 {
 }
 
-scheduled_event& scheduled_event::set_name(const std::string& n) {
+scheduled_event& scheduled_event::set_name(std::string_view n) {
 	this->name = utility::validate(n, 1, 100, "Name too short");
 	return *this;
 }
 
-scheduled_event& scheduled_event::set_description(const std::string& d) {
+scheduled_event& scheduled_event::set_description(std::string_view d) {
 	this->description = utility::validate(d, 1, 1000, "Description too short");
 	return *this;
 }
@@ -58,7 +58,7 @@ scheduled_event& scheduled_event::clear_description() {
 	return *this;
 }
 
-scheduled_event& scheduled_event::set_location(const std::string& l) {
+scheduled_event& scheduled_event::set_location(std::string_view l) {
 	this->entity_metadata.location = utility::validate(l, 1, 100, "Location too short");
 	this->channel_id = 0;
 	return *this;

--- a/src/dpp/sku.cpp
+++ b/src/dpp/sku.cpp
@@ -27,7 +27,7 @@ namespace dpp {
 
 using json = nlohmann::json;
 
-sku::sku(const snowflake _id, const sku_type _type, const snowflake _application_id, const std::string _name, const std::string _slug, const uint16_t _flags)
+sku::sku(const snowflake _id, const sku_type _type, const snowflake _application_id, std::string_view _name, std::string_view _slug, const uint16_t _flags)
 	: managed(_id), type(_type), application_id(_application_id), name(_name), slug(_slug), flags(_flags) {}
 
 sku& sku::fill_from_json_impl(nlohmann::json* j) {

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -33,13 +33,13 @@ using json = nlohmann::json;
 slashcommand::slashcommand() : managed(), application_id(0), type(ctxm_chat_input), default_permission(true), version(1), default_member_permissions(p_use_application_commands), dm_permission(false), nsfw(false) {
 }
 
-slashcommand::slashcommand(const std::string &_name, const std::string &_description, const dpp::snowflake _application_id) : slashcommand() {
+slashcommand::slashcommand(std::string_view _name, std::string_view _description, const dpp::snowflake _application_id) : slashcommand() {
 	set_name(_name);
 	set_description(_description);
 	set_application_id(_application_id);
 }
 
-slashcommand::slashcommand(const std::string &_name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id): slashcommand() {
+slashcommand::slashcommand(std::string_view _name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id): slashcommand() {
 	set_name(_name);
 	set_type(_type);
 	set_application_id(_application_id);
@@ -275,7 +275,7 @@ slashcommand& slashcommand::set_type(slashcommand_contextmenu_type t) {
 	return *this;
 }
 
-slashcommand& slashcommand::set_name(const std::string &n) {
+slashcommand& slashcommand::set_name(std::string_view n) {
 	if (type == ctxm_chat_input) {
 		name = lowercase(utility::utf8substr(n, 0, 32));
 	} else {
@@ -284,7 +284,7 @@ slashcommand& slashcommand::set_name(const std::string &n) {
 	return *this;
 }
 
-slashcommand& slashcommand::set_description(const std::string &d) {
+slashcommand& slashcommand::set_description(std::string_view d) {
 	description = utility::utf8substr(d, 0, 100);
 	return *this;
 }
@@ -304,7 +304,7 @@ slashcommand& slashcommand::disable_default_permissions() {
 	return *this;
 }
 
-command_option_choice::command_option_choice(const std::string &n, command_value v) : name(n), value(v)
+command_option_choice::command_option_choice(std::string_view n, command_value v) : name(n), value(v)
 {
 }
 
@@ -330,7 +330,7 @@ command_option_choice &command_option_choice::fill_from_json_impl(nlohmann::json
 	return *this;
 }
 
-command_option::command_option(command_option_type t, const std::string &n, const std::string &d, bool r) :
+command_option::command_option(command_option_type t, std::string_view n, std::string_view d, bool r) :
 	type(t), name(n), description(d), required(r), focused(false), autocomplete(false)
 {
 	if (std::any_of(n.begin(), n.end(), [](unsigned char c){ return std::isupper(c); })) {
@@ -484,24 +484,24 @@ json interaction::to_json_impl(bool with_id) const {
 	return "";
 }
 
-slashcommand& slashcommand::add_localization(const std::string& language, const std::string& _name, const std::string& _description) {
-	name_localizations[language] = _name;
-	if (! _description.empty()) {
-		description_localizations[language] = _description;
+slashcommand& slashcommand::add_localization(std::string_view language, std::string_view _name, std::string_view _description) {
+    utility::emplace_or_assign(name_localizations, language, _name);
+    if (! _description.empty()) {
+        utility::emplace_or_assign(description_localizations, language, _description);
 	}
 	return *this;
 }
 
-command_option_choice& command_option_choice::add_localization(const std::string& language, const std::string& _name) {
-	name_localizations[language] = _name;
+command_option_choice& command_option_choice::add_localization(std::string_view language, std::string_view _name) {
+    utility::emplace_or_assign(name_localizations, language, _name);
 	return *this;
 }
 
-command_option& command_option::add_localization(const std::string& language, const std::string& _name, const std::string& _description) {
-	name_localizations[language] = _name;
-	if (! _description.empty()) {
-		description_localizations[language] = _description;
-	}
+command_option& command_option::add_localization(std::string_view language, std::string_view _name, std::string_view _description) {
+    utility::emplace_or_assign(name_localizations, language, _name);
+    if (! _description.empty()) {
+        utility::emplace_or_assign(description_localizations, language, _description);
+    }
 	return *this;
 }
 
@@ -805,7 +805,7 @@ interaction_modal_response::interaction_modal_response() : interaction_response(
 	components.push_back({});
 }
 
-interaction_modal_response::interaction_modal_response(const std::string& _custom_id, const std::string& _title, const std::vector<component> _components) : 
+interaction_modal_response::interaction_modal_response(std::string_view _custom_id, std::string_view _title, const std::vector<component> _components) :
 	interaction_response(ir_modal_dialog),
 	current_row(0), custom_id(_custom_id),
 	title(dpp::utility::utf8substr(_title, 0, 45)) {
@@ -848,12 +848,12 @@ interaction_modal_response& interaction_modal_response::add_row() {
 	return *this;
 }
 
-interaction_modal_response& interaction_modal_response::set_custom_id(const std::string& _custom_id) {
+interaction_modal_response& interaction_modal_response::set_custom_id(std::string_view _custom_id) {
 	custom_id = _custom_id;
 	return *this;
 }
 
-interaction_modal_response& interaction_modal_response::set_title(const std::string& _title) {
+interaction_modal_response& interaction_modal_response::set_title(std::string_view _title) {
 	title = _title;
 	return *this;
 }

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -235,7 +235,7 @@ void set_signal_handler(int signal)
 }
 #endif
 
-ssl_client::ssl_client(const std::string &_hostname, const std::string &_port, bool plaintext_downgrade, bool reuse) :
+ssl_client::ssl_client(std::string_view _hostname, std::string_view _port, bool plaintext_downgrade, bool reuse) :
 	nonblocking(false),
 	sfd(INVALID_SOCKET),
 	ssl(nullptr),
@@ -378,7 +378,7 @@ void ssl_client::connect()
 	}
 }
 
-void ssl_client::write(const std::string &data)
+void ssl_client::write(std::string_view data)
 {
 	/* If we are in nonblocking mode, append to the buffer,
 	 * otherwise just use SSL_write directly. The only time we
@@ -410,7 +410,7 @@ std::string ssl_client::get_cipher() {
 	return cipher;
 }
 
-void ssl_client::log(dpp::loglevel severity, const std::string &msg) const
+void ssl_client::log(dpp::loglevel severity, std::string_view msg) const
 {
 }
 

--- a/src/dpp/webhook.cpp
+++ b/src/dpp/webhook.cpp
@@ -34,7 +34,7 @@ webhook::webhook() : managed(), type(w_incoming), guild_id(0), channel_id(0), ap
 {
 }
 
-webhook::webhook(const std::string& webhook_url) : webhook()
+webhook::webhook(std::string_view webhook_url) : webhook()
 {
 	auto pos = webhook_url.find_last_of('/');
 	if (pos == std::string::npos) { // throw when the url doesn't contain a slash at all
@@ -42,15 +42,15 @@ webhook::webhook(const std::string& webhook_url) : webhook()
 	}
 	try {
 		token = webhook_url.substr(pos + 1);
-		std::string endpoint = "https://discord.com/api/webhooks/";
-		id = std::stoull(webhook_url.substr(endpoint.size(), pos));
+        constexpr std::string_view endpoint = "https://discord.com/api/webhooks/";
+        id = dpp::snowflake(webhook_url.substr(endpoint.size(), pos));
 	}
 	catch (const std::exception& e) {
 		throw dpp::logic_exception(err_invalid_webhook, std::string("Failed to parse webhook URL: ") + e.what());
 	}
 }
 
-webhook::webhook(const snowflake webhook_id, const std::string& webhook_token) : webhook()
+webhook::webhook(const snowflake webhook_id, std::string_view webhook_token) : webhook()
 {
 	token = webhook_token;
 	id = webhook_id;
@@ -91,12 +91,12 @@ json webhook::to_json_impl(bool with_id) const {
 	return j;
 }
 
-webhook& webhook::load_image(const std::string &image_blob, const image_type type, bool is_base64_encoded) {
+webhook& webhook::load_image(std::string_view image_blob, const image_type type, bool is_base64_encoded) {
 	if (image_blob.size() > MAX_ICON_SIZE) {
 		throw dpp::length_exception(err_icon_size, "Webhook icon file exceeds discord limit of 256 kilobytes");
 	}
 
-	image_data = "data:" + utility::mime_type(type) + ";base64," + (is_base64_encoded ? image_blob : base64_encode(reinterpret_cast<unsigned char const*>(image_blob.data()), static_cast<unsigned int>(image_blob.length())));
+    image_data = "data:" + utility::mime_type(type) + ";base64," + (is_base64_encoded ? std::string(image_blob) : base64_encode(reinterpret_cast<unsigned char const*>(image_blob.data()), static_cast<unsigned int>(image_blob.length())));
 
 	return *this;
 }

--- a/src/dpp/wsclient.cpp
+++ b/src/dpp/wsclient.cpp
@@ -37,7 +37,7 @@ constexpr size_t WS_MAX_PAYLOAD_LENGTH_SMALL = 125;
 constexpr size_t WS_MAX_PAYLOAD_LENGTH_LARGE = 65535;
 constexpr size_t MAXHEADERSIZE = sizeof(uint64_t) + 2;
 
-websocket_client::websocket_client(const std::string &hostname, const std::string &port, const std::string &urlpath, ws_opcode opcode)
+websocket_client::websocket_client(std::string_view hostname, std::string_view port, std::string_view urlpath, ws_opcode opcode)
 	: ssl_client(hostname, port),
 	state(HTTP_HEADERS),
 	path(urlpath),
@@ -73,7 +73,7 @@ void websocket_client::connect()
 	);
 }
 
-bool websocket_client::handle_frame(const std::string &buffer)
+bool websocket_client::handle_frame(std::string_view buffer)
 {
 	/* This is a stub for classes that derive the websocket client */
 	return true;
@@ -111,7 +111,7 @@ size_t websocket_client::fill_header(unsigned char* outbuf, size_t sendlength, w
 }
 
 
-void websocket_client::write(const std::string &data)
+void websocket_client::write(std::string_view data)
 {
 	if (state == HTTP_HEADERS) {
 		/* Simple write */
@@ -282,7 +282,7 @@ void websocket_client::one_second_timer()
 	}
 }
 
-void websocket_client::handle_ping_pong(bool ping, const std::string &payload)
+void websocket_client::handle_ping_pong(bool ping, std::string_view payload)
 {
 	if (ping) {
 		/* For receiving pings we echo back their payload with the type OP_PONG */

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -485,7 +485,7 @@ std::vector<uint8_t> load_test_audio();
  * 
  * @return std::vector<std::byte> File data
  */
-std::vector<std::byte> load_data(const std::string& file);
+std::vector<std::byte> load_data(std::string_view file);
 
 /**
  * @brief Get the token from the environment variable DPP_UNIT_TEST_TOKEN

--- a/src/unittest/unittest.cpp
+++ b/src/unittest/unittest.cpp
@@ -147,10 +147,11 @@ std::vector<uint8_t> load_test_audio() {
 	return testaudio;
 }
 
-std::vector<std::byte> load_data(const std::string& file) {
+std::vector<std::byte> load_data(std::string_view file) {
 	std::vector<std::byte> testimage;
-	std::string dir = get_testdata_dir();
-	std::ifstream input (dir + file, std::ios::in|std::ios::binary|std::ios::ate);
+    std::string path = get_testdata_dir();
+    path += file;
+    std::ifstream input (path, std::ios::in|std::ios::binary|std::ios::ate);
 	if (input.is_open()) {
 		size_t testimage_size = input.tellg();
 		testimage.resize(testimage_size);
@@ -159,7 +160,7 @@ std::vector<std::byte> load_data(const std::string& file) {
 		input.close();
 	}
 	else {
-		std::cout << "ERROR: Can't load " + dir + file + "\n";
+        std::cout << "ERROR: Can't load " + path + "\n";
 		exit(1);
 	}
 	return testimage;


### PR DESCRIPTION
This will make the library easier to use for std::string_view users as a LOT of explicit std::string creations are needed atm. There should be some performance improvements as well (less allocations, blablabla). Tested with my own bot which is pretty complex and works 100%.

This is completely backwards compatible in my testing, with the exception of implicit conversions. For example, within the library itself, there were some assignments of a utility::icon to a string that would implicitly create a utility::iconhash - now it does not, and does not compile without explicitly creating the iconhash. With my own bot this happened with std::smatch.

There's also some new stuff / changes outside of just changing std::strings to std::string_views:
- A new utility function for maps, dpp::utility::emplace_or_assign, which essentially is insert_or_assign but with the in-place construction that emplace offers.
- All non-floating point instances of std::stoX that would take in a std::string_view have been changed to use std::from_chars.
- 2 new types, dpp::membuf and dpp::imemstream, in stringops.h, which allow input streams over a raw character array, necessary for std::string_view. These are not compiled if std::ispanstream is available, which was added in C++23, as it is far superior. All instances of std::istringstream that would take in a std::string_view have been replaced to use one or the other, depending on what's available. (P.S. should these be exported with DPP_EXPORT?)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
