### PR TITLE
refactor: cleanup namespaces and unneeded includes

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -1591,4 +1591,4 @@ typedef std::unordered_map<snowflake, slashcommand> slashcommand_map;
  */
 typedef std::unordered_map<snowflake, guild_command_permissions> guild_command_permissions_map;
 
-} // namespace dpp
+}

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -472,4 +472,4 @@ public:
  */
 typedef std::unordered_map<snowflake, application> application_map;
 
-} // namespace dpp
+}

--- a/include/dpp/auditlog.h
+++ b/include/dpp/auditlog.h
@@ -478,4 +478,4 @@ public:
 	virtual ~auditlog() = default;
 };
 
-} // namespace dpp
+}

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -400,4 +400,4 @@ public:
  */
 typedef std::unordered_map<snowflake, automod_rule> automod_rule_map;
 
-} // namespace dpp
+}

--- a/include/dpp/ban.h
+++ b/include/dpp/ban.h
@@ -66,4 +66,4 @@ public:
  */
 typedef std::unordered_map<snowflake, ban> ban_map;
 
-} // namespace dpp
+}

--- a/include/dpp/bignum.h
+++ b/include/dpp/bignum.h
@@ -98,4 +98,4 @@ public:
 	[[nodiscard]] std::vector<uint64_t> get_binary() const;
 };
 
-} // namespace dpp
+}

--- a/include/dpp/cache.h
+++ b/include/dpp/cache.h
@@ -270,5 +270,5 @@ cache_decl(role, find_role, get_role_cache, get_role_count);
 cache_decl(channel, find_channel, get_channel_cache, get_channel_count);
 cache_decl(emoji, find_emoji, get_emoji_cache, get_emoji_count);
 
-} // namespace dpp
+}
 

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -878,5 +878,5 @@ void to_json(nlohmann::json& j, const permission_overwrite& po);
  */
 typedef std::unordered_map<snowflake, channel> channel_map;
 
-} // namespace dpp
+}
 

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3993,4 +3993,4 @@ public:
 
 };
 
-} // namespace dpp
+}

--- a/include/dpp/collector.h
+++ b/include/dpp/collector.h
@@ -470,4 +470,4 @@ public:
 	virtual ~scheduled_event_collector() = default;
 };
 
-} // namespace dpp
+}

--- a/include/dpp/commandhandler.h
+++ b/include/dpp/commandhandler.h
@@ -425,4 +425,4 @@ public:
 
 };
 
-} // namespace dpp
+}

--- a/include/dpp/coro/async.h
+++ b/include/dpp/coro/async.h
@@ -184,6 +184,6 @@ public:
 
 DPP_CHECK_ABI_COMPAT(async<>, async_dummy);
 
-} // namespace dpp
+}
 
 #endif /* DPP_CORO */

--- a/include/dpp/coro/coroutine.h
+++ b/include/dpp/coro/coroutine.h
@@ -393,7 +393,7 @@ namespace detail::coroutine {
 DPP_CHECK_ABI_COMPAT(coroutine<void>, coroutine_dummy)
 DPP_CHECK_ABI_COMPAT(coroutine<uint64_t>, coroutine_dummy)
 
-} // namespace dpp
+}
 
 /**
  * @brief Specialization of std::coroutine_traits, helps the standard library figure out a promise type from a coroutine function.

--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -433,7 +433,7 @@ std_coroutine::coroutine_handle<> final_awaiter<R>::await_suspend(handle_t<R> ha
 DPP_CHECK_ABI_COMPAT(task<void>, task_dummy)
 DPP_CHECK_ABI_COMPAT(task<uint64_t>, task_dummy)
 
-} // namespace dpp
+}
 
 /**
  * @brief Specialization of std::coroutine_traits, helps the standard library figure out a promise_t type from a coroutine function.

--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -533,4 +533,4 @@ public:
 	voiceconn* get_voice(snowflake guild_id);
 };
 
-} // namespace dpp
+}

--- a/include/dpp/discordevents.h
+++ b/include/dpp/discordevents.h
@@ -229,4 +229,4 @@ std::string DPP_EXPORT base64_encode(unsigned char const* buf, unsigned int buff
  */
 std::string DPP_EXPORT ts_to_string(time_t ts);
 
-} // namespace dpp
+}

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -1240,5 +1240,5 @@ public:
 	void process_mls_group_rosters(const std::map<uint64_t, std::vector<uint8_t>>& rmap);
 };
 
-} // namespace dpp
+}
 

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -2221,5 +2221,5 @@ struct DPP_EXPORT entitlement_delete_t : public event_dispatch_t {
 	entitlement deleted = {};
 };
 
-} // namespace dpp
+}
 

--- a/include/dpp/dtemplate.h
+++ b/include/dpp/dtemplate.h
@@ -112,4 +112,4 @@ public:
  */
 typedef std::unordered_map<snowflake, dtemplate> dtemplate_map;
 
-} // namespace dpp
+}

--- a/include/dpp/emoji.h
+++ b/include/dpp/emoji.h
@@ -249,4 +249,4 @@ public:
  */
 typedef std::unordered_map<snowflake, emoji> emoji_map;
 
-} // namespace dpp
+}

--- a/include/dpp/entitlement.h
+++ b/include/dpp/entitlement.h
@@ -243,4 +243,4 @@ public:
  */
 typedef std::unordered_map<snowflake, entitlement> entitlement_map;
 
