### PR TITLE
feat: Added file size limit to avatars and banners

### DIFF
--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -28,6 +28,8 @@
 
 namespace dpp {
 
+constexpr uint32_t MAX_AVATAR_SIZE = 10240 * 1000; // 10240KB.
+
 /**
  * @brief Various bitmask flags used to represent information about a dpp::user
  */

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -38,7 +38,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 	};
 
 	if (!avatar_blob.empty()) {
-		if(avatar_blob.size() > (10240 * 1000)) { // Avatar limit is 10240 kb.
+		if(avatar_blob.size() > MAX_AVATAR_SIZE) { // Avatar limit is 10240 kb.
 			throw dpp::length_exception(err_icon_size, "Avatar file exceeds discord limit of 10240 kilobytes");
 		}
 		j["avatar"] = "data:" + mimetypes.find(avatar_type)->second + ";base64," + base64_encode((unsigned char const*)avatar_blob.data(), static_cast<unsigned int>(avatar_blob.length()));
@@ -48,7 +48,7 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 		/* There doesn't seem to be a banner limit (probably due to the limit of 640x280)
 		 * however, this is here as a precautionary.
 		 */
-		if(banner_blob.size() > (10240 * 1000)) {
+		if(banner_blob.size() > MAX_AVATAR_SIZE) {
 			throw dpp::length_exception(err_icon_size, "Banner file exceeds discord limit of 10240 kilobytes");
 		}
 		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -38,10 +38,19 @@ void cluster::current_user_edit(const std::string &nickname, const std::string& 
 	};
 
 	if (!avatar_blob.empty()) {
+		if(avatar_blob.size() > (10240 * 1000)) { // Avatar limit is 10240 kb.
+			throw dpp::length_exception(err_icon_size, "Avatar file exceeds discord limit of 10240 kilobytes");
+		}
 		j["avatar"] = "data:" + mimetypes.find(avatar_type)->second + ";base64," + base64_encode((unsigned char const*)avatar_blob.data(), static_cast<unsigned int>(avatar_blob.length()));
 	}
 
 	if (!banner_blob.empty()) {
+		/* There doesn't seem to be a banner limit (probably due to the limit of 640x280)
+		 * however, this is here as a precautionary.
+		 */
+		if(banner_blob.size() > (10240 * 1000)) {
+			throw dpp::length_exception(err_icon_size, "Banner file exceeds discord limit of 10240 kilobytes");
+		}
 		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));
 	}
 


### PR DESCRIPTION
This PR adds a file size limit to avatars and banners as Discord seemed to silently introduce an avatar file limit (either that or it's always been there and it wasn't properly working the other day).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
