### PR TITLE
Feat/no user join ready dave

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1335,17 +1335,6 @@ public:
 
 	
 	/**
-	 * @brief Called when a user is talking on a voice channel.
-	 *
-	 * @warning If the cache policy has disabled guild caching, the pointer to the guild in this event may be nullptr.
-	 *
-	 * @note Use operator() to attach a lambda to this event, and the detach method to detach the listener using the returned ID.
-	 * The function signature for this event takes a single `const` reference of type voice_user_talking_t&, and returns void.
-	 */
-	event_router_t<voice_user_talking_t> on_voice_user_talking;
-
-	
-	/**
 	 * @brief Called when a voice channel is connected and ready to send audio.
 	 * Note that this is not directly attached to the READY event of the websocket,
 	 * as there is further connection that needs to be done before audio is ready to send.

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -440,7 +440,7 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	bool paused;
 
 	/**
-	 * @brief Whether has sent 5 frame of silence before stopping on pause/stop.
+	 * @brief Whether has sent 5 frame of silence before stopping on pause.
 	 *
 	 * This is to avoid unintended Opus interpolation with subsequent transmissions.
 	 */

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -1035,6 +1035,8 @@ public:
 	 *
 	 * @param send_now send this packet right away without buffering.
 	 * Do NOT set send_now to true outside write_ready.
+	 * Also make sure you're not locking stream_mutex if you
+	 * don't set send_now to true.
 	 * 
 	 * @return discord_voice_client& Reference to self
 	 * @throw dpp::voice_exception if voice support is not compiled into D++

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -241,6 +241,11 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	void cleanup();
 
 	/**
+	 * @brief A frame of silence packet
+	 */
+	static constexpr uint8_t silence_packet[3] = { 0xf8, 0xff, 0xfe };
+
+	/**
 	 * @brief Mutex for outbound packet stream
 	 */
 	std::mutex stream_mutex;
@@ -433,6 +438,13 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @brief If true, audio packet sending is paused
 	 */
 	bool paused;
+
+	/**
+	 * @brief Whether has sent 5 frame of silence before stopping on pause/stop.
+	 *
+	 * This is to avoid unintended Opus interpolation with subsequent transmissions.
+	 */
+	bool sent_stop_frames;
 
 #ifdef HAVE_VOICE
 	/**
@@ -650,8 +662,10 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @param packet packet data
 	 * @param len length of packet
 	 * @param duration duration of opus packet
+	 * @param send_now send this packet right away without buffering.
+	 * Do NOT set send_now to true outside write_ready.
 	 */
-	void send(const char* packet, size_t len, uint64_t duration);
+	void send(const char* packet, size_t len, uint64_t duration, bool send_now = false);
 
 	/**
 	 * @brief Queue a message to be sent via the websocket
@@ -962,6 +976,10 @@ public:
 	 * @param duration Generally duration is 2.5, 5, 10, 20, 40 or 60
 	 * if the timescale is 1000000 (1ms) 
 	 * 
+	 * @param send_now Send this packet right away without buffering,
+	 * this will skip duration calculation for the packet being sent
+	 * and only safe to be set to true in write_ready.
+	 *
 	 * @return discord_voice_client& Reference to self
 	 * 
 	 * @note It is your responsibility to ensure that packets of data 
@@ -972,7 +990,7 @@ public:
 	 * 
 	 * @throw dpp::voice_exception If data length is invalid or voice support not compiled into D++
 	 */
-	discord_voice_client& send_audio_opus(uint8_t* opus_packet, const size_t length, uint64_t duration);
+	discord_voice_client& send_audio_opus(const uint8_t* opus_packet, const size_t length, uint64_t duration, bool send_now = false);
 
 	/**
 	 * @brief Send opus packets to the voice channel
@@ -999,7 +1017,7 @@ public:
 	 * 
 	 * @throw dpp::voice_exception If data length is invalid or voice support not compiled into D++
 	 */
-	discord_voice_client& send_audio_opus(uint8_t* opus_packet, const size_t length);
+	discord_voice_client& send_audio_opus(const uint8_t* opus_packet, const size_t length);
 
 	/**
 	 * @brief Send silence to the voice channel
@@ -1011,6 +1029,17 @@ public:
 	 * @throw dpp::voice_exception if voice support is not compiled into D++
 	 */
 	discord_voice_client& send_silence(const uint64_t duration);
