### PR TITLE
Add XBPS docs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -141,7 +141,8 @@
 		"tparam",
 		"khanda",
 		"oclock",
-		"moai"
+		"moai",
+		"xbps"
 	],
 	"flagWords": [
 		"hte"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![D++ CI](https://github.com/brainboxdotcc/DPP/actions/workflows/ci.yml/badge.svg)](https://github.com/brainboxdotcc/DPP/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/brainboxdotcc/DPP/badge)](https://securityscorecards.dev/viewer/?uri=github.com/brainboxdotcc/DPP)
 [![AUR version](https://img.shields.io/aur/version/dpp)](https://aur.archlinux.org/packages/dpp)
+[![XBPS version](https://repology.org/badge/version-for-repo/void_x86_64/dpp-discord.svg?header=xbps)](https://github.com/void-linux/void-packages/blob/master/srcpkgs/dpp/template)
 ![vcpkg version](https://img.shields.io/vcpkg/v/dpp)
 [![Homebrew version](https://img.shields.io/homebrew/v/libdpp)](https://formulae.brew.sh/formula/libdpp#default)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)

--- a/docpages/03_installing.md
+++ b/docpages/03_installing.md
@@ -6,6 +6,7 @@ There are many ways to install D++, either from a package manager, or from sourc
 * \subpage install-linux-rpm
 * \subpage install-vcpkg
 * \subpage install-arch-aur
+* \subpage install-void-xbps
 * \subpage install-windows-vs-zip
 * \subpage install-xmake
 * \subpage install-brew

--- a/docpages/install/install-void-xbps.md
+++ b/docpages/install/install-void-xbps.md
@@ -1,0 +1,43 @@
+\page install-void-xbps Installing from XBPS (Void Linux)
+
+To install [D++ from XBPS source packages collection](https://github.com/void-linux/void-packages/blob/master/srcpkgs/dpp/template), follow the step below (as root):
+
+```bash
+xbps-install -Sy dpp-devel
+```
+
+This will install D++ development files and related libraries
+
+
+You will now be able to use D++ by including its library on the command line:
+
+```bash
+g++ mybot.cpp -o mybot -ldpp
+```
+
+\include{doc} install_prebuilt_footer.dox
+
+To build D++ with coroutine support as an XBPS package, follow the steps below. Ensure that [xbps-src is set up](https://github.com/void-linux/void-packages?tab=readme-ov-file#quick-start) beforehand:
+
+```bash
+# Inside the void-packages root folder
+git checkout master && git pull
+# Modifies the configure arguments to include coroutine support (-DDPP_CORO=ON)
+grep -q 'configure_args=.*-DDPP_CORO=ON' srcpkgs/dpp/template || sed -i -e 's/\(configure_args="[^"]*\)"/\1 -DDPP_CORO=ON"/' srcpkgs/dpp/template
+./xbps-src -K pkg dpp
+```
+
+Then as root:
+```bash
+# Inside the void-packages root folder
+xbps-install --repository hostdir/binpkgs dpp-devel
+```
+
+This will do the following three things:
+- Update the void-packages repository to the latest commit on master
+- Patch the template file of D++ to enable coroutine support
+- Build an XBPS package for D++ and install it
+
+\note Cloning the void-packages repository may take some time
+
+\include{doc} coro_warn.dox


### PR DESCRIPTION
Added installation documentation for Void XBPS package manager

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
