### PR TITLE
refactor: readability changes to sslclient and wsclient

### DIFF
--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -32,7 +32,7 @@
 
 namespace dpp {
 
-static inline const std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, "
+static inline constexpr std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, "
                                                 + to_hex(DPP_VERSION_MAJOR, false) + "."
                                                 + to_hex(DPP_VERSION_MINOR, false) + "."
                                                 + to_hex(DPP_VERSION_PATCH, false) + ")";

--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -32,7 +32,7 @@
 
 namespace dpp {
 
-static inline constexpr std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, "
+static inline const std::string http_version = "DiscordBot (https://github.com/brainboxdotcc/DPP, "
                                                 + to_hex(DPP_VERSION_MAJOR, false) + "."
                                                 + to_hex(DPP_VERSION_MINOR, false) + "."
                                                 + to_hex(DPP_VERSION_PATCH, false) + ")";

--- a/include/dpp/sslclient.h
+++ b/include/dpp/sslclient.h
@@ -239,7 +239,7 @@ public:
 
 	/**
 	 * @brief Write to the output buffer.
-	 * @param data Data to be written to the buffer
+	 * @param data Data to be written to the buffer.
 	 * @note The data may not be written immediately and may be written at a later time to the socket.
 	 */
 	virtual void write(const std::string_view data);

--- a/include/dpp/sslclient.h
+++ b/include/dpp/sslclient.h
@@ -242,7 +242,7 @@ public:
 	 * @param data Data to be written to the buffer
 	 * @note The data may not be written immediately and may be written at a later time to the socket.
 	 */
-	virtual void write(const std::string &data);
+	virtual void write(const std::string_view data);
 
 	/**
 	 * @brief Close socket connection

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -37,7 +37,7 @@ enum websocket_protocol_t : uint8_t {
 	 * @brief JSON data, text, UTF-8 character set
 	 */
 	ws_json = 0,
-	
+
 	/**
 	 * @brief Erlang Term Format (ETF) binary protocol
 	 */
@@ -68,32 +68,32 @@ enum ws_opcode : uint8_t {
 	/**
 	 * @brief Continuation.
 	 */
-        OP_CONTINUATION = 0x00,
+	OP_CONTINUATION = 0x00,
 
 	/**
 	 * @brief Text frame.
 	 */
-        OP_TEXT = 0x01,
+	OP_TEXT = 0x01,
 
 	/**
 	 * @brief Binary frame.
 	 */
-        OP_BINARY = 0x02,
+	OP_BINARY = 0x02,
 
 	/**
 	 * @brief Close notification with close code.
 	 */
-        OP_CLOSE = 0x08,
+	OP_CLOSE = 0x08,
 
 	/**
 	 * @brief Low level ping.
 	 */
-        OP_PING = 0x09,
+	OP_PING = 0x09,
 
 	/**
 	 * @brief Low level pong.
 	 */
-        OP_PONG = 0x0a
+	OP_PONG = 0x0a
 };
 
 /**
@@ -130,7 +130,7 @@ class DPP_EXPORT websocket_client : public ssl_client {
 	 * @param buffer The buffer to operate on. Will modify the string removing completed items from the head of the queue
 	 * @return true if a complete header has been received
 	 */
-	bool parseheader(std::string &buffer);
+	bool parseheader(std::string& buffer);
 
 	/**
 	 * @brief Unpack a frame and pass completed frames up the stack.
@@ -139,7 +139,7 @@ class DPP_EXPORT websocket_client : public ssl_client {
 	 * @param first True if is the first element (reserved for future use)
 	 * @return true if a complete frame has been received
 	 */
-	bool unpack(std::string &buffer, uint32_t offset, bool first = true);
+	bool unpack(std::string& buffer, uint32_t offset, bool first = true);
 
 	/**
 	 * @brief Fill a header for outbound messages
@@ -154,7 +154,7 @@ class DPP_EXPORT websocket_client : public ssl_client {
 	 * @brief Handle ping requests.
 	 * @param payload The ping payload, to be returned as-is for a pong
 	 */
-	void handle_ping(const std::string &payload);
+	void handle_ping(const std::string& payload);
 
 protected:
 
@@ -167,7 +167,7 @@ protected:
 	 * @brief Get websocket state
 	 * @return websocket state
 	 */
-	ws_state get_state();
+	ws_state get_state() const;
 
 public:
 
@@ -180,41 +180,41 @@ public:
 	 * @note Voice websockets only support OP_TEXT, and other websockets must be
 	 * OP_BINARY if you are going to send ETF.
 	 */
-        websocket_client(const std::string &hostname, const std::string &port = "443", const std::string &urlpath = "", ws_opcode opcode = OP_BINARY);
+	websocket_client(const std::string& hostname, const std::string& port = "443", const std::string& urlpath = "", ws_opcode opcode = OP_BINARY);
 
 	/**
 	 * @brief Destroy the websocket client object
 	 */
-        virtual ~websocket_client() = default;
+	virtual ~websocket_client() = default;
 
 	/**
 	 * @brief Write to websocket. Encapsulates data in frames if the status is CONNECTED.
 	 * @param data The data to send.
 	 */
-        virtual void write(const std::string &data);
+	virtual void write(const std::string_view data);
 
 	/**
 	 * @brief Processes incoming frames from the SSL socket input buffer.
 	 * @param buffer The buffer contents. Can modify this value removing the head elements when processed.
 	 */
-        virtual bool handle_buffer(std::string &buffer);
+	virtual bool handle_buffer(std::string& buffer);
 
 	/**
 	 * @brief Close websocket
 	 */
-        virtual void close();
+	virtual void close();
 
 	/**
 	 * @brief Receives raw frame content only without headers
-	 * 
+	 *
 	 * @param buffer The buffer contents
 	 * @return True if the frame was successfully handled. False if no valid frame is in the buffer.
 	 */
-	virtual bool handle_frame(const std::string &buffer);
+	virtual bool handle_frame(const std::string& buffer);
 
 	/**
 	 * @brief Called upon error frame.
-	 * 
+	 *
 	 * @param errorcode The error code from the websocket server
 	 */
 	virtual void error(uint32_t errorcode);

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -23,8 +23,6 @@
 #include <dpp/export.h>
 #include <string>
 #include <map>
-#include <vector>
-#include <variant>
 #include <dpp/sslclient.h>
 
 namespace dpp {
@@ -167,7 +165,7 @@ protected:
 	 * @brief Get websocket state
 	 * @return websocket state
 	 */
-	ws_state get_state() const;
+	[[nodiscard]] ws_state get_state() const;
 
 public:
 

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -151,11 +151,10 @@ class DPP_EXPORT websocket_client : public ssl_client {
 	size_t fill_header(unsigned char* outbuf, size_t sendlength, ws_opcode opcode);
 
 	/**
-	 * @brief Handle ping and pong requests.
-	 * @param ping True if this is a ping, false if it is a pong 
-	 * @param payload The ping payload, to be returned as-is for a ping
+	 * @brief Handle ping requests.
+	 * @param payload The ping payload, to be returned as-is for a pong
 	 */
-	void handle_ping_pong(bool ping, const std::string &payload);
+	void handle_ping(const std::string &payload);
 
 protected:
 

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -123,7 +123,7 @@ thread_local std::unordered_map<std::string, keepalive_cache_t> keepalives;
  * SSL_read in non-blocking mode will only read 16k at a time. There's no point in a bigger buffer as
  * it'd go unused.
  */
-constexpr uint32_t DPP_BUFSIZE{16 * 1024};
+constexpr uint16_t DPP_BUFSIZE{16 * 1024};
 
 /* Represents a failed socket system call, e.g. connect() failure */
 constexpr int ERROR_STATUS{-1};

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -379,7 +379,7 @@ void ssl_client::connect()
 	}
 }
 
-void ssl_client::write(const std::string &data)
+void ssl_client::write(const std::string_view data)
 {
 	/* If we are in nonblocking mode, append to the buffer,
 	 * otherwise just use SSL_write directly. The only time we


### PR DESCRIPTION
This PR aims to make sslclient.cpp and wsclient.cpp more readable, making it easier to maintain. There are also a couple of extra improvements (moving from `#define` to `constexpr` for example).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
