### PR TITLE
refactor(breaking): Deprecate sync calls

### DIFF
--- a/buildtools/classes/Generator/SyncGenerator.php
+++ b/buildtools/classes/Generator/SyncGenerator.php
@@ -88,7 +88,7 @@ EOT;
      */
     public function generateHeaderDef(string $returnType, string $currentFunction, string $parameters, string $noDefaults, string $parameterTypes, string $parameterNames): string
     {
-        return "$returnType {$currentFunction}_sync($parameters);\n\n";
+        return "DPP_DEPRECATED(\"Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html\") $returnType {$currentFunction}_sync($parameters);\n\n";
     }
 
     /**
@@ -107,6 +107,7 @@ EOT;
         return [
             " * \memberof dpp::cluster",
             " * @throw dpp::rest_exception upon failure to execute REST function",
+            " * @deprecated This function is deprecated, please use coroutines instead.",
             " * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.",
             " * Avoid direct use of this function inside an event handler.",
         ];

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -38,10 +38,11 @@
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map global_bulk_command_create_sync(const std::vector<slashcommand> &commands);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map global_bulk_command_create_sync(const std::vector<slashcommand> &commands);
 
 /**
  * @brief Delete all existing global slash commands.
@@ -51,10 +52,11 @@ slashcommand_map global_bulk_command_create_sync(const std::vector<slashcommand>
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map global_bulk_command_delete_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map global_bulk_command_delete_sync();
 
 /**
  * @brief Create a global slash command (a bot can have a maximum of 100 of these).
@@ -65,10 +67,11 @@ slashcommand_map global_bulk_command_delete_sync();
  * @return slashcommand returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand global_command_create_sync(const slashcommand &s);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand global_command_create_sync(const slashcommand &s);
 
 /**
  * @brief Get a global slash command
@@ -79,10 +82,11 @@ slashcommand global_command_create_sync(const slashcommand &s);
  * @return slashcommand returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand global_command_get_sync(snowflake id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand global_command_get_sync(snowflake id);
 
 /**
  * @brief Delete a global slash command (a bot can have a maximum of 100 of these)
@@ -93,10 +97,11 @@ slashcommand global_command_get_sync(snowflake id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation global_command_delete_sync(snowflake id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation global_command_delete_sync(snowflake id);
 
 /**
  * @brief Edit a global slash command (a bot can have a maximum of 100 of these)
@@ -107,10 +112,11 @@ confirmation global_command_delete_sync(snowflake id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation global_command_edit_sync(const slashcommand &s);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation global_command_edit_sync(const slashcommand &s);
 
 /**
  * @brief Get the application's global slash commands
@@ -120,10 +126,11 @@ confirmation global_command_edit_sync(const slashcommand &s);
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map global_commands_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map global_commands_get_sync();
 
 /**
  * @brief Create/overwrite guild slash commands.
@@ -137,10 +144,11 @@ slashcommand_map global_commands_get_sync();
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map guild_bulk_command_create_sync(const std::vector<slashcommand> &commands, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map guild_bulk_command_create_sync(const std::vector<slashcommand> &commands, snowflake guild_id);
 
 /**
  * @brief Delete all existing guild slash commands.
@@ -151,10 +159,11 @@ slashcommand_map guild_bulk_command_create_sync(const std::vector<slashcommand> 
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map guild_bulk_command_delete_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map guild_bulk_command_delete_sync(snowflake guild_id);
 
 /**
  * @brief Get all slash command permissions of a guild
@@ -165,10 +174,11 @@ slashcommand_map guild_bulk_command_delete_sync(snowflake guild_id);
  * @return guild_command_permissions_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_command_permissions_map guild_commands_get_permissions_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_command_permissions_map guild_commands_get_permissions_sync(snowflake guild_id);
 
 /**
  * @brief Edit/Overwrite the permissions of all existing slash commands in a guild
@@ -184,10 +194,11 @@ guild_command_permissions_map guild_commands_get_permissions_sync(snowflake guil
  * @deprecated This has been disabled with updates to Permissions v2. You can use guild_command_edit_permissions instead
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_command_permissions_map guild_bulk_command_edit_permissions_sync(const std::vector<slashcommand> &commands, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_command_permissions_map guild_bulk_command_edit_permissions_sync(const std::vector<slashcommand> &commands, snowflake guild_id);
 
 /**
  * @brief Create a slash command local to a guild
@@ -200,10 +211,11 @@ guild_command_permissions_map guild_bulk_command_edit_permissions_sync(const std
  * @return slashcommand returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand guild_command_create_sync(const slashcommand &s, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand guild_command_create_sync(const slashcommand &s, snowflake guild_id);
 
 /**
  * @brief Delete a slash command local to a guild
@@ -215,10 +227,11 @@ slashcommand guild_command_create_sync(const slashcommand &s, snowflake guild_id
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_command_delete_sync(snowflake id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_command_delete_sync(snowflake id, snowflake guild_id);
 
 /**
  * @brief Edit slash command permissions of a guild
@@ -231,10 +244,11 @@ confirmation guild_command_delete_sync(snowflake id, snowflake guild_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_command_edit_permissions_sync(const slashcommand &s, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_command_edit_permissions_sync(const slashcommand &s, snowflake guild_id);
 
 /**
  * @brief Get a slash command of a guild
@@ -247,10 +261,11 @@ confirmation guild_command_edit_permissions_sync(const slashcommand &s, snowflak
  * @return slashcommand returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand guild_command_get_sync(snowflake id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand guild_command_get_sync(snowflake id, snowflake guild_id);
 
 /**
  * @brief Get the permissions for a slash command of a guild
@@ -262,10 +277,11 @@ slashcommand guild_command_get_sync(snowflake id, snowflake guild_id);
  * @return guild_command_permissions returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_command_permissions guild_command_get_permissions_sync(snowflake id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_command_permissions guild_command_get_permissions_sync(snowflake id, snowflake guild_id);
 
 /**
  * @brief Edit a slash command local to a guild
@@ -277,10 +293,11 @@ guild_command_permissions guild_command_get_permissions_sync(snowflake id, snowf
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_command_edit_sync(const slashcommand &s, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_command_edit_sync(const slashcommand &s, snowflake guild_id);
 
 /**
  * @brief Get the application's slash commands for a guild
@@ -292,10 +309,11 @@ confirmation guild_command_edit_sync(const slashcommand &s, snowflake guild_id);
  * @return slashcommand_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-slashcommand_map guild_commands_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") slashcommand_map guild_commands_get_sync(snowflake guild_id);
 
 /**
  * @brief Respond to a slash command
@@ -308,10 +326,11 @@ slashcommand_map guild_commands_get_sync(snowflake guild_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_response_create_sync(snowflake interaction_id, const std::string &token, const interaction_response &r);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_response_create_sync(snowflake interaction_id, const std::string &token, const interaction_response &r);
 
 /**
  * @brief Edit response to a slash command
@@ -323,10 +342,11 @@ confirmation interaction_response_create_sync(snowflake interaction_id, const st
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_response_edit_sync(const std::string &token, const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_response_edit_sync(const std::string &token, const message &m);
 
 /**
  * @brief Get the original response to a slash command
@@ -337,10 +357,11 @@ confirmation interaction_response_edit_sync(const std::string &token, const mess
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_response_get_original_sync(const std::string &token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message interaction_response_get_original_sync(const std::string &token);
 
 /**
  * @brief Create a followup message to a slash command
@@ -352,10 +373,11 @@ message interaction_response_get_original_sync(const std::string &token);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_create_sync(const std::string &token, const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_followup_create_sync(const std::string &token, const message &m);
 
 /**
  * @brief Edit original followup message to a slash command
@@ -368,10 +390,11 @@ confirmation interaction_followup_create_sync(const std::string &token, const me
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_edit_original_sync(const std::string &token, const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_followup_edit_original_sync(const std::string &token, const message &m);
 
 /**
  * @brief Delete the initial interaction response
@@ -382,10 +405,11 @@ confirmation interaction_followup_edit_original_sync(const std::string &token, c
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_delete_sync(const std::string &token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_followup_delete_sync(const std::string &token);
 
 /**
  * @brief Edit followup message to a slash command
@@ -398,10 +422,11 @@ confirmation interaction_followup_delete_sync(const std::string &token);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation interaction_followup_edit_sync(const std::string &token, const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation interaction_followup_edit_sync(const std::string &token, const message &m);
 
 /**
  * @brief Get the followup message to a slash command
@@ -413,10 +438,11 @@ confirmation interaction_followup_edit_sync(const std::string &token, const mess
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_followup_get_sync(const std::string &token, snowflake message_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message interaction_followup_get_sync(const std::string &token, snowflake message_id);
 
 /**
  * @brief Get the original followup message to a slash command
@@ -428,10 +454,11 @@ message interaction_followup_get_sync(const std::string &token, snowflake messag
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message interaction_followup_get_original_sync(const std::string &token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message interaction_followup_get_original_sync(const std::string &token);
 
 /**
  * @brief Get all auto moderation rules for a guild
@@ -440,10 +467,11 @@ message interaction_followup_get_original_sync(const std::string &token);
  * @return automod_rule_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-automod_rule_map automod_rules_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") automod_rule_map automod_rules_get_sync(snowflake guild_id);
 
 /**
  * @brief Get a single auto moderation rule
@@ -453,10 +481,11 @@ automod_rule_map automod_rules_get_sync(snowflake guild_id);
  * @return automod_rule returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-automod_rule automod_rule_get_sync(snowflake guild_id, snowflake rule_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") automod_rule automod_rule_get_sync(snowflake guild_id, snowflake rule_id);
 
 /**
  * @brief Create an auto moderation rule
@@ -466,10 +495,11 @@ automod_rule automod_rule_get_sync(snowflake guild_id, snowflake rule_id);
  * @return automod_rule returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-automod_rule automod_rule_create_sync(snowflake guild_id, const automod_rule& r);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") automod_rule automod_rule_create_sync(snowflake guild_id, const automod_rule& r);
 
 /**
  * @brief Edit an auto moderation rule
@@ -479,10 +509,11 @@ automod_rule automod_rule_create_sync(snowflake guild_id, const automod_rule& r)
  * @return automod_rule returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-automod_rule automod_rule_edit_sync(snowflake guild_id, const automod_rule& r);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") automod_rule automod_rule_edit_sync(snowflake guild_id, const automod_rule& r);
 
 /**
  * @brief Delete an auto moderation rule
@@ -492,10 +523,11 @@ automod_rule automod_rule_edit_sync(snowflake guild_id, const automod_rule& r);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation automod_rule_delete_sync(snowflake guild_id, snowflake rule_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation automod_rule_delete_sync(snowflake guild_id, snowflake rule_id);
 
 /**
  * @brief Create a channel
@@ -513,10 +545,11 @@ confirmation automod_rule_delete_sync(snowflake guild_id, snowflake rule_id);
  * @return channel returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel channel_create_sync(const class channel &c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel channel_create_sync(const class channel &c);
 
 /**
  * @brief Remove a permission from a channel
@@ -528,10 +561,11 @@ channel channel_create_sync(const class channel &c);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_delete_permission_sync(const class channel &c, snowflake overwrite_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_delete_permission_sync(const class channel &c, snowflake overwrite_id);
 
 /**
  * @brief Delete a channel
@@ -542,10 +576,11 @@ confirmation channel_delete_permission_sync(const class channel &c, snowflake ov
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_delete_sync(snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_delete_sync(snowflake channel_id);
 
 /**
  * @brief Edit a channel's permissions
@@ -561,10 +596,11 @@ confirmation channel_delete_sync(snowflake channel_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_edit_permissions_sync(const class channel &c, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_edit_permissions_sync(const class channel &c, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member);
 
 /**
  * @brief Edit a channel's permissions
@@ -580,10 +616,11 @@ confirmation channel_edit_permissions_sync(const class channel &c, const snowfla
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_edit_permissions_sync(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_edit_permissions_sync(const snowflake channel_id, const snowflake overwrite_id, const uint64_t allow, const uint64_t deny, const bool member);
 
 /**
  * @brief Edit multiple channels positions
@@ -598,10 +635,11 @@ confirmation channel_edit_permissions_sync(const snowflake channel_id, const sno
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_edit_positions_sync(const std::vector<channel> &c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_edit_positions_sync(const std::vector<channel> &c);
 
 /**
  * @brief Edit a channel
@@ -612,10 +650,11 @@ confirmation channel_edit_positions_sync(const std::vector<channel> &c);
  * @return channel returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel channel_edit_sync(const class channel &c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel channel_edit_sync(const class channel &c);
 
 /**
  * @brief Follow an announcement (news) channel
@@ -626,10 +665,11 @@ channel channel_edit_sync(const class channel &c);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_follow_news_sync(const class channel &c, snowflake target_channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_follow_news_sync(const class channel &c, snowflake target_channel_id);
 
 /**
  * @brief Get a channel
@@ -640,10 +680,11 @@ confirmation channel_follow_news_sync(const class channel &c, snowflake target_c
  * @return channel returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel channel_get_sync(snowflake c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel channel_get_sync(snowflake c);
 
 /**
  * @brief Create invite for a channel
@@ -655,10 +696,11 @@ channel channel_get_sync(snowflake c);
  * @return invite returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite channel_invite_create_sync(const class channel &c, const class invite &i);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite channel_invite_create_sync(const class channel &c, const class invite &i);
 
 /**
  * @brief Get invites for a channel
@@ -669,10 +711,11 @@ invite channel_invite_create_sync(const class channel &c, const class invite &i)
  * @return invite_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite_map channel_invites_get_sync(const class channel &c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite_map channel_invites_get_sync(const class channel &c);
 
 /**
  * @brief Trigger channel typing indicator
@@ -682,10 +725,11 @@ invite_map channel_invites_get_sync(const class channel &c);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_typing_sync(const class channel &c);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_typing_sync(const class channel &c);
 
 /**
  * @brief Trigger channel typing indicator
@@ -695,10 +739,11 @@ confirmation channel_typing_sync(const class channel &c);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_typing_sync(snowflake cid);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_typing_sync(snowflake cid);
 
 /**
  * @brief Get all channels for a guild
@@ -709,10 +754,11 @@ confirmation channel_typing_sync(snowflake cid);
  * @return channel_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel_map channels_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel_map channels_get_sync(snowflake guild_id);
 
 /**
  * @brief Set the status of a voice channel.
@@ -724,10 +770,11 @@ channel_map channels_get_sync(snowflake guild_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation channel_set_voice_status_sync(snowflake channel_id, const std::string& status);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation channel_set_voice_status_sync(snowflake channel_id, const std::string& status);
 
 /**
  * @brief Create a dm channel
@@ -737,10 +784,11 @@ confirmation channel_set_voice_status_sync(snowflake channel_id, const std::stri
  * @return channel returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel create_dm_channel_sync(snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel create_dm_channel_sync(snowflake user_id);
 
 /**
  * @brief Get current user DM channels
@@ -748,10 +796,11 @@ channel create_dm_channel_sync(snowflake user_id);
  * @return channel_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-channel_map current_user_get_dms_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") channel_map current_user_get_dms_sync();
 
 /**
  * @brief Create a direct message, also create the channel for the direct message if needed
@@ -765,10 +814,11 @@ channel_map current_user_get_dms_sync();
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message direct_message_create_sync(snowflake user_id, const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message direct_message_create_sync(snowflake user_id, const message &m);
 
 /**
  * @brief Adds a recipient to a Group DM using their access token
@@ -781,10 +831,11 @@ message direct_message_create_sync(snowflake user_id, const message &m);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation gdm_add_sync(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation gdm_add_sync(snowflake channel_id, snowflake user_id, const std::string &access_token, const std::string &nick);
 
 /**
  * @brief Removes a recipient from a Group DM
@@ -795,10 +846,11 @@ confirmation gdm_add_sync(snowflake channel_id, snowflake user_id, const std::st
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation gdm_remove_sync(snowflake channel_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation gdm_remove_sync(snowflake channel_id, snowflake user_id);
 
 /**
  * @brief Create single emoji.
@@ -812,10 +864,11 @@ confirmation gdm_remove_sync(snowflake channel_id, snowflake user_id);
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji guild_emoji_create_sync(snowflake guild_id, const class emoji& newemoji);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji guild_emoji_create_sync(snowflake guild_id, const class emoji& newemoji);
 
 /**
  * @brief Delete a guild emoji
@@ -828,10 +881,11 @@ emoji guild_emoji_create_sync(snowflake guild_id, const class emoji& newemoji);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_emoji_delete_sync(snowflake guild_id, snowflake emoji_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_emoji_delete_sync(snowflake guild_id, snowflake emoji_id);
 
 /**
  * @brief Edit a single emoji.
@@ -845,10 +899,11 @@ confirmation guild_emoji_delete_sync(snowflake guild_id, snowflake emoji_id);
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji guild_emoji_edit_sync(snowflake guild_id, const class emoji& newemoji);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji guild_emoji_edit_sync(snowflake guild_id, const class emoji& newemoji);
 
 /**
  * @brief Get a single emoji
@@ -860,10 +915,11 @@ emoji guild_emoji_edit_sync(snowflake guild_id, const class emoji& newemoji);
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji guild_emoji_get_sync(snowflake guild_id, snowflake emoji_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji guild_emoji_get_sync(snowflake guild_id, snowflake emoji_id);
 
 /**
  * @brief Get all emojis for a guild
@@ -874,10 +930,11 @@ emoji guild_emoji_get_sync(snowflake guild_id, snowflake emoji_id);
  * @return emoji_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji_map guild_emojis_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji_map guild_emojis_get_sync(snowflake guild_id);
 
 /**
  * @brief List all Application Emojis
@@ -887,10 +944,11 @@ emoji_map guild_emojis_get_sync(snowflake guild_id);
  * @return emoji_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji_map application_emojis_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji_map application_emojis_get_sync();
 
 /**
  * @brief Get an Application Emoji
@@ -901,10 +959,11 @@ emoji_map application_emojis_get_sync();
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji application_emoji_get_sync(snowflake emoji_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji application_emoji_get_sync(snowflake emoji_id);
 
 /**
  * @brief Create an Application Emoji
@@ -915,10 +974,11 @@ emoji application_emoji_get_sync(snowflake emoji_id);
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji application_emoji_create_sync(const class emoji& newemoji);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji application_emoji_create_sync(const class emoji& newemoji);
 
 /**
  * @brief Edit an Application Emoji
@@ -929,10 +989,11 @@ emoji application_emoji_create_sync(const class emoji& newemoji);
  * @return emoji returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji application_emoji_edit_sync(const class emoji& newemoji);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji application_emoji_edit_sync(const class emoji& newemoji);
 
 /**
  * @brief Delete an Application Emoji
@@ -943,10 +1004,11 @@ emoji application_emoji_edit_sync(const class emoji& newemoji);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation application_emoji_delete_sync(snowflake emoji_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation application_emoji_delete_sync(snowflake emoji_id);
 
 /**
  * @brief Returns all entitlements for a given app, active and expired.
@@ -963,10 +1025,11 @@ confirmation application_emoji_delete_sync(snowflake emoji_id);
  * @return entitlement_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-entitlement_map entitlements_get_sync(snowflake user_id = 0, const std::vector<snowflake>& sku_ids = {}, snowflake before_id = 0, snowflake after_id = 0, uint8_t limit = 100, snowflake guild_id = 0, bool exclude_ended = false);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") entitlement_map entitlements_get_sync(snowflake user_id = 0, const std::vector<snowflake>& sku_ids = {}, snowflake before_id = 0, snowflake after_id = 0, uint8_t limit = 100, snowflake guild_id = 0, bool exclude_ended = false);
 
 /**
  * @brief Creates a test entitlement to a given SKU for a given guild or user.
@@ -980,10 +1043,11 @@ entitlement_map entitlements_get_sync(snowflake user_id = 0, const std::vector<s
  * @return entitlement returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-entitlement entitlement_test_create_sync(const class entitlement& new_entitlement);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") entitlement entitlement_test_create_sync(const class entitlement& new_entitlement);
 
 /**
  * @brief Deletes a currently-active test entitlement.
@@ -995,10 +1059,11 @@ entitlement entitlement_test_create_sync(const class entitlement& new_entitlemen
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation entitlement_test_delete_sync(snowflake entitlement_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation entitlement_test_delete_sync(snowflake entitlement_id);
 
 /**
  * @brief For One-Time Purchase consumable SKUs, marks a given entitlement for the user as consumed.
@@ -1009,10 +1074,11 @@ confirmation entitlement_test_delete_sync(snowflake entitlement_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation entitlement_consume_sync(snowflake entitlement_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation entitlement_consume_sync(snowflake entitlement_id);
 
 /**
  * @brief Get the gateway information for the bot using the token
@@ -1021,10 +1087,11 @@ confirmation entitlement_consume_sync(snowflake entitlement_id);
  * @return gateway returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-gateway get_gateway_bot_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") gateway get_gateway_bot_sync();
 
 /**
  * @brief Modify current member
@@ -1040,10 +1107,11 @@ gateway get_gateway_bot_sync();
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_current_member_edit_sync(snowflake guild_id, const std::string &nickname);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_current_member_edit_sync(snowflake guild_id, const std::string &nickname);
 
 /**
  * @brief Get the audit log for a guild
@@ -1059,10 +1127,11 @@ confirmation guild_current_member_edit_sync(snowflake guild_id, const std::strin
  * @return auditlog returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-auditlog guild_auditlog_get_sync(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") auditlog guild_auditlog_get_sync(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit);
 
 /**
  * @brief Add guild ban
@@ -1078,10 +1147,11 @@ auditlog guild_auditlog_get_sync(snowflake guild_id, snowflake user_id, uint32_t
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_ban_add_sync(snowflake guild_id, snowflake user_id, uint32_t delete_message_seconds = 0);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_ban_add_sync(snowflake guild_id, snowflake user_id, uint32_t delete_message_seconds = 0);
 
 /**
  * @brief Delete guild ban
@@ -1096,10 +1166,11 @@ confirmation guild_ban_add_sync(snowflake guild_id, snowflake user_id, uint32_t 
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_ban_delete_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_ban_delete_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Create a guild
@@ -1122,10 +1193,11 @@ confirmation guild_ban_delete_sync(snowflake guild_id, snowflake user_id);
  * @return guild returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild guild_create_sync(const class guild &g);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild guild_create_sync(const class guild &g);
 
 /**
  * @brief Delete a guild
@@ -1138,10 +1210,11 @@ guild guild_create_sync(const class guild &g);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_delete_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_delete_sync(snowflake guild_id);
 
 /**
  * @brief Delete guild integration
@@ -1157,10 +1230,11 @@ confirmation guild_delete_sync(snowflake guild_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_delete_integration_sync(snowflake guild_id, snowflake integration_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_delete_integration_sync(snowflake guild_id, snowflake integration_id);
 
 /**
  * @brief Edit a guild
@@ -1175,10 +1249,11 @@ confirmation guild_delete_integration_sync(snowflake guild_id, snowflake integra
  * @return guild returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild guild_edit_sync(const class guild &g);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild guild_edit_sync(const class guild &g);
 
 /**
  * @brief Edit guild widget
@@ -1193,10 +1268,11 @@ guild guild_edit_sync(const class guild &g);
  * @return guild_widget returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_widget guild_edit_widget_sync(snowflake guild_id, const class guild_widget &gw);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_widget guild_edit_widget_sync(snowflake guild_id, const class guild_widget &gw);
 
 /**
  * @brief Get single guild ban
@@ -1209,10 +1285,11 @@ guild_widget guild_edit_widget_sync(snowflake guild_id, const class guild_widget
  * @return ban returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-ban guild_get_ban_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") ban guild_get_ban_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Get guild ban list
@@ -1228,13 +1305,14 @@ ban guild_get_ban_sync(snowflake guild_id, snowflake user_id);
  * @return ban_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-ban_map guild_get_bans_sync(snowflake guild_id, snowflake before, snowflake after, snowflake limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") ban_map guild_get_bans_sync(snowflake guild_id, snowflake before, snowflake after, snowflake limit);
 
 
-guild guild_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild guild_get_sync(snowflake guild_id);
 
 /**
  * @brief Get guild integrations
@@ -1249,13 +1327,14 @@ guild guild_get_sync(snowflake guild_id);
  * @note This endpoint returns a maximum of 50 integrations. If a guild has more integrations, they cannot be accessed.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-integration_map guild_get_integrations_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") integration_map guild_get_integrations_sync(snowflake guild_id);
 
 
-guild guild_get_preview_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild guild_get_preview_sync(snowflake guild_id);
 
 /**
  * @brief Get guild vanity url, if enabled
@@ -1267,10 +1346,11 @@ guild guild_get_preview_sync(snowflake guild_id);
  * @return invite returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite guild_get_vanity_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite guild_get_vanity_sync(snowflake guild_id);
 
 /**
  * @brief Get guild widget
@@ -1283,10 +1363,11 @@ invite guild_get_vanity_sync(snowflake guild_id);
  * @return guild_widget returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_widget guild_get_widget_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_widget guild_get_widget_sync(snowflake guild_id);
 
 /**
  * @brief Modify guild integration
@@ -1299,10 +1380,11 @@ guild_widget guild_get_widget_sync(snowflake guild_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_modify_integration_sync(snowflake guild_id, const class integration &i);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_modify_integration_sync(snowflake guild_id, const class integration &i);
 
 /**
  * @brief Get prune counts
@@ -1319,10 +1401,11 @@ confirmation guild_modify_integration_sync(snowflake guild_id, const class integ
  * @return prune returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-prune guild_get_prune_counts_sync(snowflake guild_id, const struct prune& pruneinfo);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") prune guild_get_prune_counts_sync(snowflake guild_id, const struct prune& pruneinfo);
 
 /**
  * @brief Begin guild prune
@@ -1341,10 +1424,11 @@ prune guild_get_prune_counts_sync(snowflake guild_id, const struct prune& prunei
  * @return prune returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-prune guild_begin_prune_sync(snowflake guild_id, const struct prune& pruneinfo);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") prune guild_begin_prune_sync(snowflake guild_id, const struct prune& pruneinfo);
 
 /**
  * @brief Change current user nickname
@@ -1361,10 +1445,11 @@ prune guild_begin_prune_sync(snowflake guild_id, const struct prune& pruneinfo);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_set_nickname_sync(snowflake guild_id, const std::string &nickname);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_set_nickname_sync(snowflake guild_id, const std::string &nickname);
 
 /**
  * @brief Sync guild integration
@@ -1376,10 +1461,11 @@ confirmation guild_set_nickname_sync(snowflake guild_id, const std::string &nick
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_sync_integration_sync(snowflake guild_id, snowflake integration_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_sync_integration_sync(snowflake guild_id, snowflake integration_id);
 
 /**
  * @brief Get the guild's onboarding configuration
@@ -1390,10 +1476,11 @@ confirmation guild_sync_integration_sync(snowflake guild_id, snowflake integrati
  * @return onboarding returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-onboarding guild_get_onboarding_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") onboarding guild_get_onboarding_sync(snowflake guild_id);
 
 /**
  * @brief Edit the guild's onboarding configuration
@@ -1409,10 +1496,11 @@ onboarding guild_get_onboarding_sync(snowflake guild_id);
  * @return onboarding returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-onboarding guild_edit_onboarding_sync(const struct onboarding& o);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") onboarding guild_edit_onboarding_sync(const struct onboarding& o);
 
 /**
  * @brief Get the guild's welcome screen
@@ -1425,10 +1513,11 @@ onboarding guild_edit_onboarding_sync(const struct onboarding& o);
  * @return dpp::welcome_screen returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dpp::welcome_screen guild_get_welcome_screen_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dpp::welcome_screen guild_get_welcome_screen_sync(snowflake guild_id);
 
 /**
  * @brief Edit the guild's welcome screen
@@ -1443,10 +1532,11 @@ dpp::welcome_screen guild_get_welcome_screen_sync(snowflake guild_id);
  * @return dpp::welcome_screen returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dpp::welcome_screen guild_edit_welcome_screen_sync(snowflake guild_id, const struct welcome_screen& welcome_screen, bool enabled);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dpp::welcome_screen guild_edit_welcome_screen_sync(snowflake guild_id, const struct welcome_screen& welcome_screen, bool enabled);
 
 /**
  * @brief Add guild member. Needs a specific oauth2 scope, from which you get the access_token.
@@ -1466,10 +1556,11 @@ dpp::welcome_screen guild_edit_welcome_screen_sync(snowflake guild_id, const str
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_add_member_sync(const guild_member& gm, const std::string &access_token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_add_member_sync(const guild_member& gm, const std::string &access_token);
 
 /**
  * @brief Edit the properties of an existing guild member
@@ -1485,10 +1576,11 @@ confirmation guild_add_member_sync(const guild_member& gm, const std::string &ac
  * @return guild_member returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member guild_edit_member_sync(const guild_member& gm);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_member guild_edit_member_sync(const guild_member& gm);
 
 /**
  * @brief Get a guild member
@@ -1499,10 +1591,11 @@ guild_member guild_edit_member_sync(const guild_member& gm);
  * @return guild_member returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member guild_get_member_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_member guild_get_member_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Get all guild members
@@ -1516,10 +1609,11 @@ guild_member guild_get_member_sync(snowflake guild_id, snowflake user_id);
  * @return guild_member_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member_map guild_get_members_sync(snowflake guild_id, uint16_t limit, snowflake after);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_member_map guild_get_members_sync(snowflake guild_id, uint16_t limit, snowflake after);
 
 /**
  * @brief Add role to guild member
@@ -1535,10 +1629,11 @@ guild_member_map guild_get_members_sync(snowflake guild_id, uint16_t limit, snow
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_add_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_add_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
 
 /**
  * @brief Remove (kick) a guild member
@@ -1554,10 +1649,11 @@ confirmation guild_member_add_role_sync(snowflake guild_id, snowflake user_id, s
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_delete_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_delete_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Remove (kick) a guild member
@@ -1572,10 +1668,11 @@ confirmation guild_member_delete_sync(snowflake guild_id, snowflake user_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_kick_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_kick_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Set the timeout of a guild member
@@ -1590,10 +1687,11 @@ confirmation guild_member_kick_sync(snowflake guild_id, snowflake user_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_timeout_sync(snowflake guild_id, snowflake user_id, time_t communication_disabled_until);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_timeout_sync(snowflake guild_id, snowflake user_id, time_t communication_disabled_until);
 
 /**
  * @brief Remove the timeout of a guild member.
@@ -1607,10 +1705,11 @@ confirmation guild_member_timeout_sync(snowflake guild_id, snowflake user_id, ti
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_timeout_remove_sync(snowflake guild_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_timeout_remove_sync(snowflake guild_id, snowflake user_id);
 
 /**
  * @brief Remove role from guild member
@@ -1627,10 +1726,11 @@ confirmation guild_member_timeout_remove_sync(snowflake guild_id, snowflake user
  * @deprecated Use dpp::cluster::guild_member_remove_role instead
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_delete_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_delete_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
 
 /**
  * @brief Remove role from guild member
@@ -1646,10 +1746,11 @@ confirmation guild_member_delete_role_sync(snowflake guild_id, snowflake user_id
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_member_remove_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_member_remove_role_sync(snowflake guild_id, snowflake user_id, snowflake role_id);
 
 /**
  * @brief Moves the guild member to a other voice channel, if member is connected to one.
@@ -1666,10 +1767,11 @@ confirmation guild_member_remove_role_sync(snowflake guild_id, snowflake user_id
  * @return guild_member returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member guild_member_move_sync(const snowflake channel_id, const snowflake guild_id, const snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_member guild_member_move_sync(const snowflake channel_id, const snowflake guild_id, const snowflake user_id);
 
 /**
  * @brief Search for guild members based on whether their username or nickname starts with the given string.
@@ -1683,10 +1785,11 @@ guild_member guild_member_move_sync(const snowflake channel_id, const snowflake 
  * @return guild_member_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_member_map guild_search_members_sync(snowflake guild_id, const std::string& query, uint16_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_member_map guild_search_members_sync(snowflake guild_id, const std::string& query, uint16_t limit);
 
 /**
  * @brief Get guild invites
@@ -1699,13 +1802,14 @@ guild_member_map guild_search_members_sync(snowflake guild_id, const std::string
  * @return invite_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite_map guild_get_invites_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite_map guild_get_invites_sync(snowflake guild_id);
 
 
-invite invite_delete_sync(const std::string &invitecode);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite invite_delete_sync(const std::string &invitecode);
 
 /**
  * @brief Get details about an invite
@@ -1716,10 +1820,11 @@ invite invite_delete_sync(const std::string &invitecode);
  * @return invite returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-invite invite_get_sync(const std::string &invite_code);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") invite invite_get_sync(const std::string &invite_code);
 
 /**
  * @brief Add a reaction to a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1731,10 +1836,11 @@ invite invite_get_sync(const std::string &invite_code);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_add_reaction_sync(const struct message &m, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_add_reaction_sync(const struct message &m, const std::string &reaction);
 
 /**
  * @brief Add a reaction to a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1747,10 +1853,11 @@ confirmation message_add_reaction_sync(const struct message &m, const std::strin
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_add_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_add_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
 
 /**
  * @brief Send a message to a channel. The callback function is called when the message has been sent
@@ -1761,10 +1868,11 @@ confirmation message_add_reaction_sync(snowflake message_id, snowflake channel_i
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message message_create_sync(const struct message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message message_create_sync(const struct message &m);
 
 /**
  * @brief Crosspost a message. The callback function is called when the message has been sent
@@ -1776,10 +1884,11 @@ message message_create_sync(const struct message &m);
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message message_crosspost_sync(snowflake message_id, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message message_crosspost_sync(snowflake message_id, snowflake channel_id);
 
 /**
  * @brief Delete all reactions on a message
@@ -1790,10 +1899,11 @@ message message_crosspost_sync(snowflake message_id, snowflake channel_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_all_reactions_sync(const struct message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_all_reactions_sync(const struct message &m);
 
 /**
  * @brief Delete all reactions on a message by id
@@ -1805,10 +1915,11 @@ confirmation message_delete_all_reactions_sync(const struct message &m);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_all_reactions_sync(snowflake message_id, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_all_reactions_sync(snowflake message_id, snowflake channel_id);
 
 /**
  * @brief Bulk delete messages from a channel. The callback function is called when the message has been edited
@@ -1823,10 +1934,11 @@ confirmation message_delete_all_reactions_sync(snowflake message_id, snowflake c
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_bulk_sync(const std::vector<snowflake> &message_ids, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_bulk_sync(const std::vector<snowflake> &message_ids, snowflake channel_id);
 
 /**
  * @brief Delete a message from a channel. The callback function is called when the message has been edited
@@ -1839,10 +1951,11 @@ confirmation message_delete_bulk_sync(const std::vector<snowflake> &message_ids,
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_sync(snowflake message_id, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_sync(snowflake message_id, snowflake channel_id);
 
 /**
  * @brief Delete own reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1854,10 +1967,11 @@ confirmation message_delete_sync(snowflake message_id, snowflake channel_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_own_reaction_sync(const struct message &m, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_own_reaction_sync(const struct message &m, const std::string &reaction);
 
 /**
  * @brief Delete own reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character.
@@ -1870,10 +1984,11 @@ confirmation message_delete_own_reaction_sync(const struct message &m, const std
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
 
 /**
  * @brief Delete a user's reaction from a message. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1886,10 +2001,11 @@ confirmation message_delete_own_reaction_sync(snowflake message_id, snowflake ch
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_sync(const struct message &m, snowflake user_id, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_reaction_sync(const struct message &m, snowflake user_id, const std::string &reaction);
 
 /**
  * @brief Delete a user's reaction from a message by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1903,10 +2019,11 @@ confirmation message_delete_reaction_sync(const struct message &m, snowflake use
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_reaction_sync(snowflake message_id, snowflake channel_id, snowflake user_id, const std::string &reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1918,10 +2035,11 @@ confirmation message_delete_reaction_sync(snowflake message_id, snowflake channe
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_emoji_sync(const struct message &m, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_reaction_emoji_sync(const struct message &m, const std::string &reaction);
 
 /**
  * @brief Delete all reactions on a message using a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1934,10 +2052,11 @@ confirmation message_delete_reaction_emoji_sync(const struct message &m, const s
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_delete_reaction_emoji_sync(snowflake message_id, snowflake channel_id, const std::string &reaction);
 
 /**
  * @brief Edit a message on a channel. The callback function is called when the message has been edited
@@ -1948,10 +2067,11 @@ confirmation message_delete_reaction_emoji_sync(snowflake message_id, snowflake 
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message message_edit_sync(const struct message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message message_edit_sync(const struct message &m);
 
 /**
  * @brief Edit the flags of a message on a channel. The callback function is called when the message has been edited
@@ -1960,10 +2080,11 @@ message message_edit_sync(const struct message &m);
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message message_edit_flags_sync(const struct message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message message_edit_flags_sync(const struct message &m);
 
 /**
  * @brief Get a message
@@ -1975,10 +2096,11 @@ message message_edit_flags_sync(const struct message &m);
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message message_get_sync(snowflake message_id, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message message_get_sync(snowflake message_id, snowflake channel_id);
 
 /**
  * @brief Get reactions on a message for a particular emoji. The reaction string must be either an `emojiname:id` or a unicode character
@@ -1993,10 +2115,11 @@ message message_get_sync(snowflake message_id, snowflake channel_id);
  * @return user_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_map message_get_reactions_sync(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_map message_get_reactions_sync(const struct message &m, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Get reactions on a message for a particular emoji by id. The reaction string must be either an `emojiname:id` or a unicode character
@@ -2012,10 +2135,11 @@ user_map message_get_reactions_sync(const struct message &m, const std::string &
  * @return emoji_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-emoji_map message_get_reactions_sync(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") emoji_map message_get_reactions_sync(snowflake message_id, snowflake channel_id, const std::string &reaction, snowflake before, snowflake after, snowflake limit);
 
 /**
  * @brief Pin a message
@@ -2027,10 +2151,11 @@ emoji_map message_get_reactions_sync(snowflake message_id, snowflake channel_id,
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_pin_sync(snowflake channel_id, snowflake message_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_pin_sync(snowflake channel_id, snowflake message_id);
 
 /**
  * @brief Get multiple messages.
@@ -2047,10 +2172,11 @@ confirmation message_pin_sync(snowflake channel_id, snowflake message_id);
  * @return message_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message_map messages_get_sync(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message_map messages_get_sync(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit);
 
 /**
  * @brief Unpin a message
@@ -2062,10 +2188,11 @@ message_map messages_get_sync(snowflake channel_id, snowflake around, snowflake 
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation message_unpin_sync(snowflake channel_id, snowflake message_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation message_unpin_sync(snowflake channel_id, snowflake message_id);
 
 /**
  * @brief Get a list of users that voted for this specific answer.
@@ -2079,10 +2206,11 @@ confirmation message_unpin_sync(snowflake channel_id, snowflake message_id);
  * @see https://discord.com/developers/docs/resources/poll#get-answer-voters
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_map poll_get_answer_voters_sync(const message& m, uint32_t answer_id, snowflake after, uint64_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_map poll_get_answer_voters_sync(const message& m, uint32_t answer_id, snowflake after, uint64_t limit);
 
 /**
  * @brief Get a list of users that voted for this specific answer.
@@ -2097,10 +2225,11 @@ user_map poll_get_answer_voters_sync(const message& m, uint32_t answer_id, snowf
  * @see https://discord.com/developers/docs/resources/poll#get-answer-voters
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_map poll_get_answer_voters_sync(snowflake message_id, snowflake channel_id, uint32_t answer_id, snowflake after, uint64_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_map poll_get_answer_voters_sync(snowflake message_id, snowflake channel_id, uint32_t answer_id, snowflake after, uint64_t limit);
 
 /**
  * @brief Immediately end a poll.
@@ -2111,10 +2240,11 @@ user_map poll_get_answer_voters_sync(snowflake message_id, snowflake channel_id,
  * @see https://discord.com/developers/docs/resources/poll#end-poll
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message poll_end_sync(const message &m);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message poll_end_sync(const message &m);
 
 /**
  * @brief Immediately end a poll.
@@ -2126,10 +2256,11 @@ message poll_end_sync(const message &m);
  * @see https://discord.com/developers/docs/resources/poll#end-poll
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message poll_end_sync(snowflake message_id, snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message poll_end_sync(snowflake message_id, snowflake channel_id);
 
 /**
  * @brief Get a channel's pins
@@ -2139,10 +2270,11 @@ message poll_end_sync(snowflake message_id, snowflake channel_id);
  * @return message_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message_map channel_pins_get_sync(snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message_map channel_pins_get_sync(snowflake channel_id);
 
 /**
  * @brief Create a role on a guild
@@ -2157,10 +2289,11 @@ message_map channel_pins_get_sync(snowflake channel_id);
  * @return role returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-role role_create_sync(const class role &r);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") role role_create_sync(const class role &r);
 
 /**
  * @brief Delete a role
@@ -2175,10 +2308,11 @@ role role_create_sync(const class role &r);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation role_delete_sync(snowflake guild_id, snowflake role_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation role_delete_sync(snowflake guild_id, snowflake role_id);
 
 /**
  * @brief Edit a role on a guild
@@ -2192,10 +2326,11 @@ confirmation role_delete_sync(snowflake guild_id, snowflake role_id);
  * @return role returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-role role_edit_sync(const class role &r);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") role role_edit_sync(const class role &r);
 
 /**
  * @brief Edit multiple role's position in a guild. Returns a list of all roles of the guild on success.
@@ -2211,10 +2346,11 @@ role role_edit_sync(const class role &r);
  * @return role_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-role_map roles_edit_position_sync(snowflake guild_id, const std::vector<role> &roles);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") role_map roles_edit_position_sync(snowflake guild_id, const std::vector<role> &roles);
 
 /**
  * @brief Get a role for a guild
@@ -2225,10 +2361,11 @@ role_map roles_edit_position_sync(snowflake guild_id, const std::vector<role> &r
  * @return role_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-role_map roles_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") role_map roles_get_sync(snowflake guild_id);
 
 /**
  * @brief Get the application's role connection metadata records
@@ -2239,10 +2376,11 @@ role_map roles_get_sync(snowflake guild_id);
  * @return application_role_connection returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-application_role_connection application_role_connection_get_sync(snowflake application_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") application_role_connection application_role_connection_get_sync(snowflake application_id);
 
 /**
  * @brief Update the application's role connection metadata records
@@ -2255,10 +2393,11 @@ application_role_connection application_role_connection_get_sync(snowflake appli
  * @note An application can have a maximum of 5 metadata records.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-application_role_connection application_role_connection_update_sync(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") application_role_connection application_role_connection_update_sync(snowflake application_id, const std::vector<application_role_connection_metadata> &connection_metadata);
 
 /**
  * @brief Get user application role connection
@@ -2269,10 +2408,11 @@ application_role_connection application_role_connection_update_sync(snowflake ap
  * @return application_role_connection returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-application_role_connection user_application_role_connection_get_sync(snowflake application_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") application_role_connection user_application_role_connection_get_sync(snowflake application_id);
 
 /**
  * @brief Update user application role connection
@@ -2284,10 +2424,11 @@ application_role_connection user_application_role_connection_get_sync(snowflake 
  * @return application_role_connection returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-application_role_connection user_application_role_connection_update_sync(snowflake application_id, const application_role_connection &connection);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") application_role_connection user_application_role_connection_update_sync(snowflake application_id, const application_role_connection &connection);
 
 /**
  * @brief Get all scheduled events for a guild
@@ -2297,10 +2438,11 @@ application_role_connection user_application_role_connection_update_sync(snowfla
  * @return scheduled_event_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-scheduled_event_map guild_events_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") scheduled_event_map guild_events_get_sync(snowflake guild_id);
 
 /**
  * @brief Create a scheduled event on a guild
@@ -2311,10 +2453,11 @@ scheduled_event_map guild_events_get_sync(snowflake guild_id);
  * @return scheduled_event returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-scheduled_event guild_event_create_sync(const scheduled_event& event);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") scheduled_event guild_event_create_sync(const scheduled_event& event);
 
 /**
  * @brief Delete a scheduled event from a guild
@@ -2326,10 +2469,11 @@ scheduled_event guild_event_create_sync(const scheduled_event& event);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_event_delete_sync(snowflake event_id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_event_delete_sync(snowflake event_id, snowflake guild_id);
 
 /**
  * @brief Edit/modify a scheduled event on a guild
@@ -2340,10 +2484,11 @@ confirmation guild_event_delete_sync(snowflake event_id, snowflake guild_id);
  * @return scheduled_event returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-scheduled_event guild_event_edit_sync(const scheduled_event& event);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") scheduled_event guild_event_edit_sync(const scheduled_event& event);
 
 /**
  * @brief Get a scheduled event for a guild
@@ -2355,10 +2500,11 @@ scheduled_event guild_event_edit_sync(const scheduled_event& event);
  * @return scheduled_event returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-scheduled_event guild_event_get_sync(snowflake guild_id, snowflake event_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") scheduled_event guild_event_get_sync(snowflake guild_id, snowflake event_id);
 
 /**
  * @brief Returns all SKUs for a given application.
@@ -2370,13 +2516,14 @@ scheduled_event guild_event_get_sync(snowflake guild_id, snowflake event_id);
  * @return sku_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sku_map skus_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sku_map skus_get_sync();
 
 
-stage_instance stage_instance_create_sync(const stage_instance& si);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") stage_instance stage_instance_create_sync(const stage_instance& si);
 
 /**
  * @brief Get the stage instance associated with the channel id, if it exists.
@@ -2386,13 +2533,14 @@ stage_instance stage_instance_create_sync(const stage_instance& si);
  * @return stage_instance returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-stage_instance stage_instance_get_sync(const snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") stage_instance stage_instance_get_sync(const snowflake channel_id);
 
 
-stage_instance stage_instance_edit_sync(const stage_instance& si);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") stage_instance stage_instance_edit_sync(const stage_instance& si);
 
 /**
  * @brief Delete a stage instance.
@@ -2403,10 +2551,11 @@ stage_instance stage_instance_edit_sync(const stage_instance& si);
  * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation stage_instance_delete_sync(const snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation stage_instance_delete_sync(const snowflake channel_id);
 
 /**
  * @brief Create a sticker in a guild
@@ -2417,10 +2566,11 @@ confirmation stage_instance_delete_sync(const snowflake channel_id);
  * @return sticker returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker guild_sticker_create_sync(const sticker &s);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker guild_sticker_create_sync(const sticker &s);
 
 /**
  * @brief Delete a sticker from a guild
@@ -2432,10 +2582,11 @@ sticker guild_sticker_create_sync(const sticker &s);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_sticker_delete_sync(snowflake sticker_id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_sticker_delete_sync(snowflake sticker_id, snowflake guild_id);
 
 /**
  * @brief Get a guild sticker
@@ -2446,10 +2597,11 @@ confirmation guild_sticker_delete_sync(snowflake sticker_id, snowflake guild_id)
  * @return sticker returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker guild_sticker_get_sync(snowflake id, snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker guild_sticker_get_sync(snowflake id, snowflake guild_id);
 
 /**
  * @brief Modify a sticker in a guild
@@ -2460,10 +2612,11 @@ sticker guild_sticker_get_sync(snowflake id, snowflake guild_id);
  * @return sticker returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker guild_sticker_modify_sync(const sticker &s);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker guild_sticker_modify_sync(const sticker &s);
 
 /**
  * @brief Get all guild stickers
@@ -2473,10 +2626,11 @@ sticker guild_sticker_modify_sync(const sticker &s);
  * @return sticker_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker_map guild_stickers_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker_map guild_stickers_get_sync(snowflake guild_id);
 
 /**
  * @brief Get a nitro sticker
@@ -2486,10 +2640,11 @@ sticker_map guild_stickers_get_sync(snowflake guild_id);
  * @return sticker returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker nitro_sticker_get_sync(snowflake id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker nitro_sticker_get_sync(snowflake id);
 
 /**
  * @brief Get a list of available sticker packs
@@ -2498,10 +2653,11 @@ sticker nitro_sticker_get_sync(snowflake id);
  * @return sticker_pack_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-sticker_pack_map sticker_packs_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") sticker_pack_map sticker_packs_get_sync();
 
 /**
  * @brief Create a new guild based on a template.
@@ -2513,10 +2669,11 @@ sticker_pack_map sticker_packs_get_sync();
  * @return guild returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild guild_create_from_template_sync(const std::string &code, const std::string &name);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild guild_create_from_template_sync(const std::string &code, const std::string &name);
 
 /**
  * @brief Creates a template for the guild
@@ -2529,10 +2686,11 @@ guild guild_create_from_template_sync(const std::string &code, const std::string
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_create_sync(snowflake guild_id, const std::string &name, const std::string &description);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dtemplate guild_template_create_sync(snowflake guild_id, const std::string &name, const std::string &description);
 
 /**
  * @brief Deletes the template
@@ -2544,10 +2702,11 @@ dtemplate guild_template_create_sync(snowflake guild_id, const std::string &name
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation guild_template_delete_sync(snowflake guild_id, const std::string &code);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation guild_template_delete_sync(snowflake guild_id, const std::string &code);
 
 /**
  * @brief Modifies the template's metadata.
@@ -2561,10 +2720,11 @@ confirmation guild_template_delete_sync(snowflake guild_id, const std::string &c
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_modify_sync(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dtemplate guild_template_modify_sync(snowflake guild_id, const std::string &code, const std::string &name, const std::string &description);
 
 /**
  * @brief Get guild templates
@@ -2575,10 +2735,11 @@ dtemplate guild_template_modify_sync(snowflake guild_id, const std::string &code
  * @return dtemplate_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate_map guild_templates_get_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dtemplate_map guild_templates_get_sync(snowflake guild_id);
 
 /**
  * @brief Syncs the template to the guild's current state.
@@ -2590,10 +2751,11 @@ dtemplate_map guild_templates_get_sync(snowflake guild_id);
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate guild_template_sync_sync(snowflake guild_id, const std::string &code);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dtemplate guild_template_sync_sync(snowflake guild_id, const std::string &code);
 
 /**
  * @brief Get a template
@@ -2603,10 +2765,11 @@ dtemplate guild_template_sync_sync(snowflake guild_id, const std::string &code);
  * @return dtemplate returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-dtemplate template_get_sync(const std::string &code);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") dtemplate template_get_sync(const std::string &code);
 
 /**
  * @brief Join a thread
@@ -2616,10 +2779,11 @@ dtemplate template_get_sync(const std::string &code);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation current_user_join_thread_sync(snowflake thread_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation current_user_join_thread_sync(snowflake thread_id);
 
 /**
  * @brief Leave a thread
@@ -2629,10 +2793,11 @@ confirmation current_user_join_thread_sync(snowflake thread_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation current_user_leave_thread_sync(snowflake thread_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation current_user_leave_thread_sync(snowflake thread_id);
 
 /**
  * @brief Get all active threads in the guild, including public and private threads. Threads are ordered by their id, in descending order.
@@ -2642,10 +2807,11 @@ confirmation current_user_leave_thread_sync(snowflake thread_id);
  * @return active_threads returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-active_threads threads_get_active_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") active_threads threads_get_active_sync(snowflake guild_id);
 
 /**
  * @brief Get private archived threads in a channel which current user has joined (Sorted by ID in descending order)
@@ -2657,10 +2823,11 @@ active_threads threads_get_active_sync(snowflake guild_id);
  * @return thread_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread_map threads_get_joined_private_archived_sync(snowflake channel_id, snowflake before_id, uint16_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread_map threads_get_joined_private_archived_sync(snowflake channel_id, snowflake before_id, uint16_t limit);
 
 /**
  * @brief Get private archived threads in a channel (Sorted by archive_timestamp in descending order)
@@ -2672,10 +2839,11 @@ thread_map threads_get_joined_private_archived_sync(snowflake channel_id, snowfl
  * @return thread_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread_map threads_get_private_archived_sync(snowflake channel_id,  time_t before_timestamp, uint16_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread_map threads_get_private_archived_sync(snowflake channel_id,  time_t before_timestamp, uint16_t limit);
 
 /**
  * @brief Get public archived threads in a channel (Sorted by archive_timestamp in descending order)
@@ -2687,10 +2855,11 @@ thread_map threads_get_private_archived_sync(snowflake channel_id,  time_t befor
  * @return thread_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread_map threads_get_public_archived_sync(snowflake channel_id, time_t before_timestamp, uint16_t limit);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread_map threads_get_public_archived_sync(snowflake channel_id, time_t before_timestamp, uint16_t limit);
 
 /**
  * @brief Get a thread member
@@ -2701,10 +2870,11 @@ thread_map threads_get_public_archived_sync(snowflake channel_id, time_t before_
  * @return thread_member returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread_member thread_member_get_sync(const snowflake thread_id, const snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread_member thread_member_get_sync(const snowflake thread_id, const snowflake user_id);
 
 /**
  * @brief Get members of a thread
@@ -2714,10 +2884,11 @@ thread_member thread_member_get_sync(const snowflake thread_id, const snowflake 
  * @return thread_member_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread_member_map thread_members_get_sync(snowflake thread_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread_member_map thread_members_get_sync(snowflake thread_id);
 
 /**
  * @brief Create a thread in a forum or media channel
@@ -2734,10 +2905,11 @@ thread_member_map thread_members_get_sync(snowflake thread_id);
  * @return thread returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_in_forum_sync(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread thread_create_in_forum_sync(const std::string& thread_name, snowflake channel_id, const message& msg, auto_archive_duration_t auto_archive_duration, uint16_t rate_limit_per_user, std::vector<snowflake> applied_tags = {});
 
 /**
  * @brief Create a thread
@@ -2754,10 +2926,11 @@ thread thread_create_in_forum_sync(const std::string& thread_name, snowflake cha
  * @return thread returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_sync(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread thread_create_sync(const std::string& thread_name, snowflake channel_id, uint16_t auto_archive_duration, channel_type thread_type, bool invitable, uint16_t rate_limit_per_user);
 
 /**
  * @brief Edit a thread
@@ -2769,10 +2942,11 @@ thread thread_create_sync(const std::string& thread_name, snowflake channel_id, 
  * @return thread returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_edit_sync(const thread &t);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread thread_edit_sync(const thread &t);
 
 /**
  * @brief Create a thread with a message (Discord: ID of a thread is same as message ID)
@@ -2787,10 +2961,11 @@ thread thread_edit_sync(const thread &t);
  * @return thread returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_create_with_message_sync(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread thread_create_with_message_sync(const std::string& thread_name, snowflake channel_id, snowflake message_id, uint16_t auto_archive_duration, uint16_t rate_limit_per_user);
 
 /**
  * @brief Add a member to a thread
@@ -2801,10 +2976,11 @@ thread thread_create_with_message_sync(const std::string& thread_name, snowflake
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation thread_member_add_sync(snowflake thread_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation thread_member_add_sync(snowflake thread_id, snowflake user_id);
 
 /**
  * @brief Remove a member from a thread
@@ -2815,10 +2991,11 @@ confirmation thread_member_add_sync(snowflake thread_id, snowflake user_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation thread_member_remove_sync(snowflake thread_id, snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation thread_member_remove_sync(snowflake thread_id, snowflake user_id);
 
 /**
  * @brief Get the thread specified by thread_id. This uses the same call as dpp::cluster::channel_get but returns a thread object.
@@ -2828,10 +3005,11 @@ confirmation thread_member_remove_sync(snowflake thread_id, snowflake user_id);
  * @return thread returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-thread thread_get_sync(snowflake thread_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") thread thread_get_sync(snowflake thread_id);
 
 /**
  * @brief Edit current (bot) user.
@@ -2852,10 +3030,11 @@ thread thread_get_sync(snowflake thread_id);
  	 * @throw dpp::length_exception Image data is larger than the maximum size of 256 kilobytes
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user current_user_edit_sync(const std::string &nickname, const std::string& avatar_blob = "", const image_type avatar_type = i_png, const std::string& banner_blob = "", const image_type banner_type = i_png);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user current_user_edit_sync(const std::string &nickname, const std::string& avatar_blob = "", const image_type avatar_type = i_png, const std::string& banner_blob = "", const image_type banner_type = i_png);
 
 /**
  * @brief Get current (bot) application
@@ -2865,10 +3044,11 @@ user current_user_edit_sync(const std::string &nickname, const std::string& avat
  * @return application returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-application current_application_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") application current_application_get_sync();
 
 /**
  * @brief Get current (bot) user
@@ -2880,10 +3060,11 @@ application current_application_get_sync();
  * If you do not have these scopes, these fields are empty. You can safely convert a user_identified to user with `dynamic_cast`.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_identified current_user_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_identified current_user_get_sync();
 
 /**
  * @brief Set the bot's voice state on a stage channel
@@ -2908,10 +3089,11 @@ user_identified current_user_get_sync();
  * @throw std::logic_exception You attempted to set a request_to_speak_timestamp in the past which is not the value of 0.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation current_user_set_voice_state_sync(snowflake guild_id, snowflake channel_id, bool suppress = false, time_t request_to_speak_timestamp = 0);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation current_user_set_voice_state_sync(snowflake guild_id, snowflake channel_id, bool suppress = false, time_t request_to_speak_timestamp = 0);
 
 /**
  * @brief Set a user's voice state on a stage channel
@@ -2935,10 +3117,11 @@ confirmation current_user_set_voice_state_sync(snowflake guild_id, snowflake cha
  * @param suppress True if the user's audio should be suppressed, false if it should not
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation user_set_voice_state_sync(snowflake user_id, snowflake guild_id, snowflake channel_id, bool suppress = false);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation user_set_voice_state_sync(snowflake user_id, snowflake guild_id, snowflake channel_id, bool suppress = false);
 
 /**
  * @brief Get current user's connections (linked accounts, e.g. steam, xbox).
@@ -2949,10 +3132,11 @@ confirmation user_set_voice_state_sync(snowflake user_id, snowflake guild_id, sn
  * @return connection_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-connection_map current_user_connections_get_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") connection_map current_user_connections_get_sync();
 
 /**
  * @brief Get current (bot) user guilds
@@ -2961,10 +3145,11 @@ connection_map current_user_connections_get_sync();
  * @return guild_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-guild_map current_user_get_guilds_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") guild_map current_user_get_guilds_sync();
 
 /**
  * @brief Leave a guild
@@ -2974,10 +3159,11 @@ guild_map current_user_get_guilds_sync();
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation current_user_leave_guild_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation current_user_leave_guild_sync(snowflake guild_id);
 
 /**
  * @brief Get a user by id, without using the cache
@@ -2992,10 +3178,11 @@ confirmation current_user_leave_guild_sync(snowflake guild_id);
  * Call `dpp::find_user` instead that looks up the user in the cache rather than a REST call.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_identified user_get_sync(snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_identified user_get_sync(snowflake user_id);
 
 /**
  * @brief Get a user by id, checking in the cache first
@@ -3010,10 +3197,11 @@ user_identified user_get_sync(snowflake user_id);
  * where you want to for example resolve a user who may no longer be in the bot's guilds, for something like a ban log message.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-user_identified user_get_cached_sync(snowflake user_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") user_identified user_get_cached_sync(snowflake user_id);
 
 /**
  * @brief Get all voice regions
@@ -3022,10 +3210,11 @@ user_identified user_get_cached_sync(snowflake user_id);
  * @return voiceregion_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-voiceregion_map get_voice_regions_sync();
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") voiceregion_map get_voice_regions_sync();
 
 /**
  * @brief Get guild voice regions.
@@ -3040,13 +3229,14 @@ voiceregion_map get_voice_regions_sync();
  * @return voiceregion_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-voiceregion_map guild_get_voice_regions_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") voiceregion_map guild_get_voice_regions_sync(snowflake guild_id);
 
 
-webhook create_webhook_sync(const class webhook &wh);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook create_webhook_sync(const class webhook &wh);
 
 /**
  * @brief Delete a webhook
@@ -3057,10 +3247,11 @@ webhook create_webhook_sync(const class webhook &wh);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation delete_webhook_sync(snowflake webhook_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation delete_webhook_sync(snowflake webhook_id);
 
 /**
  * @brief Delete webhook message
@@ -3073,10 +3264,11 @@ confirmation delete_webhook_sync(snowflake webhook_id);
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation delete_webhook_message_sync(const class webhook &wh, snowflake message_id, snowflake thread_id = 0);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation delete_webhook_message_sync(const class webhook &wh, snowflake message_id, snowflake thread_id = 0);
 
 /**
  * @brief Delete webhook with token
@@ -3087,10 +3279,11 @@ confirmation delete_webhook_message_sync(const class webhook &wh, snowflake mess
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-confirmation delete_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") confirmation delete_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
 
 /**
  * @brief Edit webhook
@@ -3101,10 +3294,11 @@ confirmation delete_webhook_with_token_sync(snowflake webhook_id, const std::str
  * @return webhook returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook edit_webhook_sync(const class webhook& wh);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook edit_webhook_sync(const class webhook& wh);
 
 /**
  * @brief Edit webhook message
@@ -3123,10 +3317,11 @@ webhook edit_webhook_sync(const class webhook& wh);
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message edit_webhook_message_sync(const class webhook &wh, const struct message &m, snowflake thread_id = 0);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message edit_webhook_message_sync(const class webhook &wh, const struct message &m, snowflake thread_id = 0);
 
 /**
  * @brief Edit webhook with token (token is encapsulated in the webhook object)
@@ -3136,10 +3331,11 @@ message edit_webhook_message_sync(const class webhook &wh, const struct message 
  * @return webhook returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook edit_webhook_with_token_sync(const class webhook& wh);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook edit_webhook_with_token_sync(const class webhook& wh);
 
 /**
  * @brief Execute webhook
@@ -3155,10 +3351,11 @@ webhook edit_webhook_with_token_sync(const class webhook& wh);
  * @note If the webhook channel is a forum channel, you must provide either `thread_id` or `thread_name`. If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message execute_webhook_sync(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, const std::string& thread_name = "");
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message execute_webhook_sync(const class webhook &wh, const struct message &m, bool wait = false, snowflake thread_id = 0, const std::string& thread_name = "");
 
 /**
  * @brief Get channel webhooks
@@ -3168,10 +3365,11 @@ message execute_webhook_sync(const class webhook &wh, const struct message &m, b
  * @return webhook_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook_map get_channel_webhooks_sync(snowflake channel_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook_map get_channel_webhooks_sync(snowflake channel_id);
 
 /**
  * @brief Get guild webhooks
@@ -3181,10 +3379,11 @@ webhook_map get_channel_webhooks_sync(snowflake channel_id);
  * @return webhook_map returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook_map get_guild_webhooks_sync(snowflake guild_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook_map get_guild_webhooks_sync(snowflake guild_id);
 
 /**
  * @brief Get webhook
@@ -3194,10 +3393,11 @@ webhook_map get_guild_webhooks_sync(snowflake guild_id);
  * @return webhook returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook get_webhook_sync(snowflake webhook_id);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook get_webhook_sync(snowflake webhook_id);
 
 /**
  * @brief Get webhook message
@@ -3210,10 +3410,11 @@ webhook get_webhook_sync(snowflake webhook_id);
  * @return message returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-message get_webhook_message_sync(const class webhook &wh, snowflake message_id, snowflake thread_id = 0);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") message get_webhook_message_sync(const class webhook &wh, snowflake message_id, snowflake thread_id = 0);
 
 /**
  * @brief Get webhook using token
@@ -3224,10 +3425,11 @@ message get_webhook_message_sync(const class webhook &wh, snowflake message_id, 
  * @return webhook returned object on completion
  * \memberof dpp::cluster
  * @throw dpp::rest_exception upon failure to execute REST function
+ * @deprecated This function is deprecated, please use coroutines instead.
  * @warning This function is a blocking (synchronous) call and should only be used from within a separate thread.
  * Avoid direct use of this function inside an event handler.
  */
