### PR TITLE
docs: add docblock comments to all libdave class variables

### DIFF
--- a/src/dpp/dave/array_view.h
+++ b/src/dpp/dave/array_view.h
@@ -116,5 +116,4 @@ inline array_view<T> make_array_view(std::vector<T>& data)
 	return array_view<T>(data.data(), data.size());
 }
 
-} // namespace dpp::dave
-
+}

--- a/src/dpp/dave/cipher_interface.cpp
+++ b/src/dpp/dave/cipher_interface.cpp
@@ -34,5 +34,4 @@ std::unique_ptr<cipher_interface> create_cipher(dpp::cluster& cl, const encrypti
 	return cipher->is_valid() ? std::move(cipher) : nullptr;
 }
 
-} // namespace dpp::dave
-
+}

--- a/src/dpp/dave/cipher_interface.h
+++ b/src/dpp/dave/cipher_interface.h
@@ -99,5 +99,4 @@ protected:
  */
 std::unique_ptr<cipher_interface> create_cipher(dpp::cluster& cl, const encryption_key& key);
 
-} // namespace dpp::dave
-
+}

--- a/src/dpp/dave/clock.h
+++ b/src/dpp/dave/clock.h
@@ -74,5 +74,4 @@ public:
 	}
 };
 
-} // namespace dpp::dave
-
+}

--- a/src/dpp/dave/codec_utils.h
+++ b/src/dpp/dave/codec_utils.h
@@ -91,6 +91,4 @@ bool process_frame_av1(outbound_frame_processor & processor, array_view<const ui
  */
 bool validate_encrypted_frame(outbound_frame_processor& processor, array_view<uint8_t> frame);
 
-} // namespace dpp::dave::codec_utils
-
-
+}

--- a/src/dpp/dave/cryptor_manager.h
+++ b/src/dpp/dave/cryptor_manager.h
@@ -149,16 +149,49 @@ private:
 	 */
 	void cleanup_expired_ciphers();
 
+	/**
+	 * @brief chrono clock
+	 */
 	const clock_interface& current_clock;
+
+	/**
+	 * @brief key ratchet for cryptor
+	 */
 	std::unique_ptr<key_ratchet_interface> current_key_ratchet;
+
+	/**
+	 * @brief Cryptor for each generation with expiry
+	 */
 	std::unordered_map<key_generation, expiring_cipher> cryptor_generations;
 
+	/**
+	 * @brief Time ratchet was created
+	 */
 	time_point ratchet_creation;
+
+	/**
+	 * @brief Time ratchet expired
+	 */
 	time_point ratchet_expiry;
+
+	/**
+	 * @brief Oldest generation for ratchet
+	 */
 	key_generation oldest_generation{0};
+
+	/**
+	 * @brief Newest generation for ratchet
+	 */
 	key_generation newest_generation{0};
 
+	/**
+	 * @brief Newest nonce
+	 */
 	std::optional<big_nonce> newest_processed_nonce;
+
+	/**
+	 * @brief List of missing nonces from sequence
+	 */
 	std::deque<big_nonce> missing_nonces;
 
 	/**

--- a/src/dpp/dave/decryptor.h
+++ b/src/dpp/dave/decryptor.h
@@ -177,15 +177,39 @@ private:
 	 */
 	void return_frame_processor(std::unique_ptr<inbound_frame_processor> frame_processor);
 
+	/**
+	 * @brief Chrono clock
+	 */
 	clock current_clock;
+
+	/**
+	 * @brief Cryptor manager list
+	 */
 	std::deque<aead_cipher_manager> cryptor_managers;
 
+	/**
+	 * @brief Mutex for thread safety of frame processor list
+	 */
 	std::mutex frame_processors_mutex;
+
+	/**
+	 * @brief List of frame processors
+	 */
 	std::vector<std::unique_ptr<inbound_frame_processor>> frame_processors;
 
+	/**
+	 * @brief Passthrough expiry time
+	 */
 	time_point allow_pass_through_until{time_point::min()};
 