-} // namespace dpp
+}

--- a/include/dpp/etf.h
+++ b/include/dpp/etf.h
@@ -708,4 +708,4 @@ public:
 	std::string build(const nlohmann::json& j);
 };
 
-} // namespace dpp
+}

--- a/include/dpp/event.h
+++ b/include/dpp/event.h
@@ -156,4 +156,4 @@ event_decl(entitlement_create, ENTITLEMENT_CREATE);
 event_decl(entitlement_update, ENTITLEMENT_UPDATE);
 event_decl(entitlement_delete, ENTITLEMENT_DELETE);
 
-} // namespace dpp::events
+}

--- a/include/dpp/event_router.h
+++ b/include/dpp/event_router.h
@@ -742,4 +742,4 @@ const T &awaitable<T>::await_resume() {
 }
 #endif
 
-} // namespace dpp
+}

--- a/include/dpp/exception.h
+++ b/include/dpp/exception.h
@@ -602,5 +602,5 @@ public:
 #  endif /* DPP_CORO */
 #endif
 
-} // namespace dpp
+}
 

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -2048,4 +2048,4 @@ typedef std::unordered_map<snowflake, guild_member> guild_member_map;
  */
 guild_member DPP_EXPORT find_guild_member(const snowflake guild_id, const snowflake user_id);
 
-} // namespace dpp
+}

--- a/include/dpp/httpsclient.h
+++ b/include/dpp/httpsclient.h
@@ -356,4 +356,4 @@ public:
 
 };
 
-} // namespace dpp
+}

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -335,5 +335,5 @@ typedef std::unordered_map<snowflake, integration> integration_map;
  */
 typedef std::unordered_map<snowflake, connection> connection_map;
 
-} // namespace dpp
+}
 

--- a/include/dpp/intents.h
+++ b/include/dpp/intents.h
@@ -152,4 +152,4 @@ enum intents {
         i_unverified_default_intents    = dpp::i_default_intents | dpp::i_message_content
 };
 
-} // namespace dpp
+}

--- a/include/dpp/invite.h
+++ b/include/dpp/invite.h
@@ -242,4 +242,4 @@ public:
  */
 typedef std::unordered_map<std::string, invite> invite_map;
 
-} // namespace dpp
+}

--- a/include/dpp/isa/avx.h
+++ b/include/dpp/isa/avx.h
@@ -107,6 +107,6 @@ namespace dpp {
 		}
 	};
 
-} // namespace dpp
+}
 
 #endif

--- a/include/dpp/isa/avx2.h
+++ b/include/dpp/isa/avx2.h
@@ -110,6 +110,6 @@ namespace dpp {
 		}
 	};
 
-} // namespace dpp
+}
 
 #endif

--- a/include/dpp/isa/avx512.h
+++ b/include/dpp/isa/avx512.h
@@ -113,6 +113,6 @@ namespace dpp {
 		}
 	};
 
-} // namespace dpp
+}
 
 #endif

--- a/include/dpp/isa/fallback.h
+++ b/include/dpp/isa/fallback.h
@@ -76,4 +76,4 @@ namespace dpp {
 		}
 	};
 
-} // namespace dpp
+}

--- a/include/dpp/json_interface.h
+++ b/include/dpp/json_interface.h
@@ -70,4 +70,4 @@ struct json_interface {
 	}
 };
 
-} // namespace dpp
+}

--- a/include/dpp/managed.h
+++ b/include/dpp/managed.h
@@ -113,4 +113,4 @@ public:
 	}
 };
 
-} // namespace dpp
+}

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2651,4 +2651,4 @@ typedef std::unordered_map<snowflake, sticker> sticker_map;
  */
 typedef std::unordered_map<snowflake, sticker_pack> sticker_pack_map;
 
-} // namespace dpp
+}

--- a/include/dpp/misc-enum.h
+++ b/include/dpp/misc-enum.h
@@ -86,4 +86,4 @@ enum loglevel {
 	ll_critical
 };
 
-} // namespace dpp
+}

--- a/include/dpp/once.h
+++ b/include/dpp/once.h
@@ -43,4 +43,4 @@ template <typename T> auto run_once() {
 	return !std::exchange(called, true);
 };
 
-} // namespace dpp
+}

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -456,4 +456,4 @@ public:
 	}
 };
 
-} // namespace dpp
+}

--- a/include/dpp/presence.h
+++ b/include/dpp/presence.h
@@ -595,4 +595,4 @@ public:
  */
 typedef std::unordered_map<snowflake, presence> presence_map;
 
-} // namespace dpp
+}

--- a/include/dpp/prune.h
+++ b/include/dpp/prune.h
@@ -77,4 +77,4 @@ public:
 	json to_json(bool with_id = false) const; // Intentional shadow of json_interface, mostly present for documentation
 };
 
-} // namespace dpp
+}

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -671,4 +671,4 @@ public:
 	bool is_globally_ratelimited() const;
 };
 
-} // namespace dpp
+}

--- a/include/dpp/restrequest.h
+++ b/include/dpp/restrequest.h
@@ -294,4 +294,4 @@ template<class T> inline void rest_request_vector(dpp::cluster* c, const char* b
 }
 
 
-} // namespace dpp
+}

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -335,4 +335,4 @@ typedef std::function<void(const confirmation_callback_t&)> command_completion_e
  * @brief Automatically JSON encoded HTTP result
  */
 typedef std::function<void(json&, const http_request_completion_t&)> json_encode_t;
