### PR TITLE
fix: incorrect comment

### DIFF
--- a/docpages/example_code/commandhandler.cpp
+++ b/docpages/example_code/commandhandler.cpp
@@ -35,7 +35,7 @@ int main() {
 			/* Command description */
 			"A test ping command",
 
-			/* Guild id (omit for a guild command) */
+			/* Guild id (omit for a global command) */
 			819556414099554344
 		);
 


### PR DESCRIPTION
Change incorrect comment in example code.

`omit for guild command` -> `omit for global command`

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
