### PR TITLE
docs: Remove XBPS coroutine section

### DIFF
--- a/docpages/install/install-void-xbps.md
+++ b/docpages/install/install-void-xbps.md
@@ -16,28 +16,3 @@ g++ mybot.cpp -o mybot -ldpp
 ```
 
 \include{doc} install_prebuilt_footer.dox
-
-To build D++ with coroutine support as an XBPS package, follow the steps below. Ensure that [xbps-src is set up](https://github.com/void-linux/void-packages?tab=readme-ov-file#quick-start) beforehand:
-
-```bash
-# Inside the void-packages root folder
-git checkout master && git pull
-# Modifies the configure arguments to include coroutine support (-DDPP_CORO=ON)
-grep -q 'configure_args=.*-DDPP_CORO=ON' srcpkgs/dpp/template || sed -i -e 's/\(configure_args="[^"]*\)"/\1 -DDPP_CORO=ON"/' srcpkgs/dpp/template
-./xbps-src -K pkg dpp
-```
-
-Then as root:
-```bash
-# Inside the void-packages root folder
-xbps-install --repository hostdir/binpkgs dpp-devel
-```
-
-This will do the following three things:
-- Update the void-packages repository to the latest commit on master
-- Patch the template file of D++ to enable coroutine support
-- Build an XBPS package for D++ and install it
-
-\note Cloning the void-packages repository may take some time
-
-\include{doc} coro_warn.dox


### PR DESCRIPTION
Remove the manually compiling with coroutine support section due to [package](https://github.com/void-linux/void-packages/commit/ca76d8ce914a9cc23321f9ed86d1435e3675b07a) being default compiled with coroutine support enabled

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