-} // namespace dpp
+}

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -994,5 +994,5 @@ typedef std::unordered_map<snowflake, role> role_map;
  */
 typedef std::vector<application_role_connection_metadata> application_role_connection_metadata_list;
 
-} // namespace dpp
+}
 

--- a/include/dpp/sku.h
+++ b/include/dpp/sku.h
@@ -173,4 +173,4 @@ public:
  */
 typedef std::unordered_map<snowflake, sku> sku_map;
 
-} // namespace dpp
+}

--- a/include/dpp/snowflake.h
+++ b/include/dpp/snowflake.h
@@ -269,7 +269,7 @@ public:
 	}
 };
 
-} // namespace dpp
+}
 
 template<>
 struct std::hash<dpp::snowflake>

--- a/include/dpp/sslclient.h
+++ b/include/dpp/sslclient.h
@@ -257,4 +257,4 @@ public:
 	virtual void log(dpp::loglevel severity, const std::string &msg) const;
 };
 
-} // namespace dpp
+}

--- a/include/dpp/stage_instance.h
+++ b/include/dpp/stage_instance.h
@@ -109,4 +109,4 @@ public:
  */
 typedef std::unordered_map<snowflake, stage_instance> stage_instance_map;
 
-} // namespace dpp
+}

--- a/include/dpp/stringops.h
+++ b/include/dpp/stringops.h
@@ -220,4 +220,4 @@ template <typename T> std::string leading_zeroes(T i, size_t width)
 	return stream.str();
 }
 
-} // namespace dpp
+}

--- a/include/dpp/sync.h
+++ b/include/dpp/sync.h
@@ -78,4 +78,4 @@ template<typename T, class F, class... Ts> T sync(class cluster* c, F func, Ts&&
 	return _f.get();
 }
 
-} // namespace dpp
+}

--- a/include/dpp/timed_listener.h
+++ b/include/dpp/timed_listener.h
@@ -102,4 +102,4 @@ public:
 	}
 };
 
-} // namespace dpp
+}

--- a/include/dpp/timer.h
+++ b/include/dpp/timer.h
@@ -129,4 +129,4 @@ public:
 	~oneshot_timer();
 };
 
-} // namespace dpp
+}

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -581,4 +581,4 @@ void from_json(const nlohmann::json& j, user_identified& u);
  */
 typedef std::unordered_map<snowflake, user> user_map;
 
-} // namespace dpp
+}

--- a/include/dpp/utility.h
+++ b/include/dpp/utility.h
@@ -1066,4 +1066,4 @@ struct alignas(T) dummy {
 };
 
 } // namespace utility
-} // namespace dpp
+}

--- a/include/dpp/voiceregion.h
+++ b/include/dpp/voiceregion.h
@@ -123,4 +123,4 @@ public:
  */
 typedef std::unordered_map<std::string, voiceregion> voiceregion_map;
 
-} // namespace dpp
+}

--- a/include/dpp/voicestate.h
+++ b/include/dpp/voicestate.h
@@ -176,4 +176,4 @@ public:
 /** A container of voicestates */
 typedef std::unordered_map<std::string, voicestate> voicestate_map;
 
-} // namespace dpp
+}

--- a/include/dpp/webhook.h
+++ b/include/dpp/webhook.h
@@ -196,4 +196,4 @@ public:
  */
 typedef std::unordered_map<snowflake, webhook> webhook_map;
 
-} // namespace dpp
+}

--- a/include/dpp/wsclient.h
+++ b/include/dpp/wsclient.h
@@ -237,4 +237,4 @@ public:
 	void send_close_packet();
 };
 
-} // namespace dpp
+}

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -21,10 +21,7 @@
  ************************************************************************************/
 #include <dpp/application.h>
 #include <dpp/discordevents.h>
-#include <dpp/snowflake.h>
-#include <dpp/managed.h>
 #include <dpp/json.h>
-#include <iostream>
 
 namespace dpp {
 
@@ -168,5 +165,4 @@ std::string application::get_icon_url(uint16_t size, const image_type format) co
 	return "";
 }
 
-} // namespace dpp
-
+}

--- a/src/dpp/auditlog.cpp
+++ b/src/dpp/auditlog.cpp
@@ -74,5 +74,5 @@ auditlog& auditlog::fill_from_json_impl(nlohmann::json* j) {
 	return *this;
 }
 
-} // namespace dpp
+}
 

--- a/src/dpp/automod.cpp
+++ b/src/dpp/automod.cpp
@@ -186,5 +186,5 @@ json automod_rule::to_json_impl(bool with_id) const {
 	return j;
 }
 
-} // namespace dpp
+}
 

--- a/src/dpp/ban.cpp
+++ b/src/dpp/ban.cpp
@@ -40,5 +40,5 @@ ban& ban::fill_from_json_impl(nlohmann::json* j) {
 	return *this;
 }
 
-} // namespace dpp
+}
 

--- a/src/dpp/cache.cpp
+++ b/src/dpp/cache.cpp
@@ -21,10 +21,8 @@
  ************************************************************************************/
 #include <dpp/export.h>
 #include <mutex>
-#include <iostream>
 #include <variant>
 #include <dpp/cache.h>
