### PR TITLE
fix: vcpkg is always built with voice

### DIFF
--- a/library-vcpkg/CMakeLists.txt
+++ b/library-vcpkg/CMakeLists.txt
@@ -18,12 +18,7 @@
 
 add_compile_definitions(HAVE_VOICE)
 
-if (HAVE_VOICE)
-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
-else()
-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/stub/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
-endif()
-
+file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
 
 set(LIB_NAME "${PROJECT_NAME}")
 
@@ -87,12 +82,10 @@ target_include_directories(
 	"$<INSTALL_INTERFACE:include>"
 )
 
-if (HAVE_VOICE)
-	add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
-	include_directories("${DPP_ROOT_PATH}/mlspp/include")
-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
-endif()
+add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
+include_directories("${DPP_ROOT_PATH}/mlspp/include")
+include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
+include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
 
 set_target_properties(
 	"${LIB_NAME}" PROPERTIES
@@ -120,17 +113,15 @@ target_link_libraries(
 	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
 )
 
-if (HAVE_VOICE)
-	# Private statically linked dependencies
-	target_link_libraries(
-		${LIB_NAME} PRIVATE
-		mlspp
-		mls_vectors
-		bytes
-		tls_syntax
-		hpke
-	)
-endif()
+# Private statically linked dependencies
+target_link_libraries(
+	${LIB_NAME} PRIVATE
+	mlspp
+	mls_vectors
+	bytes
+	tls_syntax
+	hpke
+)
 
 set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
 set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")


### PR DESCRIPTION
fix vcpkg build to enable voice at all times. it brings in the deps it needs so does not need to check theyre there.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
