### PR TITLE
feat: banners can now be uploaded to bots

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3259,13 +3259,15 @@ public:
 	 * Fires a `Guild Member Update` Gateway event.
 	 * @see https://discord.com/developers/docs/resources/user#modify-current-user
 	 * @param nickname Nickname to set
-	 * @param image_blob Avatar data to upload (NOTE: Very heavily rate limited!)
-	 * @param type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+	 * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+	 * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+	 * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+	 * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
 	 */
-	void current_user_edit(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png, command_completion_event_t callback = utility::log_error());
+	void current_user_edit(const std::string &nickname, const std::string& avatar_blob = "", const image_type avatar_type = i_png, const std::string& banner_blob = "", const image_type banner_type = i_png, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get current user DM channels

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3253,15 +3253,18 @@ public:
 	void current_user_get_guilds(command_completion_event_t callback);
 
 	/**
-	 * @brief Edit current (bot) user
+	 * @brief Edit current (bot) user.
 	 *
-	 * Modifies the current member in a guild. Returns the updated guild_member object on success.
-	 * Fires a `Guild Member Update` Gateway event.
+	 * Modify the requester's user account settings. Returns a dpp::user object on success.
+	 * Fires a User Update Gateway event.
+	 *
+	 * @note There appears to be no limit to the image size, however, if your image cannot be processed/uploaded in time, you will receive a malformed http request.
+	 *
 	 * @see https://discord.com/developers/docs/resources/user#modify-current-user
 	 * @param nickname Nickname to set
-	 * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+	 * @param avatar_blob Avatar data to upload
 	 * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
-	 * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+	 * @param banner_blob Banner data to upload
 	 * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::user object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -2253,13 +2253,15 @@
  * @see dpp::cluster::current_user_edit
  * @see https://discord.com/developers/docs/resources/user#modify-current-user
  * @param nickname Nickname to set
- * @param image_blob Avatar data to upload (NOTE: Very heavily rate limited!)
- * @param type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+ * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+ * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+ * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+ * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
  * @return user returned object on completion
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_current_user_edit(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png);
+[[nodiscard]] async<confirmation_callback_t> co_current_user_edit(const std::string &nickname, const std::string& avatar_blob = "", const image_type avatar_type = i_png, const std::string& banner_blob = "", const image_type banner_type = i_png);
 
 /**
  * @brief Get current (bot) application

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -2246,16 +2246,19 @@
 [[nodiscard]] async<confirmation_callback_t> co_thread_get(snowflake thread_id);
 
 /**
- * @brief Edit current (bot) user
+ * @brief Edit current (bot) user.
  *
- * Modifies the current member in a guild. Returns the updated guild_member object on success.
- * Fires a `Guild Member Update` Gateway event.
+ * Modify the requester's user account settings. Returns a dpp::user object on success.
+ * Fires a User Update Gateway event.
+ *
+ * @note There appears to be no limit to the image size, however, if your image cannot be processed/uploaded in time, you will receive a malformed http request.
+ *
  * @see dpp::cluster::current_user_edit
  * @see https://discord.com/developers/docs/resources/user#modify-current-user
  * @param nickname Nickname to set
- * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+ * @param avatar_blob Avatar data to upload
  * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
- * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+ * @param banner_blob Banner data to upload
  * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
  * @return user returned object on completion
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -2772,8 +2772,10 @@ thread thread_get_sync(snowflake thread_id);
  * @see dpp::cluster::current_user_edit
  * @see https://discord.com/developers/docs/resources/user#modify-current-user
  * @param nickname Nickname to set
- * @param image_blob Avatar data to upload (NOTE: Very heavily rate limited!)
- * @param type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+ * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+ * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
+ * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+ * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
  * @return user returned object on completion
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
  * \memberof dpp::cluster
@@ -2781,7 +2783,7 @@ thread thread_get_sync(snowflake thread_id);
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user current_user_edit_sync(const std::string &nickname, const std::string& image_blob = "", const image_type type = i_png);
+user current_user_edit_sync(const std::string &nickname, const std::string& avatar_blob = "", const image_type avatar_type = i_png, const std::string& banner_blob = "", const image_type banner_type = i_png);
 
 /**
  * @brief Get current (bot) application

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -2765,16 +2765,19 @@ confirmation thread_member_remove_sync(snowflake thread_id, snowflake user_id);
 thread thread_get_sync(snowflake thread_id);
 
 /**
- * @brief Edit current (bot) user
+ * @brief Edit current (bot) user.
  *
- * Modifies the current member in a guild. Returns the updated guild_member object on success.
- * Fires a `Guild Member Update` Gateway event.
+ * Modify the requester's user account settings. Returns a dpp::user object on success.
+ * Fires a User Update Gateway event.
+ *
+ * @note There appears to be no limit to the image size, however, if your image cannot be processed/uploaded in time, you will receive a malformed http request.
+ *
  * @see dpp::cluster::current_user_edit
  * @see https://discord.com/developers/docs/resources/user#modify-current-user
  * @param nickname Nickname to set
- * @param avatar_blob Avatar data to upload (NOTE: Very heavily rate limited!)
+ * @param avatar_blob Avatar data to upload
  * @param avatar_type Type of image for avatar. It can be one of `i_gif`, `i_jpg` or `i_png`.
- * @param banner_blob Banner data to upload (NOTE: Very heavily rate limited!)
+ * @param banner_blob Banner data to upload
  * @param banner_type Type of image for Banner. It can be one of `i_gif`, `i_jpg` or `i_png`.
  * @return user returned object on completion
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes

--- a/include/dpp/misc-enum.h
+++ b/include/dpp/misc-enum.h
@@ -28,7 +28,7 @@ namespace dpp {
 /**
  * @brief Supported image types for profile pictures and CDN endpoints
  */
-enum image_type {
+enum image_type : uint8_t {
 	/**
 	 * @brief image/png
 	 */

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -38,16 +38,10 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 	};
 
 	if (!avatar_blob.empty()) {
-		if (avatar_blob.size() > MAX_EMOJI_SIZE) {
-			throw dpp::length_exception(err_icon_size, "User icon file exceeds discord limit of 256 kilobytes");
-		}
 		j["avatar"] = "data:" + mimetypes.find(avatar_type)->second + ";base64," + base64_encode((unsigned char const*)avatar_blob.data(), static_cast<unsigned int>(avatar_blob.length()));
 	}
 
 	if (!banner_blob.empty()) {
-		if (banner_blob.size() > MAX_EMOJI_SIZE) {
-			throw dpp::length_exception(err_icon_size, "User banner file exceeds discord limit of 256 kilobytes");
-		}
 		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));
 	}
 

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -24,23 +24,32 @@
 
 namespace dpp {
 
-void cluster::current_user_edit(const std::string &nickname, const std::string& image_blob, const image_type type, command_completion_event_t callback) {
+void cluster::current_user_edit(const std::string &nickname, const std::string& avatar_blob, const image_type avatar_type, const std::string& banner_blob, const image_type banner_type, command_completion_event_t callback) {
 	json j = json::parse("{\"nickname\": null}");
 	if (!nickname.empty()) {
 		j["nickname"] = nickname;
 	}
-	if (!image_blob.empty()) {
-		static const std::map<image_type, std::string> mimetypes = {
-			{ i_gif, "image/gif" },
-			{ i_jpg, "image/jpeg" },
-			{ i_png, "image/png" },
-			{ i_webp, "image/webp" },
-		};
-		if (image_blob.size() > MAX_EMOJI_SIZE) {
+
+	static const std::map<image_type, std::string> mimetypes = {
+		{ i_gif, "image/gif" },
+		{ i_jpg, "image/jpeg" },
+		{ i_png, "image/png" },
+	};
+
+	if (!avatar_blob.empty()) {
+		if (avatar_blob.size() > MAX_EMOJI_SIZE) {
 			throw dpp::length_exception(err_icon_size, "User icon file exceeds discord limit of 256 kilobytes");
 		}
-		j["avatar"] = "data:" + mimetypes.find(type)->second + ";base64," + base64_encode((unsigned char const*)image_blob.data(), (unsigned int)image_blob.length());
+		j["avatar"] = "data:" + mimetypes.find(avatar_type)->second + ";base64," + base64_encode((unsigned char const*)avatar_blob.data(), static_cast<unsigned int>(avatar_blob.length()));
 	}
+
+	if (!banner_blob.empty()) {
+		if (avatar_blob.size() > MAX_EMOJI_SIZE) {
+			throw dpp::length_exception(err_icon_size, "User banner file exceeds discord limit of 256 kilobytes");
+		}
+		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));
+	}
+
 	rest_request<user>(this, API_PATH "/users", "@me", "", m_patch, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -34,6 +34,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 		{ i_gif, "image/gif" },
 		{ i_jpg, "image/jpeg" },
 		{ i_png, "image/png" },
+		{ i_webp, "image/webp" }, /* Whilst webp isn't supported (as of 13/07/24, UK date), best to keep this here for when Discord support webp */
 	};
 
 	if (!avatar_blob.empty()) {
@@ -44,7 +45,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 	}
 
 	if (!banner_blob.empty()) {
-		if (avatar_blob.size() > MAX_EMOJI_SIZE) {
+		if (banner_blob.size() > MAX_EMOJI_SIZE) {
 			throw dpp::length_exception(err_icon_size, "User banner file exceeds discord limit of 256 kilobytes");
 		}
 		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -747,8 +747,8 @@ async<confirmation_callback_t> cluster::co_thread_get(snowflake thread_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_get), thread_id };
 }
 
-async<confirmation_callback_t> cluster::co_current_user_edit(const std::string &nickname, const std::string& image_blob, const image_type type) {
-	return async{ this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type };
+async<confirmation_callback_t> cluster::co_current_user_edit(const std::string &nickname, const std::string& avatar_blob, const image_type avatar_type, const std::string& banner_blob, const image_type banner_type) {
+	return async{ this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, avatar_blob, avatar_type, banner_blob, banner_type };
 }
 
 async<confirmation_callback_t> cluster::co_current_application_get() {

--- a/src/dpp/cluster_sync_calls.cpp
+++ b/src/dpp/cluster_sync_calls.cpp
@@ -745,8 +745,8 @@ thread cluster::thread_get_sync(snowflake thread_id) {
 	return dpp::sync<thread>(this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::thread_get), thread_id);
 }
 
-user cluster::current_user_edit_sync(const std::string &nickname, const std::string& image_blob, const image_type type) {
-	return dpp::sync<user>(this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, image_blob, type);
+user cluster::current_user_edit_sync(const std::string &nickname, const std::string& avatar_blob, const image_type avatar_type, const std::string& banner_blob, const image_type banner_type) {
+	return dpp::sync<user>(this, static_cast<void (cluster::*)(const std::string &, const std::string&, const image_type, const std::string&, const image_type, command_completion_event_t)>(&cluster::current_user_edit), nickname, avatar_blob, avatar_type, banner_blob, banner_type);
 }
 
 application cluster::current_application_get_sync() {


### PR DESCRIPTION
This PR adds the ability to add banners to bots. I have also removed the limit imposed on avatars and banners as it seems the 256kb limit isn't true.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
