### PR TITLE
docs: create Gentoo installation tutorial

### DIFF
--- a/docpages/03_installing.md
+++ b/docpages/03_installing.md
@@ -7,6 +7,7 @@ There are many ways to install D++, either from a package manager, or from sourc
 * \subpage install-vcpkg
 * \subpage install-arch-aur
 * \subpage install-void-xbps
+* \subpage install-gentoo-portage
 * \subpage install-windows-vs-zip
 * \subpage install-xmake
 * \subpage install-brew

--- a/docpages/install/install-gentoo-portage.md
+++ b/docpages/install/install-gentoo-portage.md
@@ -1,0 +1,27 @@
+\page install-gentoo-portage Installing with Portage (Gentoo)
+
+D++ is available on [GURU](https://wiki.gentoo.org/wiki/Project:GURU). To install D++, you must first enable the GURU repository.
+To do so, execute the following commands (as root):
+
+```bash
+emerge --ask app-eselect/eselect-repository
+eselect repository enable guru
+emaint sync --repo guru
+```
+
+This enables the GURU repository, which consists of user-contributed packages, such as D++!
+
+If you wish, you may enable coroutine and voice support through USE flags. To do so, using your text editor of choice, add the following line to `/etc/portage/package.use/dpp` (as root):
+
+```
+dev-cpp/dpp voice coro
+```
+> You may choose between voice, coro, or both, just pick and choose!
+
+You will now be able to use D++ by including its library on the command line:
+
+```bash
+g++ mybot.cpp -o mybot -ldpp
+```
+
+\include{doc} install_prebuilt_footer.dox


### PR DESCRIPTION
I'm one of the Gentoo maintainers for D++, so I decided to make a page on how to install it on Gentoo.

The tutorial explains how to enable GURU, how to install D++ using portage, how to enable voice and coro support, and finally how to build a bot using G++, as I noticed is the case with all other installation guides.

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