+
+	/**
+	 * @brief Send stop frames to the voice channel.
+	 *
+	 * @param send_now send this packet right away without buffering.
+	 * Do NOT set send_now to true outside write_ready.
+	 * 
+	 * @return discord_voice_client& Reference to self
+	 * @throw dpp::voice_exception if voice support is not compiled into D++
+	 */
+	discord_voice_client& send_stop_frames(bool send_now = false);
 
 	/**
 	 * @brief Sets the audio type that will be sent with send_audio_* methods.

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -1989,30 +1989,7 @@ struct DPP_EXPORT voice_buffer_send_t : public event_dispatch_t {
 };
 
 /**
- * @brief voice user talking
- */
-struct DPP_EXPORT voice_user_talking_t : public event_dispatch_t {
-	using event_dispatch_t::event_dispatch_t;
-	using event_dispatch_t::operator=;
-
-	/**
-	 * @brief voice client where user is talking
-	 */
-	class discord_voice_client* voice_client = nullptr;
-
-	/**
-	 * @brief talking user id
-	 */
-	snowflake user_id = {};
-
-	/**
-	 * @brief flags for talking user
-	 */
-	uint8_t talking_flags = 0;
-};
-
-/**
- * @brief voice user talking
+ * @brief voice ready
  */
 struct DPP_EXPORT voice_ready_t : public event_dispatch_t {
 	using event_dispatch_t::event_dispatch_t;

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -176,10 +176,12 @@ dpp::utility::uptime discord_voice_client::get_remaining() {
 }
 
 discord_voice_client& discord_voice_client::stop_audio() {
-	std::lock_guard<std::mutex> lock(this->stream_mutex);
-	outbuf.clear();
-	track_meta.clear();
-	tracks = 0;
+	{
+		std::lock_guard<std::mutex> lock(this->stream_mutex);
+		outbuf.clear();
+		track_meta.clear();
+		tracks = 0;
+	}
 	this->send_stop_frames();
 	return *this;
 }

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -416,7 +416,6 @@ discord_voice_client& discord_voice_client::set_send_audio_type(send_audio_type_
 
 discord_voice_client& discord_voice_client::speak() {
 	if (!this->sending) {
-		std::cout << "Sending voice_opcode_client_speaking\n";
 		this->queue_message(json({
 		{"op", voice_opcode_client_speaking},
 		{"d", {

--- a/src/dpp/voice/enabled/courier_loop.cpp
+++ b/src/dpp/voice/enabled/courier_loop.cpp
@@ -147,8 +147,8 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 						 * we can only pretend there is an event, without any raw payload byte.
 						 */
 						voice_receive_t vr(nullptr, "", &client, d.user_id,
-						 reinterpret_cast<uint8_t *>(flush_data_pcm),
-						 lost_packet_samples * opus_channel_count * sizeof(opus_int16));
+						                   reinterpret_cast<uint8_t *>(flush_data_pcm),
+						                   lost_packet_samples * opus_channel_count * sizeof(opus_int16));
 
 						park_count = audio_mix(client, *client.mixer, pcm_mix, flush_data_pcm, park_count, lost_packet_samples, max_samples);
 						client.creator->on_voice_receive.call(vr);
@@ -283,7 +283,7 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 			}
 
 			voice_receive_t vr(nullptr, "", &client, 0, reinterpret_cast<uint8_t *>(pcm_downsample),
-					  max_samples * opus_channel_count * sizeof(opus_int16));
+			                   max_samples * opus_channel_count * sizeof(opus_int16));
 
 			client.creator->on_voice_receive_combined.call(vr);
 		}

--- a/src/dpp/voice/enabled/handle_frame.cpp
+++ b/src/dpp/voice/enabled/handle_frame.cpp
@@ -411,6 +411,11 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 								});
 						}
 						this->reinit_dave_mls_group();
+
+						/* Ready now if there's no DAVE user waiting in the vc */
+						if (dave_mls_user_list.empty()) {
+							ready_now = true;
+						}
 					}
 				} else {
 					/* Non-DAVE ready immediately */

--- a/src/dpp/voice/enabled/opus.cpp
+++ b/src/dpp/voice/enabled/opus.cpp
@@ -71,14 +71,14 @@ discord_voice_client& discord_voice_client::send_audio_raw(uint16_t* audio_data,
 	return *this;
 }
 
-discord_voice_client& discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length) {
+discord_voice_client& discord_voice_client::send_audio_opus(const uint8_t* opus_packet, const size_t length) {
 	int samples = opus_packet_get_nb_samples(opus_packet, (opus_int32)length, opus_sample_rate_hz);
 	uint64_t duration = (samples / 48) / (timescale / 1000000);
-	send_audio_opus(opus_packet, length, duration);
+	send_audio_opus(opus_packet, length, duration, false);
 	return *this;
 }
 
-discord_voice_client& discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length, uint64_t duration) {
+discord_voice_client& discord_voice_client::send_audio_opus(const uint8_t* opus_packet, const size_t length, uint64_t duration, bool send_now) {
 	int frame_size = (int)(48 * duration * (timescale / 1000000));
 	opus_int32 encoded_audio_max_length = (opus_int32)length;
 	std::vector<uint8_t> encoded_audio(encoded_audio_max_length);
@@ -147,7 +147,7 @@ discord_voice_client& discord_voice_client::send_audio_opus(uint8_t* opus_packet
 	/* Append the 4 byte nonce to the resulting payload */
 	std::memcpy(payload.data() + payload.size() - sizeof(noncel), &noncel, sizeof(noncel));
 
-	this->send(reinterpret_cast<const char *>(payload.data()), payload.size(), duration);
+	this->send(reinterpret_cast<const char *>(payload.data()), payload.size(), duration, send_now);
 
 	timestamp += frame_size;
 

--- a/src/dpp/voice/enabled/read_ready.cpp
+++ b/src/dpp/voice/enabled/read_ready.cpp
@@ -20,6 +20,7 @@
  *
  ************************************************************************************/
 
+#include <chrono>
 #include <string_view>
 #include <dpp/exception.h>
 #include <dpp/isa_detection.h>
@@ -65,9 +66,12 @@ void discord_voice_client::read_ready()
 		return;
 	}
 
+	auto start = std::chrono::steady_clock::now();
+	std::cout << "read_ready START: " << std::chrono::duration_cast<std::chrono::milliseconds>(start.time_since_epoch()) .count() << "\n";
+
 	voice_payload vp{0, // seq, populate later
-			 0, // timestamp, populate later
-			 std::make_unique<voice_receive_t>(nullptr, std::string(reinterpret_cast<char*>(buffer), packet_size))};
+		0, // timestamp, populate later
+		std::make_unique<voice_receive_t>(nullptr, std::string(reinterpret_cast<char*>(buffer), packet_size))};
 
 	vp.vr->voice_client = this;
 
@@ -86,90 +90,11 @@ void discord_voice_client::read_ready()
 	std::memcpy(&vp.timestamp, &buffer[4], sizeof(rtp_timestamp_t));
 	vp.timestamp = ntohl(vp.timestamp);
 
-	constexpr size_t nonce_size = sizeof(uint32_t);
-	/* Nonce is 4 byte at the end of payload with zero padding */
-	uint8_t nonce[24] = { 0 };
-	std::memcpy(nonce, buffer + packet_size - nonce_size, nonce_size);
-
-	/* Get the number of CSRC in header */
-	const size_t csrc_count = buffer[0] & 0b0000'1111;
-	/* Skip to the encrypted voice data */
-	const ptrdiff_t offset_to_data = header_size + sizeof(uint32_t) * csrc_count;
-	size_t total_header_len = offset_to_data;
-
-	uint8_t* ciphertext = buffer + offset_to_data;
-	size_t ciphertext_len = packet_size - offset_to_data - nonce_size;
-
-	size_t ext_len = 0;
-	if ([[maybe_unused]] const bool uses_extension = (buffer[0] >> 4) & 0b0001) {
-		/**
-		 * Get the RTP Extensions size, we only get the size here because
-		 * the extension itself is encrypted along with the opus packet
-		 */
-		{
-			uint16_t ext_len_in_words;
-			memcpy(&ext_len_in_words, &ciphertext[2], sizeof(uint16_t));
-			ext_len_in_words = ntohs(ext_len_in_words);
-			ext_len = sizeof(uint32_t) * ext_len_in_words;
-		}
-		constexpr size_t ext_header_len = sizeof(uint16_t) * 2;
-		ciphertext += ext_header_len;
-		ciphertext_len -= ext_header_len;
-		total_header_len += ext_header_len;
-	}
-
-	uint8_t decrypted[65535] = { 0 };
-	unsigned long long opus_packet_len  = 0;
-	if (ssl_crypto_aead_xchacha20poly1305_ietf_decrypt(
-		decrypted, &opus_packet_len,
-		nullptr,
-		ciphertext, ciphertext_len,
-		buffer,
-		/**
-		 * Additional Data:
-		 * The whole header (including csrc list) +
-		 * 4 byte extension header (magic 0xBEDE + 16-bit denoting extension length)
-		 */
-		total_header_len,
-		nonce, secret_key.data()) != 0) {
-		/* Invalid Discord RTP payload. */
-		return;
-	}
-
-	uint8_t *opus_packet = decrypted;
-	if (ext_len > 0) {
-		/* Skip previously encrypted RTP Header Extension */
-		opus_packet += ext_len;
-		opus_packet_len -= ext_len;
-	}
-
-	/**
-	 * If DAVE is enabled, use the user's ratchet to decrypt the OPUS audio data
-	 */
-	std::vector<uint8_t> frame;
-	if (is_end_to_end_encrypted()) {
-		auto decryptor = mls_state->decryptors.find(vp.vr->user_id);
-		if (decryptor != mls_state->decryptors.end()) {
-			frame.resize(decryptor->second->get_max_plaintext_byte_size(dave::media_type::media_audio, opus_packet_len));
-			size_t enc_len = decryptor->second->decrypt(
-				dave::media_type::media_audio,
-				dave::make_array_view<const uint8_t>(opus_packet, opus_packet_len),
-				dave::make_array_view(frame)
-			);
-			if (enc_len > 0) {
-				opus_packet = frame.data();
-				opus_packet_len = enc_len;
-			}
-		}
-	}
-
-	/*
-	 * We're left with the decrypted, opus-encoded data.
-	 * Park the payload and decode on the voice courier thread.
-	 */
-	vp.vr->audio_data.assign(opus_packet, opus_packet + opus_packet_len);
+	vp.vr->audio_data.assign(buffer, buffer + packet_size);
 
 	{
+		std::cout << "voice_courier_shared_state.mtx LOCK\n";
+
 		std::lock_guard lk(voice_courier_shared_state.mtx);
 		auto& [range, payload_queue, pending_decoder_ctls, decoder] = voice_courier_shared_state.parked_voice_payloads[vp.vr->user_id];
 
@@ -183,7 +108,7 @@ void discord_voice_client::read_ready()
 
 			int opus_error = 0;
 			decoder.reset(opus_decoder_create(opus_sample_rate_hz, opus_channel_count, &opus_error),
-				      &opus_decoder_destroy);
+				 &opus_decoder_destroy);
 			if (opus_error) {
 				/**
 				 * NOTE: The -10 here makes the opus_error match up with values of exception_error_code,
@@ -195,20 +120,32 @@ void discord_voice_client::read_ready()
 
 		if (vp.seq < range.min_seq && vp.timestamp < range.min_timestamp) {
 			/* This packet arrived too late. We can only discard it. */
+
+			std::cout << "voice_courier_shared_state.mtx RELEASE\n";
+
 			return;
 		}
 		range.max_seq = vp.seq;
 		range.max_timestamp = vp.timestamp;
 		payload_queue.push(std::move(vp));
+
+		std::cout << "voice_courier_shared_state.mtx RELEASE\n";
 	}
 
