### PR TITLE
docs: Change init to create

### DIFF
--- a/docpages/install/install-xmake.md
+++ b/docpages/install/install-xmake.md
@@ -3,7 +3,7 @@
 To install D++ on a project from XMake:
 
 - Ensure XMake [is correctly installed](https://xmake.io/#/guide/installation)
-- Create a new XMake project if you haven't already one, using `xmake init <project_name>`
+- Create a new XMake project if you haven't already one, using `xmake create <project_name>`
 - Update the `xmake.lua` file by adding the `dpp` package, below the minimum configuration:
 
 ~~~~~~~~~~~lua


### PR DESCRIPTION
In xmake, init doesn't (anymore?) exist, the new command for creating projects is create

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
