### PR TITLE
fix: Added missing include to awaitable.h

### DIFF
--- a/include/dpp/coro/awaitable.h
+++ b/include/dpp/coro/awaitable.h
@@ -39,6 +39,7 @@ struct awaitable_dummy {
 
 // Do not include <coroutine> as coro.h includes <experimental/coroutine> or <coroutine> depending on clang version
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <type_traits>
 #include <exception>


### PR DESCRIPTION
Added missing include _optional_ to awaitable.h.
Required for line 140.