+	std::cout << "read_ready NOTIFY_ONE\n";
+
 	voice_courier_shared_state.signal_iteration.notify_one();
+
+	auto end = std::chrono::steady_clock::now();
+	std::cout << "read_ready END: " << std::chrono::duration_cast<std::chrono::milliseconds>(start.time_since_epoch()).count() << "\n";
+
+	std::cout << "read_ready TIME: " << std::chrono::duration_cast<std::chrono::milliseconds>((end - start)).count() << "\n";
 
 	if (!voice_courier.joinable()) {
 		/* Courier thread is not running, start it */
 		voice_courier = std::thread(&voice_courier_loop,
-					    std::ref(*this),
-					    std::ref(voice_courier_shared_state));
+							  std::ref(*this),
+							  std::ref(voice_courier_shared_state));
 	}
 }
 

--- a/src/dpp/voice/enabled/read_ready.cpp
+++ b/src/dpp/voice/enabled/read_ready.cpp
@@ -67,8 +67,8 @@ void discord_voice_client::read_ready()
 	}
 
 	voice_payload vp{0, // seq, populate later
-		0, // timestamp, populate later
-		std::make_unique<voice_receive_t>(nullptr, std::string(reinterpret_cast<char*>(buffer), packet_size))};
+	                 0, // timestamp, populate later
+	                 std::make_unique<voice_receive_t>(nullptr, std::string(reinterpret_cast<char*>(buffer), packet_size))};
 
 	vp.vr->voice_client = this;
 
