### PR TITLE
fix(test): fix ban unit tests to be dependent upon each other

### DIFF
--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -1751,10 +1751,10 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			set_test(GUILD_BANS_GET, false);
 			set_test(GUILD_BAN_DELETE, false);
 			if (!offline) {
-				// some deleted discord accounts to test the ban stuff with...
-				dpp::snowflake deadUser1(802670069523415057);
-				dpp::snowflake deadUser2(875302419335094292);
-				dpp::snowflake deadUser3(1048247361903792198);
+				// some discord accounts to test the ban stuff with...
+				dpp::snowflake deadUser1(155149108183695360); // Dyno
+				dpp::snowflake deadUser2(159985870458322944); // MEE6
+				dpp::snowflake deadUser3(936929561302675456); // MidJourney Bot
 
 				bot.set_audit_reason("ban reason one").guild_ban_add(TEST_GUILD_ID, deadUser1, 0, [deadUser1, deadUser2, deadUser3, &bot](const dpp::confirmation_callback_t &event) {
 					if (!event.is_error()) bot.guild_ban_add(TEST_GUILD_ID, deadUser2, 0, [deadUser1, deadUser2, deadUser3, &bot](const dpp::confirmation_callback_t &event) {
@@ -1766,47 +1766,50 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 							// when created, continue with getting and deleting
 
 							// get ban
-							bot.guild_get_ban(TEST_GUILD_ID, deadUser1, [deadUser1](const dpp::confirmation_callback_t &event) {
+							bot.guild_get_ban(TEST_GUILD_ID, deadUser1, [&bot, deadUser1, deadUser2, deadUser3](const dpp::confirmation_callback_t &event) {
 								if (!event.is_error()) {
 									dpp::ban ban = event.get<dpp::ban>();
 									if (ban.user_id == deadUser1 && ban.reason == "ban reason one") {
 										set_test(GUILD_BAN_GET, true);
+									} else {
+										set_test(GUILD_BAN_GET, false);
 									}
-								}
-							});
-
-							// get multiple bans
-							bot.guild_get_bans(TEST_GUILD_ID, 0, deadUser1, 3, [deadUser2, deadUser3](const dpp::confirmation_callback_t &event) {
-								if (!event.is_error()) {
-									dpp::ban_map bans = event.get<dpp::ban_map>();
-									int successCount = 0;
-									for (auto &ban: bans) {
-										if (ban.first == ban.second.user_id) { // the key should match the ban's user_id
-											if (ban.first == deadUser2 && ban.second.reason.empty()) {
-												successCount++;
-											} else if (ban.first == deadUser3 && ban.second.reason == "ban reason three") {
-												successCount++;
-											}
-										}
-									}
-									if (successCount == 2) {
-										set_test(GUILD_BANS_GET, true);
-									}
-								}
-							});
-
-							// unban them
-							bot.guild_ban_delete(TEST_GUILD_ID, deadUser1, [&bot, deadUser2, deadUser3](const dpp::confirmation_callback_t &event) {
-								if (!event.is_error()) {
-									bot.guild_ban_delete(TEST_GUILD_ID, deadUser2, [&bot, deadUser3](const dpp::confirmation_callback_t &event) {
+									// get multiple bans
+									bot.guild_get_bans(TEST_GUILD_ID, 0, deadUser1, 50, [&bot, deadUser1, deadUser2, deadUser3](const dpp::confirmation_callback_t &event) {
 										if (!event.is_error()) {
-											bot.guild_ban_delete(TEST_GUILD_ID, deadUser3, [](const dpp::confirmation_callback_t &event) {
+											auto bans = event.get<dpp::ban_map>();
+											set_test(
+												GUILD_BANS_GET,
+												bans.find(deadUser1) == bans.end()
+												&& bans.find(deadUser2) != bans.end()
+												&& bans.find(deadUser3) != bans.end()
+											);
+											// unban them
+											bot.guild_ban_delete(TEST_GUILD_ID, deadUser1, [&bot, deadUser1, deadUser2, deadUser3](const dpp::confirmation_callback_t &event) {
 												if (!event.is_error()) {
-													set_test(GUILD_BAN_DELETE, true);
+													bot.guild_ban_delete(TEST_GUILD_ID, deadUser2, [&bot, deadUser3](const dpp::confirmation_callback_t &event) {
+														if (!event.is_error()) {
+															bot.guild_ban_delete(TEST_GUILD_ID, deadUser3, [](const dpp::confirmation_callback_t &event) {
+																if (!event.is_error()) {
+																	set_test(GUILD_BAN_DELETE, true);
+																} else {
+																	set_test(GUILD_BAN_DELETE, false);
+																}
+															});
+														} else {
+															set_test(GUILD_BAN_DELETE, false);
+														}
+													});
+												} else {
+													set_test(GUILD_BAN_DELETE, false);
 												}
 											});
+										} else {
+											set_test(GUILD_BANS_GET, false);
 										}
 									});
+								} else {
+									set_test(GUILD_BAN_GET, false);
 								}
 							});
 						});

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -155,7 +155,7 @@ DPP_TEST(ERRORS, "Human readable error translation", tf_offline);
 DPP_TEST(INVALIDUTF8, "Invalid UTF-8 handling", tf_online);
 
 DPP_TEST(GUILD_EDIT, "cluster::guild_edit", tf_online);
-DPP_TEST(GUILD_BAN_CREATE, "cluster::guild_ban_add ban three deleted discord accounts", tf_online);
+DPP_TEST(GUILD_BAN_CREATE, "cluster::guild_ban_add ban three well-known discord accounts", tf_online);
 DPP_TEST(GUILD_BAN_GET, "cluster::guild_get_ban getting one of the banned accounts", tf_online);
 DPP_TEST(GUILD_BANS_GET, "cluster::guild_get_bans get bans using the after-parameter", tf_online);
 DPP_TEST(GUILD_BAN_DELETE, "cluster::guild_ban_delete unban the banned discord accounts", tf_online);


### PR DESCRIPTION
Fixes the ban set/unset/get unit tests to be properly dependent upon each other's callbacks (callback hell, yay) and also to use the IDs of valid users which should never be on a unit test server:

* MEE6
* Dyno
* MidJourney Bot

These 3 will remain valid for the forseeable future. using deleted user ids for bans is not a good idea, they eventually get purged and the side effects of adding bans for them is not doucmented behaviour.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