-webhook get_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
+DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev/coro-introduction.html") webhook get_webhook_with_token_sync(snowflake webhook_id, const std::string &token);
 
 
 /* End of auto-generated definitions */

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -2085,9 +2085,10 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 
 					// delete the voice channel
 					try {
-						dpp::sync<dpp::channel>(&bot, &dpp::cluster::channel_delete, createdChannel.id);
+						dpp::sync<dpp::confirmation>(&bot, &dpp::cluster::channel_delete, createdChannel.id);
 						set_test(VOICE_CHANNEL_DELETE, true);
 					} catch (dpp::rest_exception &exception) {
+						bot.log(dpp::ll_warning, "Exception: " + std::string(exception.what()));
 						set_test(VOICE_CHANNEL_DELETE, false);
 					}
 				}
@@ -2302,9 +2303,10 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 					set_test(ROLE_EDIT, false);
 				}
 				try {
-					dpp::sync<dpp::role>(&bot, &dpp::cluster::role_delete, TEST_GUILD_ID, createdRole.id);
+					dpp::sync<dpp::confirmation>(&bot, &dpp::cluster::role_delete, TEST_GUILD_ID, createdRole.id);
 					set_test(ROLE_DELETE, true);
 				} catch (dpp::rest_exception &exception) {
+					bot.log(dpp::ll_warning, "Exception: " + std::string(exception.what()));
 					set_test(ROLE_DELETE, false);
 				}
 			}

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -2052,7 +2052,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 					.set_user_limit(99);
 				dpp::channel createdChannel;
 				try {
-					createdChannel = bot.channel_create_sync(channel1);
+					createdChannel = dpp::sync<dpp::channel>(&bot, &dpp::cluster::channel_create, channel1);
 				} catch (dpp::rest_exception &exception) {
 					set_test(VOICE_CHANNEL_CREATE, false);
 				}