+	/**
+	 * @brief Last stats generation time
+	 */
 	time_point last_stats_time{time_point::min()};
+
+	/**
+	 * @brief Stats for audio and video decryption
+	 */
 	std::array<decryption_stats, 2> stats;
 
 	/**

--- a/src/dpp/dave/encryptor.cpp
+++ b/src/dpp/dave/encryptor.cpp
@@ -164,7 +164,14 @@ encryptor::result_code encryptor::encrypt(media_type this_media_type, uint32_t s
 		}
 
 		// write the supplemental bytes size
-		supplemental_bytes_size supplemental_bytes = SUPPLEMENTAL_BYTES + size + ranges_size;
+		uint64_t supplemental_bytes_large = SUPPLEMENTAL_BYTES + size + ranges_size;
+
+		if (supplemental_bytes_large > std::numeric_limits<supplemental_bytes_size>::max()) {
+			result = rc_encryption_failure;
+			break;
+		}
+
+		supplemental_bytes_size supplemental_bytes = supplemental_bytes_large;
 		std::memcpy(supplemental_bytes_buffer.data(), &supplemental_bytes, sizeof(supplemental_bytes_size));
 
 		// write the marker bytes, ends the frame

--- a/src/dpp/dave/encryptor.h
+++ b/src/dpp/dave/encryptor.h
@@ -77,9 +77,9 @@ struct encryption_stats {
 class encryptor {
 public:
 	/**
- * @brief Constructor
- * @param cl Creator
- */
+	 * @brief Constructor
+	 * @param cl Creator
+	 */
 	encryptor(dpp::cluster& cl) : creator(cl) { };
 
 	/**
@@ -219,25 +219,79 @@ private:
 	 */
 	void update_current_protocol_version(protocol_version version);
 
+	/**
+	 * @brief True if passthrough is enabled
+	 */
 	std::atomic_bool passthrough_mode_enable{false};
 
+	/**
+	 * @brief Key generation mutex for thread safety
+	 */
 	std::mutex key_gen_mutex;
+
+	/**
+	 * @brief Current encryption (send) ratchet
+	 */
 	std::unique_ptr<key_ratchet_interface> ratchet;
+
+	/**
+	 * @brief Current encryption cipher
+	 */
 	std::shared_ptr<cipher_interface> cryptor;
+
+	/**
+	 * @brief Current key generation number
+	 */
 	key_generation current_key_generation{0};
+
+	/**
+	 * @brief Current truncated sync nonce
+	 */
 	truncated_sync_nonce truncated_nonce{0};
 
+	/**
+	 * @brief Frame processor list mutex
+	 */
 	std::mutex frame_processors_mutex;
+
+	/**
+	 * @brief List of outbound frame processors
+	 */
 	std::vector<std::unique_ptr<outbound_frame_processor>> frame_processors;
 
+	/**
+	 * @brief A pair of 32 bit SSRC and codec in use for that SSRC
+	 */
 	using ssrc_codec_pair = std::pair<uint32_t, codec>;
+
+	/**
+	 * @brief List of codec pairs for SSRCs
+	 */
 	std::vector<ssrc_codec_pair> ssrc_codec_pairs;
 
+	/**
+	 * @brief A chrono time point
+	 */
 	using time_point = std::chrono::time_point<std::chrono::steady_clock>;
+
+	/**
+	 * @brief Last time stats were updated
+	 */
 	time_point last_stats_time{time_point::min()};
+
+	/**
+	 * @brief Stores audio/video encryption stats
+	 */
 	std::array<encryption_stats, 2> stats;
 
+	/**
+	 * @brief Callback for version change, if any
+	 */
 	protocol_version_changed_callback changed_callback;
+
+	/**
+	 * Current protocol version supported
+	 */
 	protocol_version current_protocol_version{max_protocol_version()};
 
 	/**

--- a/src/dpp/dave/frame_processors.h
+++ b/src/dpp/dave/frame_processors.h
@@ -183,13 +183,44 @@ private:
 	 */
 	void add_ciphertext_bytes(const uint8_t* data, size_t size);
 
