### PR TITLE
Use string_view for message object ctors + setters

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -280,7 +280,7 @@ public:
 	 * @param value Value of option
 	 * @param description Description of option
 	 */
-	select_option(const std::string &label, const std::string &value, const std::string &description = "");
+	select_option(std::string_view label, std::string_view value, std::string_view description = "");
 
 	/**
 	 * @brief Set the label
@@ -288,7 +288,7 @@ public:
 	 * @param l the user-facing name of the option. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_label(const std::string &l);
+	select_option& set_label(std::string_view l);
 
 	/**
 	 * @brief Set the value
@@ -296,7 +296,7 @@ public:
 	 * @param v value to set. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_value(const std::string &v);
+	select_option& set_value(std::string_view v);
 
 	/**
 	 * @brief Set the description
@@ -304,7 +304,7 @@ public:
 	 * @param d description to set. It will be truncated to the maximum length of 100 UTF-8 characters.
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_description(const std::string &d);
+	select_option& set_description(std::string_view d);
 
 	/**
 	 * @brief Set the emoji
@@ -314,7 +314,7 @@ public:
 	 * @param animated true if animated emoji
 	 * @return select_option& reference to self for chaining
 	 */
-	select_option& set_emoji(const std::string &n, dpp::snowflake id = 0, bool animated = false);
+	select_option& set_emoji(std::string_view n, dpp::snowflake id = 0, bool animated = false);
 
 	/**
 	 * @brief Set the option as default
@@ -529,7 +529,7 @@ public:
 	 * @param label Label text to set. It will be truncated to the maximum length of 80 UTF-8 characters.
 	 * @return component& Reference to self
 	 */
-	component& set_label(const std::string &label);
+	component& set_label(std::string_view label);
 
 	/**
 	 * @brief Set the default value of the text input component.
@@ -539,7 +539,7 @@ public:
 	 * @param val Value text to set. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @return component& Reference to self
 	 */
-	component& set_default_value(const std::string &val);
+	component& set_default_value(std::string_view val);
 
 	/**
 	 * @brief Set the url for dpp::cos_link types.
@@ -549,7 +549,7 @@ public:
 	 * @param url URL to set. It will be truncated to the maximum length of 512 UTF-8 characters.
 	 * @return component& reference to self.
 	 */
-	component& set_url(const std::string &url);
+	component& set_url(std::string_view url);
 
 	/**
 	 * @brief Set the style of the component, e.g. button colour.
@@ -572,7 +572,7 @@ public:
 	 * If your Custom ID is longer than this, it will be truncated.
 	 * @return component& Reference to self
 	 */
-	component& set_id(const std::string &id);
+	component& set_id(std::string_view id);
 
 	/**
 	 * @brief Set the component to disabled.
@@ -600,7 +600,7 @@ public:
 	 * characters for modals.
 	 * @return component& Reference to self
 	 */
-	component& set_placeholder(const std::string &placeholder);
+	component& set_placeholder(std::string_view placeholder);
 
 	/**
 	 * @brief Set the minimum number of items that must be chosen for a select menu
@@ -677,7 +677,7 @@ public:
 	 * @param animated True if the custom emoji is animated.
 	 * @return component& Reference to self
 	 */
