### PR TITLE
fix: Improve compatiblity with socket

### DIFF
--- a/include/dpp/export.h
+++ b/include/dpp/export.h
@@ -46,7 +46,6 @@
 	#else
 		/* Including the library */
 		#ifdef _WIN32
-			#include <dpp/win32_safe_warnings.h>
 			#define DPP_EXPORT __declspec(dllimport)
 		#else
 			#define DPP_EXPORT
@@ -116,11 +115,7 @@ extern bool DPP_EXPORT validate_configuration();
 
 }
 
-#ifndef _WIN32
-	#ifndef SOCKET
-		#define SOCKET int
-	#endif
-#else
+#ifdef _WIN32
 	#ifndef NOMINMAX
 		#define NOMINMAX
 	#endif

--- a/include/dpp/export.h
+++ b/include/dpp/export.h
@@ -46,6 +46,7 @@
 	#else
 		/* Including the library */
 		#ifdef _WIN32
+			#include <dpp/win32_safe_warnings.h>
 			#define DPP_EXPORT __declspec(dllimport)
 		#else
 			#define DPP_EXPORT
@@ -116,11 +117,13 @@ extern bool DPP_EXPORT validate_configuration();
 }
 
 #ifndef _WIN32
-	#define SOCKET int
+	#ifndef SOCKET
+		#define SOCKET int
+	#endif
 #else
-  #ifndef NOMINMAX
-	  #define NOMINMAX
-  #endif
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
 
 	#include <WinSock2.h>
 #endif

--- a/include/dpp/socket.h
+++ b/include/dpp/socket.h
@@ -1,18 +1,16 @@
 #pragma once
 
-#ifndef _WIN32
-#ifndef SOCKET
-#define SOCKET int
-#endif
-#endif
-
 namespace dpp
 {
 	/**
 	 * @brief Represents a socket file descriptor.
 	 * This is used to ensure parity between windows and unix-like systems.
 	 */
-	typedef SOCKET socket;
+#ifndef _WIN32
+	using socket = int;
+#else
+	using socket = SOCKET;
+#endif
 } // namespace dpp
 
 #ifndef SOCKET_ERROR


### PR DESCRIPTION
This PR improves compatiblity with other projects that DPP is included into.

`#include <dpp/win32_safe_warnings.h>` is to prevent dll-interface warnings while compiling the main application.

`#ifndef SOCKET` is used to prevent possible incompatiblities with projects that already handle that case (such as network libraries). This way the socket will still be defined but only if it wasnt earlier.