@@ -2075,7 +2075,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 						}
 					}
 					try {
-						dpp::channel edited = bot.channel_edit_sync(createdChannel);
+						dpp::channel edited = dpp::sync<dpp::channel>(&bot, &dpp::cluster::channel_edit, createdChannel);
 						if (edited.name == "foobar2" && edited.user_limit == 2) {
 							set_test(VOICE_CHANNEL_EDIT, true);
 						}
@@ -2085,7 +2085,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 
 					// delete the voice channel
 					try {
-						bot.channel_delete_sync(createdChannel.id);
+						dpp::sync<dpp::channel>(&bot, &dpp::cluster::channel_delete, createdChannel.id);
 						set_test(VOICE_CHANNEL_DELETE, true);
 					} catch (dpp::rest_exception &exception) {
 						set_test(VOICE_CHANNEL_DELETE, false);
@@ -2280,7 +2280,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 				r.colour = dpp::colors::moon_yellow;
 				dpp::role createdRole;
 				try {
-					createdRole = bot.role_create_sync(r);
+					createdRole = dpp::sync<dpp::role>(&bot, &dpp::cluster::role_create, r);
 					if (createdRole.name == r.name &&
 						createdRole.has_move_members() &&
 						createdRole.flags & dpp::r_mentionable &&
@@ -2294,7 +2294,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 				createdRole.name = "Test-Role-Edited";
 				createdRole.colour = dpp::colors::light_sea_green;
 				try {
-					dpp::role edited = bot.role_edit_sync(createdRole);
+					dpp::role edited = dpp::sync<dpp::role>(&bot, &dpp::cluster::role_edit, createdRole);
 					if (createdRole.id == edited.id && edited.name == "Test-Role-Edited") {
 						set_test(ROLE_EDIT, true);
 					}
@@ -2302,7 +2302,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 					set_test(ROLE_EDIT, false);
 				}
 				try {
-					bot.role_delete_sync(TEST_GUILD_ID, createdRole.id);
+					dpp::sync<dpp::role>(&bot, &dpp::cluster::role_delete, TEST_GUILD_ID, createdRole.id);
 					set_test(ROLE_DELETE, true);
 				} catch (dpp::rest_exception &exception) {
 					set_test(ROLE_DELETE, false);
@@ -2335,7 +2335,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 
 		set_test(USER_GET_CACHED_PRESENT, false);
 		try {
-			dpp::user_identified u = bot.user_get_cached_sync(TEST_USER_ID);
+			dpp::user_identified u = dpp::sync<dpp::user_identified>(&bot, &dpp::cluster::user_get_cached, TEST_USER_ID);
 			set_test(USER_GET_CACHED_PRESENT, (u.id == TEST_USER_ID));
 		}
 		catch (const std::exception&) {
@@ -2350,7 +2350,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			 * If this becomes not true any more, we'll pick another well known
 			 * user ID.
 			 */
-			dpp::user_identified u = bot.user_get_cached_sync(90339695967350784);
+			dpp::user_identified u = dpp::sync<dpp::user_identified>(&bot, &dpp::cluster::user_get_cached, 90339695967350784);
 			set_test(USER_GET_CACHED_ABSENT, (u.id == dpp::snowflake(90339695967350784)));
 		}
 		catch (const std::exception&) {


### PR DESCRIPTION
 Deprecate sync calls, from now on they will be auto generated with DPP_DEPRECATED on them advising users to use coro.

This bypasses sync depreciation warnings in the unit tests by using the template directly instead. I don't want to touch this with a ten foot pole right now as this is a whole world of fragile callback hell. This can be addressed in the future maybe, but for now, this isnt directly end user facing code and isnt going to cause anyone any hassle.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
