### PR TITLE
refactor(deprecation): officially deprecate commandhandler

### DIFF
--- a/docpages/example_code/CMakeLists.txt
+++ b/docpages/example_code/CMakeLists.txt
@@ -33,7 +33,7 @@ project(documentation_tests)
 
 string(ASCII 27 Esc)
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDPP_CORO -std=c++20 -pthread -O0 -fPIC -rdynamic -DFMT_HEADER_ONLY -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDPP_CORO -std=c++20 -pthread -O0 -fPIC -rdynamic -DFMT_HEADER_ONLY -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -Wno-deprecated-declarations")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
 
 file(GLOB example_list ./*.cpp)

--- a/include/dpp/commandhandler.h
+++ b/include/dpp/commandhandler.h
@@ -253,7 +253,7 @@ struct DPP_EXPORT command_info_t {
  * functions.
  * @deprecated commandhandler and message commands are deprecated and dpp::slashcommand is encouraged as a replacement.
  */
-class DPP_EXPORT commandhandler {
+class DPP_EXPORT DPP_DEPRECATED("commandhandler should not be used. Plese consider using dpp::cluster::register_command instead.") commandhandler {
 private:
 	/**
 	 * @brief List of guild commands to bulk register

--- a/include/dpp/commandhandler.h
+++ b/include/dpp/commandhandler.h
@@ -253,7 +253,7 @@ struct DPP_EXPORT command_info_t {
  * functions.
  * @deprecated commandhandler and message commands are deprecated and dpp::slashcommand is encouraged as a replacement.
  */
-class DPP_EXPORT DPP_DEPRECATED("commandhandler should not be used. Plese consider using dpp::cluster::register_command instead.") commandhandler {
+class DPP_EXPORT DPP_DEPRECATED("commandhandler should not be used. Please consider using dpp::cluster::register_command instead.") commandhandler {
 private:
 	/**
 	 * @brief List of guild commands to bulk register


### PR DESCRIPTION
This officially deprecates `dpp::commandhandler`. This PR should be merged after or alongside #1262.

Schedule for removal is undefined, there are many bots still using this, and removing it entirely would break too much stuff, but deprecating it allows us to wash our hands of it, stop updating it, and refuse to support it directly.

This also closes #1199 as obsolete

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