-#include <dpp/exception.h>
 
 namespace dpp {
 
@@ -85,4 +83,4 @@ cache_helper(role, role_cache, find_role, get_role_cache, get_role_count);
 cache_helper(guild, guild_cache, find_guild, get_guild_cache, get_guild_count);
 cache_helper(emoji, emoji_cache, find_emoji, get_emoji_cache, get_emoji_count);
 
-} // namespace dpp
+}

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -22,7 +22,6 @@
 #include <dpp/channel.h>
 #include <dpp/cache.h>
 #include <dpp/guild.h>
-#include <dpp/user.h>
 #include <dpp/role.h>
 #include <dpp/discordevents.h>
 #include <dpp/stringops.h>
@@ -580,4 +579,4 @@ forum_layout_type channel::get_default_forum_layout() const {
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -21,17 +21,9 @@
 #include <map>
 #include <dpp/exception.h>
 #include <dpp/cluster.h>
-#include <dpp/discordclient.h>
-#include <dpp/discordevents.h>
-#include <dpp/message.h>
-#include <dpp/cache.h>
-#include <dpp/once.h>
-#include <dpp/sync.h>
 #include <chrono>
 #include <iostream>
 #include <dpp/json.h>
-#include <utility>
-#include <algorithm>
 
 namespace dpp {
 

--- a/src/dpp/cluster/appcommand.cpp
+++ b/src/dpp/cluster/appcommand.cpp
@@ -191,4 +191,4 @@ void cluster::interaction_followup_get_original(const std::string &token, comman
 	rest_request<message>(this, API_PATH "/webhooks",std::to_string(me.id), utility::url_encode(token) + "/messages/@original", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/automod.cpp
+++ b/src/dpp/cluster/automod.cpp
@@ -43,4 +43,4 @@ void cluster::automod_rule_delete(snowflake guild_id, snowflake rule_id, command
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "/auto-moderation/rules/" + std::to_string(rule_id), m_delete, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -101,4 +101,4 @@ void cluster::channel_set_voice_status(snowflake channel_id, const std::string& 
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "voice-status", m_put, j.dump(-1, ' ', false, json::error_handler_t::replace), callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/confirmation.cpp
+++ b/src/dpp/cluster/confirmation.cpp
@@ -161,4 +161,4 @@ error_info confirmation_callback_t::get_error() const {
 	return {};
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/dm.cpp
+++ b/src/dpp/cluster/dm.cpp
@@ -63,4 +63,4 @@ void cluster::gdm_remove(snowflake channel_id, snowflake user_id, command_comple
 	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "recipients/" + std::to_string(user_id), m_delete, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/emoji.cpp
+++ b/src/dpp/cluster/emoji.cpp
@@ -81,4 +81,4 @@ void cluster::application_emoji_delete(snowflake emoji_id, command_completion_ev
 	rest_request<confirmation>(this, API_PATH "/applications", me.id.str(), "emojis/" + emoji_id.str(), m_delete, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/entitlement.cpp
+++ b/src/dpp/cluster/entitlement.cpp
@@ -81,4 +81,4 @@ void cluster::entitlement_consume(const class snowflake entitlement_id, command_
 	rest_request<confirmation>(this, API_PATH "/applications", me.id.str(), "entitlements/" + entitlement_id.str() + "/consume", m_post, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/gateway.cpp
+++ b/src/dpp/cluster/gateway.cpp
@@ -26,4 +26,4 @@ void cluster::get_gateway_bot(command_completion_event_t callback) {
 	rest_request<gateway>(this, API_PATH "/gateway", "bot", "", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -169,4 +169,4 @@ void cluster::guild_edit_welcome_screen(snowflake guild_id, const struct welcome
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -152,4 +152,4 @@ void cluster::guild_search_members(snowflake guild_id, const std::string& query,
 	});
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/invite.cpp
+++ b/src/dpp/cluster/invite.cpp
@@ -35,4 +35,4 @@ void cluster::invite_get(const std::string &invite_code, command_completion_even
 	rest_request<invite>(this, API_PATH "/invites", utility::url_encode(invite_code) + "?with_counts=true&with_expiration=true", "", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/json_interface.cpp
+++ b/src/dpp/cluster/json_interface.cpp
@@ -25,4 +25,4 @@
 namespace dpp {
 
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -208,4 +208,4 @@ void cluster::channel_pins_get(snowflake channel_id, command_completion_event_t 
 	rest_request_list<message>(this, API_PATH "/channels", std::to_string(channel_id), "pins", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/role.cpp
+++ b/src/dpp/cluster/role.cpp
@@ -70,4 +70,4 @@ void cluster::user_application_role_connection_update(snowflake application_id, 
 	rest_request<application_role_connection>(this, API_PATH "/users/@me/applications", std::to_string(application_id), "role-connection", m_put, connection.build_json(), callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/scheduled_event.cpp
+++ b/src/dpp/cluster/scheduled_event.cpp
@@ -68,4 +68,4 @@ void cluster::guild_event_get(snowflake guild_id, snowflake event_id, command_co
 	rest_request<scheduled_event>(this, API_PATH "/guilds", std::to_string(guild_id), "/scheduled-events/" + std::to_string(event_id) + "?with_user_count=true", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/sku.cpp
+++ b/src/dpp/cluster/sku.cpp
@@ -27,4 +27,4 @@ void cluster::skus_get(command_completion_event_t callback) {
 	rest_request_list<sku>(this, API_PATH "/applications", me.id.str(), "entitlements", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/stage_instance.cpp
+++ b/src/dpp/cluster/stage_instance.cpp
@@ -39,4 +39,4 @@ void cluster::stage_instance_delete(const snowflake channel_id, command_completi
 	rest_request<confirmation>(this, API_PATH "/stage-instances", std::to_string(channel_id), "", m_delete, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/sticker.cpp
+++ b/src/dpp/cluster/sticker.cpp
@@ -55,4 +55,4 @@ void cluster::sticker_packs_get(command_completion_event_t callback) {
 	rest_request_list<sticker_pack>(this, API_PATH "/sticker-packs", "", "", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/template.cpp
+++ b/src/dpp/cluster/template.cpp
@@ -60,4 +60,4 @@ void cluster::template_get(const std::string &code, command_completion_event_t c
 	rest_request<dtemplate>(this, API_PATH "/guilds", "templates", code, m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/thread.cpp
+++ b/src/dpp/cluster/thread.cpp
@@ -191,4 +191,4 @@ void cluster::thread_get(snowflake thread_id, command_completion_event_t callbac
 	rest_request<thread>(this, API_PATH "/channels", std::to_string(thread_id), "", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/timer.cpp
+++ b/src/dpp/cluster/timer.cpp
@@ -146,4 +146,4 @@ oneshot_timer::~oneshot_timer() {
 	cancel();
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/user.cpp
+++ b/src/dpp/cluster/user.cpp
@@ -129,4 +129,4 @@ void cluster::user_get_cached(snowflake user_id, command_completion_event_t call
 	rest_request<user_identified>(this, API_PATH "/users", std::to_string(user_id), "", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/voice.cpp
+++ b/src/dpp/cluster/voice.cpp
@@ -32,4 +32,4 @@ void cluster::guild_get_voice_regions(snowflake guild_id, command_completion_eve
 	rest_request_list<voiceregion>(this, API_PATH "/guilds", std::to_string(guild_id), "regions", m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -117,4 +117,4 @@ void cluster::get_webhook_with_token(snowflake webhook_id, const std::string &to
 	rest_request<webhook>(this, API_PATH "/webhooks", std::to_string(webhook_id), utility::url_encode(token), m_get, "", callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/commandhandler.cpp
+++ b/src/dpp/commandhandler.cpp
@@ -20,7 +20,6 @@
  ************************************************************************************/
 #include <dpp/commandhandler.h>
 #include <dpp/cluster.h>
-#include <dpp/exception.h>
 #include <dpp/stringops.h>
 #include <sstream>
 #include <utility>
@@ -437,4 +436,4 @@ void commandhandler::thonk(command_source source, command_completion_event_t cal
 	thinking(source, callback);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -20,7 +20,6 @@
  *
  ************************************************************************************/
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <dpp/exception.h>
 #include <dpp/discordclient.h>
@@ -30,18 +29,6 @@
 #include <dpp/json.h>
 #include <dpp/etf.h>
 #include <zlib.h>
-#ifdef _WIN32
-	#include <WinSock2.h>
-	#include <WS2tcpip.h>
-	#include <io.h>
-#else
-	#include <unistd.h>
-	#include <netinet/in.h>
-	#include <resolv.h>
-	#include <netdb.h>
-	#include <sys/socket.h>
-	#include <netinet/tcp.h>
-#endif
 
 #define PATH_UNCOMPRESSED_JSON	"/?v=" DISCORD_API_VERSION "&encoding=json"
 #define PATH_COMPRESSED_JSON	"/?v=" DISCORD_API_VERSION "&encoding=json&compress=zlib-stream"
@@ -732,4 +719,4 @@ voiceconn& voiceconn::connect(snowflake guild_id) {
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -22,7 +22,7 @@
 /* OpenBSD errors when xopen_source is defined.
  * We want to make sure that OpenBSD does not define it.
  */
-#if !defined(__OpenBSD__)
+#ifndef __OpenBSD__
 	#ifndef _XOPEN_SOURCE
 		#define _XOPEN_SOURCE
 	#endif
@@ -35,11 +35,7 @@
 #include <stdlib.h>
 #include <dpp/discordevents.h>
 #include <dpp/discordclient.h>
-#include <dpp/event.h>
-#include <dpp/cache.h>
-#include <dpp/stringops.h>
 #include <dpp/json.h>
-#include <time.h>
 #include <iomanip>
 #include <sstream>
 
@@ -439,4 +435,4 @@ void discord_client::handle_event(const std::string &event, json &j, const std::
 	}
 }
 
-} // namespace dpp
+}

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -439,7 +439,6 @@ uint16_t discord_voice_client::get_iteration_interval() {
 	return this->iteration_interval;
 }
 
-}
 discord_voice_client& discord_voice_client::send_stop_frames(bool send_now) {
 	uint8_t silence_frames[sizeof(silence_packet) / sizeof(*silence_packet) * 5];
 	for (size_t i = 0; i < sizeof(silence_frames) / sizeof(*silence_frames); i++) {
@@ -451,4 +450,4 @@ discord_voice_client& discord_voice_client::send_stop_frames(bool send_now) {
 	return *this;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -20,16 +20,6 @@
  *
  ************************************************************************************/
 
-#ifdef _WIN32
-	#include <WinSock2.h>
-	#include <WS2tcpip.h>
-	#include <io.h>
-#else
-	#include <arpa/inet.h>
-	#include <netinet/in.h>
-	#include <sys/socket.h>
-#endif
-#include <string_view>
 #include <iostream>
 #include <algorithm>
 #include <cmath>
@@ -443,4 +433,4 @@ uint16_t discord_voice_client::get_iteration_interval() {
 	return this->iteration_interval;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -286,4 +286,4 @@ void voice_receive_t::reassign(discord_voice_client* vc, snowflake _user_id, con
 	audio_size = audio_data.size();
 }
 
-} // namespace dpp
+}

--- a/src/dpp/dns.cpp
+++ b/src/dpp/dns.cpp
@@ -21,7 +21,6 @@
  ************************************************************************************/
 
 #include <dpp/dns.h>
-#include <cerrno>
 #include <exception>
 #include <cstring>
 #include <mutex>

--- a/src/dpp/dtemplate.cpp
+++ b/src/dpp/dtemplate.cpp
@@ -57,4 +57,4 @@ json dtemplate::to_json_impl(bool with_id) const {
 	};
 }
 
-} // namespace dpp
+}

--- a/src/dpp/emoji.cpp
+++ b/src/dpp/emoji.cpp
@@ -22,7 +22,6 @@
 #include <dpp/emoji.h>
 #include <dpp/discordevents.h>
 #include <dpp/json.h>
-#include <dpp/exception.h>
 
 namespace dpp {
 
@@ -130,5 +129,5 @@ std::string emoji::get_url(uint16_t size, const dpp::image_type format, bool pre
 }
 
 
-} // namespace dpp
+}
 

--- a/src/dpp/entitlement.cpp
+++ b/src/dpp/entitlement.cpp
@@ -83,4 +83,4 @@ bool entitlement::is_consumed() const {
 	return flags & entitlement_flags::ent_consumed;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/etf.cpp
+++ b/src/dpp/etf.cpp
@@ -33,8 +33,6 @@
  ************************************************************************************/
 #include <dpp/etf.h>
 #include <dpp/sysdep.h>
-#include <dpp/discordevents.h>
-#include <dpp/exception.h>
 #include <dpp/json.h>
 #include <zlib.h>
 #include <iostream>
@@ -729,5 +727,5 @@ etf_buffer::etf_buffer(size_t initial) {
 
 etf_buffer::~etf_buffer() = default;
 
-} // namespace dpp
+}
 

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -20,9 +20,6 @@
  ************************************************************************************/
 #include <dpp/cache.h>
 #include <dpp/discordclient.h>
-#include <dpp/voicestate.h>
-#include <dpp/exception.h>
-#include <dpp/guild.h>
 #include <dpp/discordevents.h>
 #include <dpp/stringops.h>
 #include <dpp/json.h>
@@ -1196,4 +1193,4 @@ onboarding &onboarding::set_enabled(const bool is_enabled) {
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -27,8 +27,6 @@
 #include <climits>
 #include <dpp/httpsclient.h>
 #include <dpp/utility.h>
-#include <dpp/exception.h>
-#include <dpp/stringops.h>
 
 namespace dpp {
 
@@ -358,4 +356,4 @@ http_connect_info https_client::get_host_info(std::string url) {
 	return hci;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -25,8 +25,6 @@
 #include <dpp/json.h>
 #include <dpp/cache.h>
 
-
-
 namespace dpp {
 
 using json = nlohmann::json;
@@ -150,4 +148,4 @@ connection& connection::fill_from_json_impl(nlohmann::json* j) {
 	return *this;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/invite.cpp
+++ b/src/dpp/invite.cpp
@@ -23,8 +23,6 @@
 #include <dpp/discordevents.h>
 #include <dpp/json.h>
 
-
-
 namespace dpp {
 
 using json = nlohmann::json;
@@ -117,4 +115,4 @@ invite &invite::set_unique(const bool is_unique) {
 	return *this;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1548,4 +1548,4 @@ sticker& sticker::set_file_content(std::string_view fc) {
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/permissions.cpp
+++ b/src/dpp/permissions.cpp
@@ -27,4 +27,4 @@ permission::operator nlohmann::json() const {
 	return std::to_string(value);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/presence.cpp
+++ b/src/dpp/presence.cpp
@@ -21,11 +21,7 @@
  ************************************************************************************/
 #include <dpp/presence.h>
 #include <dpp/discordevents.h>
-#include <dpp/utility.h>
-#include <dpp/emoji.h>
 #include <dpp/json.h>
-
-
 
 namespace dpp {
 
@@ -35,8 +31,8 @@ std::string activity::get_large_asset_url(uint16_t size, const image_type format
 	if (!this->assets.large_image.empty() && this->application_id &&
 		this->assets.large_image.find(':') == std::string::npos) { // make sure it's not a prefixed proxy image
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
-										 "app-assets/" + std::to_string(this->application_id) + "/" + this->assets.large_image,
-										 format, size);
+			"app-assets/" + std::to_string(this->application_id) + "/" + this->assets.large_image,
+			format, size);
 	} else {
 		return std::string();
 	}
@@ -46,8 +42,8 @@ std::string activity::get_small_asset_url(uint16_t size, const image_type format
 	if (!this->assets.small_image.empty() && this->application_id &&
 		this->assets.small_image.find(':') == std::string::npos) { // make sure it's not a prefixed proxy image
 		return utility::cdn_endpoint_url({ i_jpg, i_png, i_webp },
-										 "app-assets/" + std::to_string(this->application_id) + "/" + this->assets.small_image,
-										 format, size);
+			"app-assets/" + std::to_string(this->application_id) + "/" + this->assets.small_image,
+			format, size);
 	} else {
 		return std::string();
 	}
@@ -308,4 +304,4 @@ presence_status presence::status() const {
 	return (presence_status)((flags >> PF_SHIFT_MAIN) & PF_STATUS_MASK);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/prune.cpp
+++ b/src/dpp/prune.cpp
@@ -51,4 +51,4 @@ json prune::to_json(bool with_id) const {
 	return to_json_impl(with_id);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -28,7 +28,6 @@
 #include <dpp/queues.h>
 #include <dpp/cluster.h>
 #include <dpp/httpsclient.h>
-#include <dpp/stringops.h>
 
 namespace dpp {
 
@@ -480,4 +479,4 @@ bool request_queue::is_globally_ratelimited() const
 	return this->globally_ratelimited;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -23,11 +23,7 @@
 #include <dpp/role.h>
 #include <dpp/cache.h>
 #include <dpp/discordevents.h>
-#include <dpp/permissions.h>
-#include <dpp/stringops.h>
 #include <dpp/json.h>
-
-
 
 namespace dpp {
 
@@ -485,4 +481,4 @@ json application_role_connection::to_json_impl(bool with_id) const {
 }
 
 
-} // namespace dpp
+}

--- a/src/dpp/scheduled_event.cpp
+++ b/src/dpp/scheduled_event.cpp
@@ -19,7 +19,6 @@
  *
  ************************************************************************************/
 #include <dpp/scheduled_event.h>
-#include <dpp/exception.h>
 #include <dpp/discordevents.h>
 #include <dpp/stringops.h>
 #include <dpp/json.h>
@@ -193,4 +192,4 @@ json scheduled_event::to_json_impl(bool with_id) const {
 	return j;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/sku.cpp
+++ b/src/dpp/sku.cpp
@@ -86,4 +86,4 @@ bool sku::is_user_subscription() const {
 	return flags & sku_flags::sku_user_subscription;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -20,7 +20,6 @@
  ************************************************************************************/
 #include <dpp/appcommand.h>
 #include <dpp/discordevents.h>
-#include <dpp/exception.h>
 #include <dpp/json.h>
 #include <dpp/stringops.h>
 #include <dpp/cache.h>
@@ -941,4 +940,4 @@ std::string command_interaction::get_mention() const {
 std::string slashcommand::get_mention() const {
 	return dpp::utility::slashcommand_mention(id, name);
 }
-} // namespace dpp
+}

--- a/src/dpp/snowflake.cpp
+++ b/src/dpp/snowflake.cpp
@@ -44,4 +44,4 @@ snowflake::operator json() const {
 	return std::to_string(value);
 }
 
-} // namespace dpp
+}

--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -37,20 +37,13 @@
 #else
 	/* Anyting other than Windows (e.g. sane OSes) */
 	#include <poll.h>
-	#include <netinet/in.h>
-	#include <resolv.h>
-	#include <netdb.h>
 	#include <sys/socket.h>
-	#include <netinet/tcp.h>
 	#include <unistd.h>
 #endif
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <csignal>
 #include <sys/types.h>
 #include <fcntl.h>
-#include <signal.h>
-#include <string.h>
+#include <cstring>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 /* Windows specific OpenSSL symbol weirdness */
@@ -676,4 +669,4 @@ ssl_client::~ssl_client()
 	cleanup();
 }
 
-} // namespace dpp
+}

--- a/src/dpp/stage_instance.cpp
+++ b/src/dpp/stage_instance.cpp
@@ -55,4 +55,4 @@ json stage_instance::to_json_impl(bool with_id) const {
 	return j;
 }
 
-} // namespace dpp
+}

--- a/src/dpp/thread.cpp
+++ b/src/dpp/thread.cpp
@@ -22,7 +22,6 @@
 #include <dpp/thread.h>
 #include <dpp/discordevents.h>
 
-
 namespace dpp {
 
 thread_member& thread_member::fill_from_json_impl(nlohmann::json* j) {

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -24,8 +24,8 @@
 #include <dpp/stringops.h>
 
 namespace dpp {
-using json = nlohmann::
-json;
+
+using json = nlohmann::json;
 
 /* A mapping of discord's flag values to our bitmap (they're different bit positions to fit other stuff in) */
 std::map<uint32_t, dpp::user_flags> usermap = {
@@ -46,12 +46,7 @@ std::map<uint32_t, dpp::user_flags> usermap = {
 	{ 1 << 22, 	dpp::u_active_developer},
 };
 
-user::user() :
-	managed(),
-	flags(0),
-	discriminator(0),
-	refcount(1)
-{
+user::user() : managed(), flags(0), discriminator(0), refcount(1) {
 }
 
 std::string user::get_mention(const snowflake& id) {
@@ -98,8 +93,8 @@ std::string user::get_avatar_url(uint16_t size, const image_type format, bool pr
 		return get_default_avatar_url();
 	} else if (this->id) {
 		return utility::cdn_endpoint_url_hash({ i_jpg, i_png, i_webp, i_gif },
-											  "avatars/" + std::to_string(this->id), this->avatar.to_string(),
-											  format, size, prefer_animated, has_animated_icon());
+			"avatars/" + std::to_string(this->id), this->avatar.to_string(),
+			format, size, prefer_animated, has_animated_icon());
 	} else {
 		return std::string();
 	}
@@ -108,12 +103,12 @@ std::string user::get_avatar_url(uint16_t size, const image_type format, bool pr
 std::string user::get_default_avatar_url() const {
 	if (this->discriminator) {
 		return utility::cdn_endpoint_url({ i_png },
-										 "embed/avatars/" + std::to_string(this->discriminator % 5),
-										 i_png, 0);
+			"embed/avatars/" + std::to_string(this->discriminator % 5),
+			i_png, 0);
 	} else if (this->id){
 		return utility::cdn_endpoint_url({ i_png },
-										 "embed/avatars/" + std::to_string((this->id >> 22) % 6),
-										 i_png, 0);
+			"embed/avatars/" + std::to_string((this->id >> 22) % 6),
+			i_png, 0);
 	} else {
 		return std::string();
 	}
@@ -122,8 +117,8 @@ std::string user::get_default_avatar_url() const {
 std::string user::get_avatar_decoration_url(uint16_t size) const {
 	if (this->id) {
 		return utility::cdn_endpoint_url_hash({ i_png },
-											  "avatar-decorations/" + std::to_string(this->id), this->avatar_decoration.to_string(),
-											  i_png, size);
+			"avatar-decorations/" + std::to_string(this->id), this->avatar_decoration.to_string(),
+			i_png, size);
 	} else {
 		return std::string();
 	}
@@ -253,8 +248,8 @@ bool user_identified::has_animated_banner() const {
 std::string user_identified::get_banner_url(uint16_t size, const image_type format, bool prefer_animated) const {
 	if (!this->banner.to_string().empty() && this->id) {
 		return utility::cdn_endpoint_url_hash({ i_jpg, i_png, i_webp, i_gif },
-											  "banners/" + std::to_string(this->id), this->banner.to_string(),
-											  format, size, prefer_animated, has_animated_banner());
+			"banners/" + std::to_string(this->id), this->banner.to_string(),
+			format, size, prefer_animated, has_animated_banner());
 	} else {
 		return std::string();
 	}
@@ -309,4 +304,4 @@ void from_json(const nlohmann::json& j, user& u) {
 	}
 }
 
-} // namespace dpp
+}

--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -21,7 +21,6 @@
  ************************************************************************************/
 #include <dpp/utility.h>
 #include <dpp/stringops.h>
-#include <dpp/exception.h>
 #include <dpp/version.h>
 #include <ctime>
 #include <iomanip>
@@ -34,9 +33,6 @@
 #include <streambuf>
 #include <array>
 #include <dpp/cluster.h>
-#include <dpp/dispatcher.h>
-#include <dpp/message.h>
-#include <dpp/discordevents.h>
 
 #ifdef _WIN32
 	#include <stdio.h>
@@ -936,4 +932,4 @@ void set_thread_name(const std::string& name) {
 	#endif
 }
 
-} // namespace dpp::utility
+}

--- a/src/dpp/voice/enabled/audio_mix.cpp
+++ b/src/dpp/voice/enabled/audio_mix.cpp
@@ -21,14 +21,12 @@
  ************************************************************************************/
 
 #include <string_view>
-#include <iostream>
 #include <fstream>
 #include <algorithm>
 #include <cmath>
 #include <dpp/exception.h>
 #include <dpp/isa_detection.h>
 #include <dpp/discordvoiceclient.h>
-#include <dpp/json.h>
 #include <opus/opus.h>
 
 namespace dpp {

--- a/src/dpp/voice/enabled/cleanup.cpp
+++ b/src/dpp/voice/enabled/cleanup.cpp
@@ -25,10 +25,8 @@
 #include <dpp/exception.h>
 #include <dpp/isa_detection.h>
 #include <dpp/discordvoiceclient.h>
-
 #include <opus/opus.h>
 #include "../../dave/encryptor.h"
-
 #include "enabled.h"
 
 namespace dpp {

--- a/src/dpp/voiceregion.cpp
+++ b/src/dpp/voiceregion.cpp
@@ -72,5 +72,4 @@ bool voiceregion::is_custom() const {
 	return flags & v_custom;
 }
 
-} // namespace dpp
-
+}

--- a/src/dpp/voicestate.cpp
+++ b/src/dpp/voicestate.cpp
@@ -90,5 +90,4 @@ bool voicestate::is_suppressed() const {
 	return flags & vs_suppress;
 }
 
-} // namespace dpp
-
+}

--- a/src/dpp/webhook.cpp
+++ b/src/dpp/webhook.cpp
@@ -22,7 +22,6 @@
 #include <dpp/webhook.h>
 #include <dpp/discordevents.h>
 #include <dpp/json.h>
-#include <dpp/exception.h>
 
 namespace dpp {
 
@@ -101,5 +100,4 @@ webhook& webhook::load_image(const std::string &image_blob, const image_type typ
 	return *this;
 }
 
-} // namespace dpp
-
+}

--- a/src/dpp/wsclient.cpp
+++ b/src/dpp/wsclient.cpp
@@ -331,4 +331,4 @@ void websocket_client::close()
 	ssl_client::close();
 }
 
-} // namespace dpp
+}


### PR DESCRIPTION
Removes redundant includes from the cpp files.
Also as we agreed we didnt need to flag namespace closing with a comment (all good ides can do this and we rarely go more than one namespace deep, the `dpp` namespace) i have gone through and removed them.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