+	/**
+	 * @brief True if frames are encrypted
+	 */
 	bool encrypted{false};
+
+	/**
+	 * @brief Original size
+	 */
 	size_t original_size{0};
+
+	/**
+	 * @brief AEAD tag
+	 */
 	array_view<const uint8_t> tag;
+
+	/**
+	 * @brief Truncated nonce
+	 */
 	truncated_sync_nonce truncated_nonce;
+
+	/**
+	 * @brief Unencrypted parts of the frames
+	 */
 	ranges unencrypted_ranges;
+
+	/**
+	 * @brief additional authenticated data
+	 */
 	std::vector<uint8_t> authenticated;
+
+	/**
+	 * @brief Ciphertext
+	 */
 	std::vector<uint8_t> ciphertext;
+
+	/**
+	 * @brief Plaintext
+	 */
 	std::vector<uint8_t> plaintext;
 
 	/**
@@ -283,11 +314,34 @@ public:
 	void add_encrypted_bytes(const uint8_t* bytes, size_t size);
 
 private:
+	/**
+	 * @brief Codec used to decrypt
+	 */
 	codec frame_codec{codec::cd_unknown};
+
+	/**
+	 * @brief Frame index
+	 */
 	size_t frame_index{0};
+
+	/**
+	 * @brief Unencrypted bytes
+	 */
 	std::vector<uint8_t> unencrypted_bytes;
+
+	/**
+	 * @brief Encrypted bytes
+	 */
 	std::vector<uint8_t> encrypted_bytes;
+
+	/**
+	 * @brief Ciphertext bytes
+	 */
 	std::vector<uint8_t> ciphertext_bytes;
+
+	/**
+	 * @brief Unencrypted ranges that need to be kept plaintext to allow for RTP routing
+	 */
 	ranges unencrypted_ranges;
 
 	/**

--- a/src/dpp/dave/frame_processors.h
+++ b/src/dpp/dave/frame_processors.h
@@ -73,7 +73,7 @@ uint8_t serialize_unencrypted_ranges(const ranges& unencrypted_ranges, uint8_t* 
  * @param unencrypted_ranges unencrypted ranges to write to
  * @return size of unencrypted ranges written
  */
-uint8_t deserialize_unencrypted_ranges(const uint8_t*& read_at, const size_t buffer_size, ranges& unencrypted_ranges);
+uint8_t deserialize_unencrypted_ranges(const uint8_t*& read_at, const uint8_t buffer_size, ranges& unencrypted_ranges);
 
 /**
  * @brief Validate unencrypted ranges

--- a/src/dpp/dave/leb128.cpp
+++ b/src/dpp/dave/leb128.cpp
@@ -76,7 +76,7 @@ size_t write_leb128(uint64_t value, uint8_t* buffer)
 		++size;
 		value >>= 7;
 	}
-	buffer[size] = value;
+	buffer[size] = static_cast<uint8_t>(value);
 	++size;
 	return size;
 }

--- a/src/dpp/dave/parameters.h
+++ b/src/dpp/dave/parameters.h
@@ -82,4 +82,4 @@ namespace dpp::dave::mls {
  */
 ::mlspp::ExtensionList group_extensions_for_protocol_version(protocol_version version, const ::mlspp::ExternalSender& external_sender) noexcept;
 
-} // namespace dpp::dave::mls
+}

--- a/src/dpp/dave/persisted_key_pair_generic.cpp
+++ b/src/dpp/dave/persisted_key_pair_generic.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<::mlspp::SignaturePrivateKey> get_generic_persisted_key_pair(dpp
 		}
 
 #ifdef _WIN32
-		int written = _write(fd, newstr.c_str(), newstr.size());
+		int written = _write(fd, newstr.c_str(), static_cast<unsigned int>(newstr.size()));
 		_close(fd);
 #else
 		ssize_t written = write(fd, newstr.c_str(), newstr.size());

