### PR TITLE
Docs: Fix embeds.cpp not required intent + add cout logger

### DIFF
--- a/docpages/example_code/embeds.cpp
+++ b/docpages/example_code/embeds.cpp
@@ -2,7 +2,7 @@
 
 int main() {
 	/* Setup the bot */
-	dpp::cluster bot("token", dpp::i_default_intents);
+	dpp::cluster bot("token");
 
 	bot.on_log(dpp::utility::cout_logger());
 

--- a/docpages/example_code/embeds.cpp
+++ b/docpages/example_code/embeds.cpp
@@ -2,7 +2,9 @@
 
 int main() {
 	/* Setup the bot */
-	dpp::cluster bot("token", dpp::i_default_intents | dpp::i_message_content);
+	dpp::cluster bot("token", dpp::i_default_intents);
+
+	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
 	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {


### PR DESCRIPTION
Remove not required intent from code example.
Add cout logger as we have it in other examples

## Documentation change checklist

- [X] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [X] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [X] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [X] I have not generated content using AI or a desktop utility such as grammarly.
