### PR TITLE
feat: Change encryption to AEAD XChaCha20 Poly1305

### DIFF
--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -217,7 +217,7 @@ void from_json(const nlohmann::json& j, guild_member& gm) {
 std::string guild_member::get_avatar_url(uint16_t size, const image_type format, bool prefer_animated) const {
 	if (this->guild_id && this->user_id && !this->avatar.to_string().empty()) {
 		return utility::cdn_endpoint_url_hash({ i_jpg, i_png, i_webp, i_gif },
-			"guilds/" + std::to_string(this->guild_id) + "/" + std::to_string(this->user_id), this->avatar.to_string(),
+			"guilds/" + std::to_string(this->guild_id) + "/users/" + std::to_string(this->user_id) + "/avatars", this->avatar.to_string(),
 			format, size, prefer_animated, has_animated_guild_avatar());
 	} else {
 		return std::string();

--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -284,7 +284,7 @@ bool https_client::handle_buffer(std::string &buffer)
 			case HTTPS_CONTENT:
 				body += buffer;
 				buffer.clear();
-				if (body.length() >= content_length) {
+				if (content_length == ULLONG_MAX || body.length() >= content_length) {
 					state = HTTPS_DONE;
 					this->close();
 					return false;


### PR DESCRIPTION
This PR introduces `AEAD XChaCha20 Poly1305 (RTP Size)` as the encryption method for voice data.

`AEAD AES256-GCM (RTP Size)` will not be introduced in this PR as it is simply a suggestion (Discord declares it as a "preference", however, it's easier to just stick with `XChaCha20 Poly1305`) therefore, after discussions internally, we will stick with just `AEAD XChaCha20 Poly1305 (RTP Size)`

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