--- a/src/dpp/dave/session.h
+++ b/src/dpp/dave/session.h
@@ -247,32 +247,99 @@ private:
 	 */
 	inline static const std::string USER_MEDIA_KEY_BASE_LABEL = "Discord Secure Frames v0";
 
+	/**
+	 * @brief DAVE protocol version for the session
+	 */
 	protocol_version session_protocol_version;
+
+	/**
+	 * @brief Session group ID (voice channel id)
+	 */
 	std::vector<uint8_t> session_group_id;
+
+	/**
+	 * @brief Signing key id
+	 */
 	std::string signing_key_id;
+
+	/**
+	 * @brief The bot's user snowflake ID
+	 */
 	std::string bot_user_id;
+
+	/**
+	 * @brief The bot's key pair context
+	 */
 	key_pair_context_type key_pair_context{nullptr};
 
+	/**
+	 * @brief Our leaf node in the ratchet tree
+	 */
 	std::unique_ptr<::mlspp::LeafNode> self_leaf_node;
+
+	/**
+	 * @brief The bots signature private key
+	 */
 	std::shared_ptr<::mlspp::SignaturePrivateKey> signature_private_key;
+
+	/**
+	 * @brief HPKE private key
+	 */
 	std::unique_ptr<::mlspp::HPKEPrivateKey> hpke_private_key;
 
+	/**
+	 * @brief Private key for join initialisation
+	 */
 	std::unique_ptr<::mlspp::HPKEPrivateKey> join_init_private_key;
+
+	/**
+	 * @brief Join key package
+	 */
 	std::unique_ptr<::mlspp::KeyPackage> join_key_package;
 
+	/**
+	 * @brief MLS External sender (the discord voice gateway server)
+	 */
 	std::unique_ptr<::mlspp::ExternalSender> mls_external_sender;
 
+	/**
+	 * @brief Pending MLS group state
+	 */
 	std::unique_ptr<::mlspp::State> pending_group_state;
+
+	/**
+	 * @brief Pending MLS group commit
+	 */
 	std::unique_ptr<::mlspp::MLSMessage> pending_group_commit;
 
+	/**
+	 * @brief Outbound cached group state
+	 */
 	std::unique_ptr<::mlspp::State> outbound_cached_group_state;
 
+	/**
+	 * @brief Current MLS state
+	 */
 	std::unique_ptr<::mlspp::State> current_state;
+
+	/**
+	 * @brief Participant roster, all users who are in the VC with dave enabled
+	 */
 	roster_map roster;
 
+	/**
+	 * @brief Current state containing proposals
+	 */
 	std::unique_ptr<::mlspp::State> state_with_proposals;
+
+	/**
+	 * @brief Queue of proposals to process
+	 */
 	std::list<queued_proposal> proposal_queue;
 
+	/**
+	 * @brief Function to call on failure, if any
+	 */
 	mls_failure_callback failure_callback{};
 
 	/**

--- a/src/dpp/voice/enabled/discover_ip.cpp
+++ b/src/dpp/voice/enabled/discover_ip.cpp
@@ -39,12 +39,10 @@
 namespace dpp {
 
 /**
- * https://discord.com/developers/docs/topics/voice-connections#ip-discovery
- */
-
-/**
  * @brief Represents an IP discovery packet sent to Discord or received
  * from Discord.
+ *
+ * https://discord.com/developers/docs/topics/voice-connections#ip-discovery
  */
 struct ip_discovery_packet {
 


### PR DESCRIPTION
Properly adds comments to all libdave member variables. Some of these i'm not 100% sure of their purpose, but they have a comment now to get the process started.

This PR also backports some fixes from discord to libdave, I have picked out the important changes to apply to our implementation and left their stylistic changes and build script on the cutting room floor: https://github.com/discord/libdave/commit/6e5ffbc1cb4eef6be96e8115c4626be598b7e501#diff-f395bfd18d0d8d925834eef8a2732beff51c7bab0cb55b2901eacf3c01a39899R133

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