-	component& set_emoji(const std::string& name, dpp::snowflake id = 0, bool animated = false);
+	component& set_emoji(std::string_view name, dpp::snowflake id = 0, bool animated = false);
 };
 
 /**
@@ -706,21 +706,21 @@ struct DPP_EXPORT embed_footer {
 	 * @param t string to set as footer text. It will be truncated to the maximum length of 2048 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_text(const std::string& t);
+	embed_footer& set_text(std::string_view t);
 
 	/**
 	 * @brief Set footer's icon url.
 	 * @param i url to set as footer icon url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_icon(const std::string& i);
+	embed_footer& set_icon(std::string_view i);
 
 	/**
 	 * @brief Set footer's proxied icon url.
 	 * @param p url to set as footer proxied icon url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed_footer& set_proxy(const std::string& p);
+	embed_footer& set_proxy(std::string_view p);
 };
 
 /**
@@ -908,14 +908,14 @@ struct DPP_EXPORT embed {
 	 * @param text The text of the title. It will be truncated to the maximum length of 256 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_title(const std::string &text);
+	embed& set_title(std::string_view text);
 
 	/**
 	 * @brief Set embed description.
 	 * @param text The text of the title. It will be truncated to the maximum length of 4096 UTF-8 characters.
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_description(const std::string &text);
+	embed& set_description(std::string_view text);
 
 	/**
 	 * @brief Set the footer of the embed.
@@ -930,7 +930,7 @@ struct DPP_EXPORT embed {
 	 * @param icon_url an url to set as footer icon url (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_footer(const std::string& text, const std::string& icon_url);
+	embed& set_footer(std::string_view text, std::string_view icon_url);
 
 	/**
 	 * @brief Set embed colour.
@@ -958,7 +958,7 @@ struct DPP_EXPORT embed {
 	 * @param url the url of the embed
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_url(const std::string &url);
+	embed& set_url(std::string_view url);
 
 	/**
 	 * @brief Add an embed field.
@@ -967,7 +967,7 @@ struct DPP_EXPORT embed {
 	 * @param is_inline Whether or not to display the field 'inline' or on its own line
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& add_field(const std::string& name, const std::string &value, bool is_inline = false);
+	embed& add_field(std::string_view name, std::string_view value, bool is_inline = false);
 
 	/**
 	 * @brief Set embed author.
@@ -983,7 +983,7 @@ struct DPP_EXPORT embed {
 	 * @param icon_url The icon URL of the author (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_author(const std::string& name, const std::string& url, const std::string& icon_url);
+	embed& set_author(std::string_view name, std::string_view url, std::string_view icon_url);
 
 	/**
 	 * @brief Set embed provider.
@@ -991,28 +991,28 @@ struct DPP_EXPORT embed {
 	 * @param url The provider url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_provider(const std::string& name, const std::string& url);
+	embed& set_provider(std::string_view name, std::string_view url);
 
 	/**
 	 * @brief Set embed image.
 	 * @param url The embed image URL (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_image(const std::string& url);
+	embed& set_image(std::string_view url);
 
 	/**
 	 * @brief Set embed video.
 	 * @param url The embed video url
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_video(const std::string& url);
+	embed& set_video(std::string_view url);
 
 	/**
 	 * @brief Set embed thumbnail.
 	 * @param url The embed thumbnail url (only supports http(s) and attachments)
 	 * @return A reference to self so this method may be "chained".
 	 */
-	embed& set_thumbnail(const std::string& url);
+	embed& set_thumbnail(std::string_view url);
 };
 
 /**
@@ -1360,15 +1360,15 @@ public:
 	 * @param fn filename
 	 * @return message& reference to self
 	 */
-	sticker& set_filename(const std::string &fn);
+	sticker& set_filename(std::string_view fn);
 
 	/**
 	 * @brief Set the file content
-	 * 
-	 * @param fc raw file content contained in std::string
+	 *
+	 * @param fc raw file content
 	 * @return message& reference to self
 	 */
-	sticker& set_file_content(const std::string &fc);
+	sticker& set_file_content(std::string_view fc);
 
 };
 
