### PR TITLE
fix: client join/part re-derive client ratchets and privacy code

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -154,7 +154,6 @@ enum voice_websocket_opcode_t : uint8_t {
 	voice_opcode_connection_hello = 8,
 	voice_opcode_connection_resumed = 9,
 	voice_opcode_multiple_clients_connect = 11,
-	voice_opcode_client_connect = 12,
 	voice_opcode_client_disconnect = 13,
 	voice_opcode_media_sink = 15,
 	voice_client_flags = 18,
@@ -677,6 +676,12 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @throw dpp::voice_exception If data length to encode is invalid or voice support not compiled into D++
 	 */
 	size_t encode(uint8_t *input, size_t inDataSize, uint8_t *output, size_t &outDataSize);
+
+	/**
+	 * Updates DAVE MLS ratchets for users in the VC
+	 * @param force True to force updating of ratchets regardless of state
+	 */
+	void update_ratchets(bool force = false);
 
 public:
 

--- a/src/davetest/dave.cpp
+++ b/src/davetest/dave.cpp
@@ -71,6 +71,9 @@ int main() {
 		if (v && v->is_ready()) {
 			v->send_audio_raw((uint16_t*)testaudio.data(), testaudio.size());
 		}
+		dave_test.start_timer([v, &testaudio](auto) {
+			v->send_audio_raw((uint16_t*)testaudio.data(), testaudio.size());
+		}, 15);
 	});
 
 

--- a/src/dpp/dave/decryptor.cpp
+++ b/src/dpp/dave/decryptor.cpp
@@ -36,8 +36,7 @@ namespace dpp::dave {
 
 constexpr auto kStatsInterval = 10s;
 
-void decryptor::transition_to_key_ratchet(std::unique_ptr<key_ratchet_interface> keyRatchet,
-					  duration transitionExpiry)
+void decryptor::transition_to_key_ratchet(std::unique_ptr<key_ratchet_interface> keyRatchet, duration transitionExpiry)
 {
 	if (keyRatchet) {
 		creator.log(dpp::ll_trace, "Transitioning to new key ratchet, expiry: " + std::to_string(transitionExpiry.count()));

--- a/src/dpp/dave/session.cpp
+++ b/src/dpp/dave/session.cpp
@@ -365,9 +365,7 @@ catch (const std::exception& e) {
 	return failed_t{};
 }
 
-std::optional<roster_map> session::process_welcome(
-  std::vector<uint8_t> welcome,
-  std::set<std::string> const& recognizedUserIDs) noexcept
+std::optional<roster_map> session::process_welcome(std::vector<uint8_t> welcome, std::set<std::string> const& recognizedUserIDs) noexcept
 try {
 	if (!has_cryptographic_state_for_welcome()) {
 		creator.log(dpp::ll_warning, "Missing local crypto state necessary to process MLS welcome");

--- a/src/dpp/voice/enabled/displayable_code.cpp
+++ b/src/dpp/voice/enabled/displayable_code.cpp
@@ -31,6 +31,10 @@ namespace dpp {
 
 std::string generate_displayable_code(const std::vector<uint8_t> &data, size_t desired_length = 30, size_t group_size = 5) {
 
+	if (data.empty()) {
+		return "";
+	}
+
 	const size_t group_modulus = std::pow(10, group_size);
 	std::stringstream result;
 

--- a/src/dpp/voice/enabled/enabled.h
+++ b/src/dpp/voice/enabled/enabled.h
@@ -70,18 +70,60 @@
 
 namespace dpp {
 
+/**
+ * @brief A list of MLS decryptors for decrypting inbound audio from users by snowflake id
+ */
+using decryptor_list = std::map<snowflake, std::unique_ptr<dave::decryptor>>;
+
+/**
+ * @brief Holds all internal DAVE E2EE encryption state
+ */
 struct dave_state {
+	/**
+	 * @brief libdave session
+	 */
 	std::unique_ptr<dave::mls::session> dave_session{};
+	/**
+	 * @brief Our key package
+	 */
 	std::shared_ptr<::mlspp::SignaturePrivateKey> mls_key;
+	/**
+	 * @brief Cached commit package for use in welcome
+	 */
 	std::vector<uint8_t> cached_commit;
+	/**
+	 * @brief Current transition ID
+	 */
 	uint64_t transition_id{0};
+	/**
+	 * @brief Details of upcoming transition
+	 */
 	struct {
+		/**
+		 * @brief pending next transition ID
+		 */
 		uint64_t id{0};
+		/**
+		 * @brief New upcoming protocol version
+		 */
 		uint64_t protocol_version{0};
+		/**
+		 * @brief True if transition is pending
+		 */
 		bool is_pending{false};
 	} pending_transition;
-	std::map<dpp::snowflake, std::unique_ptr<dave::decryptor>> decryptors;
+	/**
+	 * @brief Decryptors for inbound audio streams
+	 */
+	decryptor_list decryptors;
+	/**
+	 * @brief Encryptor for outbound audio stream
+	 */
 	std::unique_ptr<dave::encryptor> encryptor;
+	/**
+	 * @brief Current privacy code, or empty string if
+	 * MLS group is not established.
+	 */
 	std::string privacy_code;
 };
 


### PR DESCRIPTION
Fixes re-derive of ratchets when users change in MLS group. Needs testing with multiple mls alts in vc.

Also fixes on_voice_ready not being emitted when bot is first in vc, with dave enabled, and new user joins vc with dave enabled.

For a future PR: Timeout on on_ready, so if no new user turns up within X seconds to a DAVE channel, we fire on_ready anyway.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
