### PR TITLE
fix: fix requests fizzling if the response doesn't contain Content-Length

### DIFF
--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -284,7 +284,7 @@ bool https_client::handle_buffer(std::string &buffer)
 			case HTTPS_CONTENT:
 				body += buffer;
 				buffer.clear();
-				if (body.length() >= content_length) {
+				if (content_length == ULLONG_MAX || body.length() >= content_length) {
 					state = HTTPS_DONE;
 					this->close();
 					return false;


### PR DESCRIPTION
Fixes the "try using 1.0 instead" issue, I believe

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