@@ -1575,7 +1575,7 @@ struct DPP_EXPORT poll {
 	 * @param text Text for the question
 	 * @return self for method chaining
 	 */
-	poll& set_question(const std::string& text);
+	poll& set_question(std::string_view text);
 
 	/**
 	 * @brief Set the duration of the poll in hours
@@ -1611,7 +1611,7 @@ struct DPP_EXPORT poll {
 	 * @param is_animated Whether the emoji is animated
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, snowflake emoji_id = 0, bool is_animated = false);
+	poll& add_answer(std::string_view text, snowflake emoji_id = 0, bool is_animated = false);
 
 	/**
 	 * @brief Add an answer to this poll
@@ -1621,7 +1621,7 @@ struct DPP_EXPORT poll {
 	 * @param emoji Optional emoji
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, const std::string& emoji);
+	poll& add_answer(std::string_view text, std::string_view emoji);
 
 	/**
 	 * @brief Add an answer to this poll
@@ -1631,7 +1631,7 @@ struct DPP_EXPORT poll {
 	 * @param e Optional emoji
 	 * @return self for method chaining
 	 */
-	poll& add_answer(const std::string& text, const emoji& e);
+	poll& add_answer(std::string_view text, const emoji& e);
 
 	/**
 	 * @brief Helper to get the question text
@@ -2286,7 +2286,7 @@ public:
 	 * @param content The content of the message. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @param type The message type to create
 	 */
-	message(snowflake channel_id, const std::string &content, message_type type = mt_default);
+	message(snowflake channel_id, std::string_view content, message_type type = mt_default);
 
 	/**
 	 * @brief Construct a new message object with content
@@ -2309,7 +2309,7 @@ public:
 	 * @param content The content of the message. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @param type The message type to create
 	 */
-	message(const std::string &content, message_type type = mt_default);
+	message(std::string_view content, message_type type = mt_default);
 
 	/**
 	 * @brief Destroy the message object
@@ -2516,26 +2516,26 @@ public:
 	 * @return message& reference to self
 	 * @deprecated Use message::add_file instead
 	 */
-	message& set_filename(const std::string &fn);
+	message& set_filename(std::string_view fn);
 
 	/**
 	 * @brief Set the file content of the last file in list
 	 * 
-	 * @param fc raw file content contained in std::string
+	 * @param fc raw file content
 	 * @return message& reference to self
 	 * @deprecated Use message::add_file instead
 	 */
-	message& set_file_content(const std::string &fc);
+	message& set_file_content(std::string_view fc);
 
 	/**
 	 * @brief Add a file to the message
 	 *
 	 * @param filename filename
-	 * @param filecontent raw file content contained in std::string
+	 * @param filecontent raw file content
 	 * @param filemimetype optional mime type of the file
 	 * @return message& reference to self
 	 */
-	message& add_file(const std::string &filename, const std::string &filecontent, const std::string &filemimetype = "");
+	message& add_file(std::string_view filename, std::string_view filecontent, std::string_view filemimetype = "");
 
 	/**
 	 * @brief Set the message content
@@ -2543,7 +2543,7 @@ public:
 	 * @param c message content. It will be truncated to the maximum length of 4000 UTF-8 characters.
 	 * @return message& reference to self
 	 */
-	message& set_content(const std::string &c);
+	message& set_content(std::string_view c);
 	
 	/**
 	 * @brief Set the channel id

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -132,7 +132,7 @@ component& component::set_type(component_type ct)
 	return *this;
 }
 
-component& component::set_label(const std::string &l)
+component& component::set_label(std::string_view l)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -147,7 +147,7 @@ component& component::set_label(const std::string &l)
 	return *this;
 }
 
-component& component::set_default_value(const std::string &val)
+component& component::set_default_value(std::string_view val)
 {
 	if (type == cot_action_row) {
 		set_type(cot_text);
@@ -170,7 +170,7 @@ component& component::set_text_style(text_style_type ts)
 	return *this;
 }
 
-component& component::set_url(const std::string& u)
+component& component::set_url(std::string_view u)
 {
 	set_type(cot_button);
 	set_style(cos_link);
@@ -178,7 +178,7 @@ component& component::set_url(const std::string& u)
 	return *this;
 }
 
-component& component::set_id(const std::string &id)
+component& component::set_id(std::string_view id)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -205,7 +205,7 @@ component& component::set_required(bool require)
 	return *this;
 }
 
-component& component::set_emoji(const std::string& name, dpp::snowflake id, bool animated)
+component& component::set_emoji(std::string_view name, dpp::snowflake id, bool animated)
 {
 	if (type == cot_action_row) {
 		set_type(cot_button);
@@ -404,10 +404,10 @@ void to_json(json& j, const component& cp) {
 select_option::select_option() : is_default(false) {
 }
 
-select_option::select_option(const std::string &_label, const std::string &_value, const std::string &_description) : label(_label), value(_value), description(_description), is_default(false) {
+select_option::select_option(std::string_view _label, std::string_view _value, std::string_view _description) : label(_label), value(_value), description(_description), is_default(false) {
 }
 
-select_option& select_option::set_label(const std::string &l) {
+select_option& select_option::set_label(std::string_view l) {
 	label = dpp::utility::utf8substr(l, 0, 100);
 	return *this;
 }
@@ -417,17 +417,17 @@ select_option& select_option::set_default(bool def) {
 	return *this;
 }
 
-select_option& select_option::set_value(const std::string &v) {
+select_option& select_option::set_value(std::string_view v) {
 	value = dpp::utility::utf8substr(v, 0, 100);
 	return *this;
 }
 
-select_option& select_option::set_description(const std::string &d) {
+select_option& select_option::set_description(std::string_view d) {
 	description = dpp::utility::utf8substr(d, 0, 100);
 	return *this;
 }
 
-select_option& select_option::set_emoji(const std::string &n, dpp::snowflake id, bool animated) {
+select_option& select_option::set_emoji(std::string_view n, dpp::snowflake id, bool animated) {
 	emoji.name = n;
 	emoji.id = id;
 	emoji.animated = animated;
@@ -453,7 +453,7 @@ select_option& select_option::fill_from_json_impl(nlohmann::json* j) {
 	return *this;
 }
 
-component& component::set_placeholder(const std::string &_placeholder) {
+component& component::set_placeholder(std::string_view _placeholder) {
 	if (type == cot_text) {
 		placeholder = dpp::utility::utf8substr(_placeholder, 0, 100);
 	} else if (type == cot_selectmenu || type == cot_user_selectmenu || type == cot_role_selectmenu || type == cot_mentionable_selectmenu || type == cot_channel_selectmenu) {
@@ -573,7 +573,7 @@ void to_json(json& j, const poll &p) {
 	j["layout_type"] = static_cast<uint32_t>(p.layout_type);
 }
 
-poll& poll::set_question(const std::string& text) {
+poll& poll::set_question(std::string_view text) {
 	question.text = text;
 	return *this;
 }
@@ -599,16 +599,29 @@ poll& poll::add_answer(const poll_media& media) {
 	return *this;
 }
 
-poll& poll::add_answer(const std::string& text, snowflake emoji_id, bool is_animated) {
-	return add_answer(poll_media{text, partial_emoji{{}, emoji_id, is_animated}});
+poll& poll::add_answer(std::string_view text, snowflake emoji_id, bool is_animated) {
+	poll_media pm;
+	pm.emoji = partial_emoji { {}, emoji_id, is_animated };
+	pm.text = text;
+	return add_answer(pm);
 }
 
-poll& poll::add_answer(const std::string& text, const std::string& emoji) {
-	return add_answer(poll_media{text, partial_emoji{emoji, {}, false}});
+poll& poll::add_answer(std::string_view text, std::string_view emoji) {
+	poll_media pm;
+	pm.text = text;
+
+	partial_emoji pe;
+	pe.name = emoji;
+	pm.emoji = pe;
+
+	return add_answer(pm);
 }
 
-poll& poll::add_answer(const std::string& text, const emoji& e) {
-	return add_answer(poll_media{text, partial_emoji{e.name, e.id, e.is_animated()}});
+poll& poll::add_answer(std::string_view text, const emoji& e) {
+	poll_media pm;
+	pm.emoji = partial_emoji { e.name, e.id, e.is_animated() };
+	pm.text = text;
+	return add_answer(pm);
 }
 
 const std::string& poll::get_question_text() const noexcept {
@@ -682,7 +695,7 @@ message& message::set_allowed_mentions(bool _parse_users, bool _parse_roles, boo
 	return *this;
 }
 
-message::message(snowflake _channel_id, const std::string &_content, message_type t) : message() {
+message::message(snowflake _channel_id, std::string_view _content, message_type t) : message() {
 	channel_id = _channel_id;
 	content = utility::utf8substr(_content, 0, 4000);
 	type = t;
@@ -718,7 +731,7 @@ message& message::set_type(message_type t) {
 	return *this;
 }
 
-message& message::set_filename(const std::string &fn) {
+message& message::set_filename(std::string_view fn) {
 	if (file_data.empty()) {
 		message_file_data data;
 		data.name = fn;
@@ -731,7 +744,7 @@ message& message::set_filename(const std::string &fn) {
 	return *this;
 }
 
-message& message::set_file_content(const std::string &fc) {
+message& message::set_file_content(std::string_view fc) {
 	if (file_data.empty()) {
 		message_file_data data;
 		data.content = fc;
@@ -744,7 +757,7 @@ message& message::set_file_content(const std::string &fc) {
 	return *this;
 }
 
-message& message::add_file(const std::string &fn, const std::string &fc, const std::string &fm) {
+message& message::add_file(std::string_view fn, std::string_view fc, std::string_view fm) {
 	message_file_data data;
 	data.name = fn;
 	data.content = fc;
@@ -754,7 +767,7 @@ message& message::add_file(const std::string &fn, const std::string &fc, const s
 	return *this;
 }
 
-message& message::set_content(const std::string &c)
+message& message::set_content(std::string_view c)
 {
 	content = utility::utf8substr(c, 0, 4000);
 	return *this;
@@ -783,7 +796,7 @@ bool message::has_poll() const noexcept {
 	return attached_poll.has_value();
 }
 
-message::message(const std::string &_content, message_type t) : message() {
+message::message(std::string_view _content, message_type t) : message() {
 	content = utility::utf8substr(_content, 0, 4000);
 	type = t;
 }
@@ -859,7 +872,7 @@ embed::embed(json* j) : embed() {
 	}
 }
 
-embed& embed::add_field(const std::string& name, const std::string &value, bool is_inline) {
+embed& embed::add_field(std::string_view name, std::string_view value, bool is_inline) {
 	if (fields.size() < 25) {
 		embed_field f;
 		f.name = utility::utf8substr(name, 0, 256);
@@ -882,7 +895,7 @@ embed& embed::set_timestamp(time_t tstamp)
 	return *this;
 }
 
-embed& embed::set_author(const std::string& name, const std::string& url, const std::string& icon_url) {
+embed& embed::set_author(std::string_view name, std::string_view url, std::string_view icon_url) {
 	dpp::embed_author a;
 	a.name = utility::utf8substr(name, 0, 256);
 	a.url = url;
@@ -896,7 +909,7 @@ embed& embed::set_footer(const embed_footer& f) {
 	return *this;
 }
 
-embed& embed::set_footer(const std::string& text, const std::string& icon_url) {
+embed& embed::set_footer(std::string_view text, std::string_view icon_url) {
 	dpp::embed_footer f;
 	f.set_text(text);
 	f.set_icon(icon_url);
@@ -904,7 +917,7 @@ embed& embed::set_footer(const std::string& text, const std::string& icon_url) {
 	return *this;
 }
 
-embed& embed::set_provider(const std::string& name, const std::string& url) {
+embed& embed::set_provider(std::string_view name, std::string_view url) {
 	dpp::embed_provider p;
 	p.name = utility::utf8substr(name, 0, 256);
 	p.url = url;
@@ -912,33 +925,33 @@ embed& embed::set_provider(const std::string& name, const std::string& url) {
 	return *this;
 }
 
-embed& embed::set_image(const std::string& url) {
+embed& embed::set_image(std::string_view url) {
 	dpp::embed_image i;
 	i.url = url;
 	image = i;
 	return *this;
 }
 
-embed& embed::set_video(const std::string& url) {
+embed& embed::set_video(std::string_view url) {
 	dpp::embed_image v;
 	v.url = url;
 	video = v;
 	return *this;
 }
 
-embed& embed::set_thumbnail(const std::string& url) {
+embed& embed::set_thumbnail(std::string_view url) {
 	dpp::embed_image t;
 	t.url = url;
 	thumbnail = t;
 	return *this;
 }
 
-embed& embed::set_title(const std::string &text) {
+embed& embed::set_title(std::string_view text) {
 	title = utility::utf8substr(text, 0, 256);
 	return *this;
 }
 
-embed& embed::set_description(const std::string &text) {
+embed& embed::set_description(std::string_view text) {
 	description = utility::utf8substr(text, 0, 4096);
 	return *this;
 }
@@ -953,22 +966,22 @@ embed& embed::set_colour(uint32_t col) {
 	return this->set_color(col);
 }
 
-embed& embed::set_url(const std::string &u) {
+embed& embed::set_url(std::string_view u) {
 	url = u;
 	return *this;
 }
 
-embed_footer& embed_footer::set_text(const std::string& t){
+embed_footer& embed_footer::set_text(std::string_view t){
 	text = utility::utf8substr(t, 0, 2048);
 	return *this;
 }
 
-embed_footer& embed_footer::set_icon(const std::string& i){
+embed_footer& embed_footer::set_icon(std::string_view i){
 	icon_url = i;
 	return *this;
 }
 
-embed_footer& embed_footer::set_proxy(const std::string& p){
+embed_footer& embed_footer::set_proxy(std::string_view p){
 	proxy_url = p;
 	return *this;
 }
@@ -1515,12 +1528,12 @@ std::string sticker::get_url() const {
 	return utility::cdn_endpoint_url_sticker(this->id, this->format_type);
 }
 
-sticker& sticker::set_filename(const std::string &fn) {
+sticker& sticker::set_filename(std::string_view fn) {
 	filename = fn;
 	return *this;
 }
 
-sticker& sticker::set_file_content(const std::string &fc) {
+sticker& sticker::set_file_content(std::string_view fc) {
 	filecontent = fc;
 	return *this;
 }


### PR DESCRIPTION
This makes the methods more flexible with types of input, most notably with string_views themselves so the user doesn't have to create a temporary std::string.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