@@ -103,7 +103,7 @@ void discord_voice_client::read_ready()
 
 			int opus_error = 0;
 			decoder.reset(opus_decoder_create(opus_sample_rate_hz, opus_channel_count, &opus_error),
-				 &opus_decoder_destroy);
+			              &opus_decoder_destroy);
 			if (opus_error) {
 				/**
 				 * NOTE: The -10 here makes the opus_error match up with values of exception_error_code,
@@ -127,8 +127,8 @@ void discord_voice_client::read_ready()
 	if (!voice_courier.joinable()) {
 		/* Courier thread is not running, start it */
 		voice_courier = std::thread(&voice_courier_loop,
-							  std::ref(*this),
-							  std::ref(voice_courier_shared_state));
+		                            std::ref(*this),
+		                            std::ref(voice_courier_shared_state));
 	}
 }
 

--- a/src/dpp/voice/enabled/write_ready.cpp
+++ b/src/dpp/voice/enabled/write_ready.cpp
@@ -44,7 +44,7 @@ void discord_voice_client::write_ready() {
 			}
 
 			/* Fallthrough if paused */
-		} else if (outbuf.size()) {
+		} else if (!outbuf.empty()) {
 			type = send_audio_type;
 			if (outbuf[0].packet.size() == sizeof(uint16_t) && (*(reinterpret_cast<uint16_t*>(outbuf[0].packet.data()))) == AUDIO_TRACK_MARKER) {
 				outbuf.erase(outbuf.begin());
@@ -53,7 +53,7 @@ void discord_voice_client::write_ready() {
 					tracks--;
 				}
 			}
-			if (outbuf.size()) {
+			if (!outbuf.empty()) {
 				if (this->udp_send(outbuf[0].packet.data(), outbuf[0].packet.length()) == (int)outbuf[0].packet.length()) {
 					duration = outbuf[0].duration * timescale;
 					bufsize = outbuf[0].packet.length();

--- a/src/dpp/voice/enabled/write_ready.cpp
+++ b/src/dpp/voice/enabled/write_ready.cpp
@@ -37,7 +37,14 @@ void discord_voice_client::write_ready() {
 	send_audio_type_t type = satype_recorded_audio;
 	{
 		std::lock_guard<std::mutex> lock(this->stream_mutex);
-		if (!this->paused && outbuf.size()) {
+		if (this->paused) {
+			if (!this->sent_stop_frames) {
+				this->send_stop_frames(true);
+				this->sent_stop_frames = true;
+			}
+
+			/* Fallthrough if paused */
+		} else if (outbuf.size()) {
 			type = send_audio_type;
 			if (outbuf[0].packet.size() == sizeof(uint16_t) && (*(reinterpret_cast<uint16_t*>(outbuf[0].packet.data()))) == AUDIO_TRACK_MARKER) {
 				outbuf.erase(outbuf.begin());

--- a/src/dpp/voice/stub/stubs.cpp
+++ b/src/dpp/voice/stub/stubs.cpp
@@ -63,11 +63,11 @@ namespace dpp {
 		return *this;
 	}
 
-	discord_voice_client& discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length) {
+	discord_voice_client& discord_voice_client::send_audio_opus(const uint8_t* opus_packet, const size_t length, uint64_t duration, bool send_now) {
 		return *this;
 	}
 
-	discord_voice_client& discord_voice_client::send_audio_opus(uint8_t* opus_packet, const size_t length, uint64_t duration) {
+	discord_voice_client& discord_voice_client::send_audio_opus(const uint8_t* opus_packet, const size_t length) {
 		return *this;
 	}
 
@@ -80,7 +80,7 @@ namespace dpp {
 	}
 
 
-	void discord_voice_client::send(const char* packet, size_t len, uint64_t duration) {
+	void discord_voice_client::send(const char* packet, size_t len, uint64_t duration, bool send_now) {
 	}
 
 	int discord_voice_client::udp_send(const char* data, size_t length) {

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -641,7 +641,6 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::thread_member_update_t, success);
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::thread_members_update_t, success);
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::voice_buffer_send_t, success);
-		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::voice_user_talking_t, success);
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::voice_ready_t, success);
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::voice_receive_t, success);
 		DPP_CHECK_CONSTRUCT_ASSIGN(EVENT_CLASS, dpp::voice_client_speaking_t, success);


### PR DESCRIPTION
## Draft

- BREAKING CHANGE: Remove unused ancient event router from unknown origin `on_voice_user_talking`
- Fix ready event not firing when no user is in the voice channel
- Implement opus stop frames for smooth pause/stop

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
