### PR TITLE
feat: timeout is now 20 seconds. Users can now change the timeout length

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -203,6 +203,11 @@ public:
 	std::condition_variable terminating;
 
 	/**
+	 * @brief The time (in seconds) that a request is allowed to take.
+	 */
+	uint16_t request_timeout = 10;
+
+	/**
 	 * @brief Constructor for creating a cluster. All but the token are optional.
 	 * @param token The bot token to use for all HTTP commands and websocket connections
 	 * @param intents A bitmask of dpd::intents values for all shards on this cluster. This is required to be sent for all bots with over 100 servers.
@@ -419,6 +424,15 @@ public:
 	 * @return shard_list& Reference to map of shards for this cluster
 	 */
 	const shard_list& get_shards();
+
+	/**
+	 * @brief Sets the request timeout.
+	 *
+	 * @param timeout The length of time (in seconds) that requests are allowed to take. Default: 20.
+	 *
+	 * @return cluster& Reference to self for chaining.
+	 */
+	cluster& set_request_timeout(uint16_t timeout);
 
 	/* Functions for attaching to event handlers */
 

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -205,7 +205,7 @@ public:
 	/**
 	 * @brief The time (in seconds) that a request is allowed to take.
 	 */
-	uint16_t request_timeout = 10;
+	uint16_t request_timeout = 20;
 
 	/**
 	 * @brief Constructor for creating a cluster. All but the token are optional.

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -296,8 +296,10 @@ public:
 
 	/**
 	 * @brief How many seconds before the connection is considered failed if not finished
+	 *
+	 * @deprecated Please now use dpp::cluster::request_timeout
 	 */
-	time_t request_timeout;
+	DPP_DEPRECATED("Please now use dpp::cluster::request_timeout") time_t request_timeout;
 
 	/**
 	 * @brief Constructor. When constructing one of these objects it should be passed to request_queue::post_request().

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -456,4 +456,9 @@ const shard_list& cluster::get_shards() {
 	return shards;
 }
 
+cluster& cluster::set_request_timeout(uint16_t timeout) {
+	request_timeout = timeout;
+	return *this;
+}
+
 };

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -176,7 +176,7 @@ http_request_completion_t http_request::run(cluster* owner) {
 	}
 	http_connect_info hci = https_client::get_host_info(_host);
 	try {
-		https_client cli(hci.hostname, hci.port, _url, request_verb[method], multipart.body, headers, !hci.is_ssl, request_timeout, protocol);
+		https_client cli(hci.hostname, hci.port, _url, request_verb[method], multipart.body, headers, !hci.is_ssl, owner->request_timeout, protocol);
 		rv.latency = dpp::utility::time_f() - start;
 		if (cli.timed_out) {
 			rv.error = h_connection;			


### PR DESCRIPTION
This PR changes the default request timeout to be 20 seconds. This PR also adds a function to `dpp::cluster` to allow users to change the timeout length if they wish.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
