### PR TITLE
ci: Added a clang++15 osx job, fixed clang++14 job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup mold
         if: ${{ matrix.cfg.mold == 'yes' }}
-        uses: rui314/setup-mold@2e332a0b602c2fc65d2d3995941b1b29a5f554a0
+        uses: rui314/setup-mold@2e332a0b602c2fc65d2d3995941b1b29a5f554a0 # v1
 
       - name: Generate CMake
         run: cmake -B build -DDPP_NO_VCPKG=ON -DAVX_TYPE=AVX0 -DCMAKE_BUILD_TYPE=Release ${{matrix.cfg.cmake-flags}}
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
-          - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-14, cmake-flags: ''}
+          - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-15, cmake-flags: ''}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -127,6 +127,11 @@ jobs:
 
       - name: Checkout D++
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Update Xcode
+        uses: maxim-lobanov/setup-xcode@v60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '15.3'
 
       - name: Install homebrew packages
         run: brew install cmake make libsodium opus openssl pkg-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.cfg.xcode-version }}
 
+      - name: Clang Defines
+        run: clang++ -dM -E -x c /dev/null | grep __clang_m
+
       - name: Install homebrew packages
         run: brew install cmake make libsodium opus openssl pkg-config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Update Xcode
-        uses: maxim-lobanov/setup-xcode@v60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ matrix.cfg.xcode-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,6 @@ jobs:
         with:
           xcode-version: ${{ matrix.cfg.xcode-version }}
 
-      - name: Clang Defines
-        run: clang++ -dM -E -x c /dev/null | grep __clang_m
-
       - name: Install homebrew packages
         run: brew install cmake make libsodium opus openssl pkg-config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,8 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
-          - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-15, cmake-flags: ''}
+          - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-15, cmake-flags: '', xcode-version: '15.3' }
+          - { arch: 'x64', concurrency: 3, os: macos-latest, cpp-version: clang++-14, cmake-flags: '', xcode-version: '14.3.1' }
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -131,7 +132,7 @@ jobs:
       - name: Update Xcode
         uses: maxim-lobanov/setup-xcode@v60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: '15.3'
+          xcode-version: ${{ matrix.cfg.xcode-version }}
 
       - name: Install homebrew packages
         run: brew install cmake make libsodium opus openssl pkg-config


### PR DESCRIPTION
This PR changes our OSX runner to have `clang++14` and `clang++15` jobs, instead of only `clang++14`. This PR also fixes the `clang++14` job, where it was actually `clang++15`.

The `clang++15` job is using Xcode 15.3 to ensure that `std::format` is tested (as versions below don't have `std::format`), however, it should be noted that we **NEED** to enforce checks for `std::format` features to prevent Xcode 15.2 and lower versions breaking, otherwise we will be heavily breaking OSX support.