### PR TITLE
fix(qol): shut up soundboard events

### DIFF
--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -406,6 +406,7 @@ static const std::map<std::string, dpp::events::event*> event_map = {
 	{ "GUILD_SOUNDBOARD_SOUND_CREATE", nullptr },
 	{ "GUILD_SOUNDBOARD_SOUND_DELETE", nullptr },
 	{ "GUILD_SOUNDBOARD_SOUNDS_UPDATE", nullptr },
+	{ "GUILD_SOUNDBOARD_SOUND_UPDATE", nullptr },
 	{ "VOICE_CHANNEL_STATUS_UPDATE", nullptr },
 	{ "GUILD_SCHEDULED_EVENT_CREATE", make_static_event<dpp::events::guild_scheduled_event_create>() },
 	{ "GUILD_SCHEDULED_EVENT_UPDATE", make_static_event<dpp::events::guild_scheduled_event_update>() },


### PR DESCRIPTION
yet another soundboard event that isnt documented that bots recieve. Discord, you need to document or silence this nonsense, there are about 6 soundboard events now!

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
