### PR TITLE
fix: crash in threads_get_public_archived

### DIFF
--- a/src/dpp/thread.cpp
+++ b/src/dpp/thread.cpp
@@ -46,12 +46,14 @@ thread& thread::fill_from_json_impl(json* j) {
 	set_int8_not_null(j, "member_count", this->member_count);
 	set_bool_not_null(j, "newly_created", this->newly_created);
 
-	auto json_metadata = (*j)["thread_metadata"];
-	metadata.archived = bool_not_null(&json_metadata, "archived");
-	metadata.archive_timestamp = ts_not_null(&json_metadata, "archive_timestamp");
-	metadata.auto_archive_duration = int16_not_null(&json_metadata, "auto_archive_duration");
-	metadata.locked = bool_not_null(&json_metadata, "locked");
-	metadata.invitable = bool_not_null(&json_metadata, "invitable");
+	if (j->contains("thread_metadata")) {
+		auto json_metadata = (*j)["thread_metadata"];
+		metadata.archived = bool_not_null(&json_metadata, "archived");
+		metadata.archive_timestamp = ts_not_null(&json_metadata, "archive_timestamp");
+		metadata.auto_archive_duration = int16_not_null(&json_metadata, "auto_archive_duration");
+		metadata.locked = bool_not_null(&json_metadata, "locked");
+		metadata.invitable = bool_not_null(&json_metadata, "invitable");
+	}
 
 	/* Only certain events set this */
 	if (j->contains("member"))  {


### PR DESCRIPTION
threads_get_public_archived crashes as it does not contain thread_metadata, which is assumed present in `thread::fill_from_json_impl`

Fixes #1269 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
