### PR TITLE
feat: add support for user apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     target-branch: "dev"
 
   - package-ecosystem: github-actions

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -1489,6 +1489,7 @@ public:
 	 * @brief True if this command should be allowed in a DM
 	 * D++ defaults this to false. Cannot be set to true in a guild
 	 * command, only a global command.
+	 * @deprecated Use dpp::slashcommand_t::set_interaction_contexts instead
 	 */
 	bool dm_permission;
 

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -19,6 +19,7 @@
  *
  ************************************************************************************/
 #pragma once
+#include <dpp/integration.h>
 #include <dpp/export.h>
 #include <dpp/snowflake.h>
 #include <dpp/managed.h>
@@ -773,6 +774,26 @@ enum interaction_type {
 	it_modal_submit = 5,
 };
 
+/*
+* @brief Context type where the interaction can be used or triggered from, e.g. guild, user etc
+*/
+enum interaction_context_type {
+	/**
+	 * @brief Interaction can be used within servers
+	 */
+	itc_guild = 0,
+
+	/**
+	 * @brief Interaction can be used within DMs with the app's bot user
+	 */
+	itc_bot_dm = 1,
+
+	/**
+	 * @brief Interaction can be used within Group DMs and DMs other than the app's bot user
+	 */
+	itc_private_channel = 2,
+};
+
 /**
  * @brief Right-click context menu types
  */
@@ -952,6 +973,16 @@ protected:
 	virtual json to_json_impl(bool with_id = false) const;
 
 public:
+	/**
+	 * @brief Context where the interaction was triggered from
+	 */
+	std::map<application_integration_types, snowflake> authorizing_integration_owners;
+
+	/**
+	 * @brief Context where the interaction was triggered from
+	 */
+	std::optional<interaction_context_type> context;
+
 	/**
 	 * @brief ID of the application this interaction is for.
 	 */
@@ -1421,11 +1452,21 @@ public:
 	permission default_member_permissions;
 
 	/**
+	 * @brief Installation contexts where the command is available, only for globally-scoped commands. Defaults to your app's configured contexts
+	 */
+	std::vector<application_integration_types> integration_types;
+
+	/**
+	 * @brief Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+	 */
+	std::vector<interaction_context_type> contexts;
+
+	/**
 	 * @brief True if this command should be allowed in a DM
 	 * D++ defaults this to false. Cannot be set to true in a guild
 	 * command, only a global command.
 	 */
-	bool dm_permission;
+	[[deprecated("Use contexts instead.")]] bool dm_permission;
 
 	/**
 	 * @brief Indicates whether the command is [age-restricted](https://discord.com/developers/docs/interactions/application-commands#agerestricted-commands).
@@ -1542,6 +1583,14 @@ public:
 	 * @return slashcommand& reference to self for chaining of calls
 	 */
 	slashcommand& set_application_id(snowflake i);
+
+	/**
+	 * @brief Set the interaction contexts for the command
+	 *
+	 * @param contexts the contexts to set
+	 * @return slashcommand& reference to self for chaining of calls
+	 */
+	slashcommand& set_interaction_contexts(std::vector<interaction_context_type> contexts);
 
 	/**
 	 * @brief Adds a permission to the command

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -1225,6 +1225,30 @@ public:
 	 * is not for a command.
 	 */
 	std::string get_command_name() const;
+
+	/**
+	 * @brief Get the user who installed the application for a given type.
+	 * @param type Type of installation for the command, e.g. dpp::ait_guild_install or
+	 * dpp::ait_user_install.
+	 * @return The snowflake of the user. In the event this type is not allowed for the
+	 * given command, this will return a default-initialised snowflake with value 0.
+	 */
+	dpp::snowflake get_authorizing_integration_owner(application_integration_types type) const;
+
+	/**
+	 * @brief Returns true if this interaction occurred as a user-app interaction, e.g.
+	 * within a DM or group DM, added to the user not a guild.
+	 * @return true if a user-app interaction
+	 */
+	bool is_user_app_interaction() const;
+
+	/**
+	 * @brief Returns true if this interaction occurred as a guild-invited interaction, e.g.
+	 * within a guild's channel, or a DM of a user in that guild.
+	 * @return true if a guild interaction
+	 */
+	bool is_guild_interaction() const;
+
 };
 
 /**
@@ -1466,7 +1490,7 @@ public:
 	 * D++ defaults this to false. Cannot be set to true in a guild
 	 * command, only a global command.
 	 */
-	[[deprecated("Use contexts instead.")]] bool dm_permission;
+	bool dm_permission;
 
 	/**
 	 * @brief Indicates whether the command is [age-restricted](https://discord.com/developers/docs/interactions/application-commands#agerestricted-commands).

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -21,6 +21,7 @@
  ************************************************************************************/
 
 #pragma once
+#include <dpp/integration.h>
 #include <dpp/export.h>
 #include <dpp/snowflake.h>
 #include <dpp/managed.h>
@@ -30,6 +31,8 @@
 #include <dpp/permissions.h>
 #include <dpp/json_fwd.h>
 #include <dpp/json_interface.h>
+#include <map>
+#include <optional>
 
 namespace dpp {
 
@@ -210,6 +213,13 @@ public:
 };
 
 /**
+ *  * @brief Configuration object for an app installation
+ *   */
+struct integration_configuration {
+		std::optional<application_install_params> oauth2_install_params;
+};
+
+/**
  * @brief The application class represents details of a bot application
  */
 class DPP_EXPORT application : public managed, public json_interface<application> {
@@ -356,6 +366,11 @@ public:
 	 * @brief Settings for the application's default in-app authorization link, if enabled.
 	 */
 	application_install_params install_params;
+
+	/**
+	 * @brief Default scopes and permissions for each supported installation context
+	 */
+	std::map<application_integration_types, integration_configuration> integration_types_config;
 
 	/**
 	 * @brief The application's default custom authorization link, if enabled.

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -213,9 +213,9 @@ public:
 };
 
 /**
- *  * @brief Configuration object for an app installation
- *   */
-struct integration_configuration {
+ * @brief Configuration object for an app installation
+ */
+struct DPP_EXPORT integration_configuration {
 		std::optional<application_install_params> oauth2_install_params;
 };
 

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -31,6 +31,20 @@
 namespace dpp {
 
 /**
+ * @brief Where an app can be installed, also called its supported installation contexts.
+ */
+enum application_integration_types {
+	/**
+	* @brief Installable to servers
+	*/
+	ait_guild_install = 0,
+	/**
+	* @brief Installable to users
+	*/
+	ait_user_install = 1,
+};
+
+/**
  * @brief Integration types
  */
 enum integration_type {

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2011,6 +2011,43 @@ namespace cache_policy {
 };
 
 /**
+ * @brief Metadata about the interaction, including the source of the interaction and relevant server and user IDs.
+ */
+struct DPP_EXPORT interaction_metadata_type {
+
+	/**
+	 * @brief ID of the interaction
+	 */
+	snowflake id;
+
+	/**
+	 * @brief User who triggered the interaction
+	 */
+	uint8_t type;
+
+	/**
+	 * @brief User who triggered the interaction
+	 */
+	user usr;
+
+	/**
+	 * @brief ID of the original response message, present only on follow-up messages
+	 */
+	snowflake original_response_message_id;
+
+	/**
+	 * @brief ID of the message that contained interactive component, present only on messages created from component interactions
+	 */
+	snowflake interacted_message_id;
+
+	// FIXME: Add this field sometime 
+	/**
+	 * @brief Metadata for the interaction that was used to open the modal, present only on modal submit interactions
+	 */
+	// interaction_metadata_type triggering_interaction_metadata;
+};
+
+/**
  * @brief Message Reference type
  */
 enum DPP_EXPORT message_ref_type : uint8_t {
@@ -2192,7 +2229,7 @@ public:
 	/**
 	 * @brief Reference to an interaction
 	 */
-	struct message_interaction_struct {
+	DPP_DEPRECATED("Use interaction_metadata instead.") struct message_interaction_struct{
 		/**
 		 * @brief ID of the interaction.
 		 */
@@ -2213,6 +2250,11 @@ public:
 		 */
 		user usr;
 	} interaction;
+
+	/**
+	 * @brief Sent if the message is sent as a result of an interaction
+	 */
+	interaction_metadata_type interaction_metadata;
 
 	/**
 	 * @brief Allowed mentions details

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2229,7 +2229,7 @@ public:
 	/**
 	 * @brief Reference to an interaction
 	 */
-	DPP_DEPRECATED("Use interaction_metadata instead.") struct message_interaction_struct{
+	struct message_interaction_struct {
 		/**
 		 * @brief ID of the interaction.
 		 */

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -21,11 +21,27 @@
  ************************************************************************************/
 #include <dpp/application.h>
 #include <dpp/discordevents.h>
+#include <dpp/integration.h>
 #include <dpp/json.h>
 
 namespace dpp {
 
 using json = nlohmann::json;
+
+void from_json(const json &j, application_integration_types& out) {
+	out = static_cast<dpp::application_integration_types>(j.get<int>());
+}
+
+void from_json(const json &j, application_install_params& out) {
+	out.permissions = j.at("permissions").get<uint64_t>();
+	j.at("scopes").get_to(out.scopes);
+}
+
+void from_json(const json &j, integration_configuration& out) {
+	if (auto it = j.find("oauth2_install_params"); it != j.end()) {
+		it->get_to(out.oauth2_install_params.value());
+	}
+}
 
 application::application() : managed(0), bot_public(false), bot_require_code_grant(false), guild_id(0), primary_sku_id(0), flags(0)
 {
@@ -114,6 +130,10 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 		for (const auto& scope : p["scopes"]) {
 			this->install_params.scopes.push_back(to_string(scope));
 		}
+	}
+
+	if (auto it = j->find("integration_types_config"); it != j->end()) {
+		it->get_to(this->integration_types_config);
 	}
 
 	set_string_not_null(j, "custom_install_url", custom_install_url);

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -21,7 +21,6 @@
  ************************************************************************************/
 #include <dpp/application.h>
 #include <dpp/discordevents.h>
-#include <dpp/integration.h>
 #include <dpp/json.h>
 
 namespace dpp {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -649,14 +649,20 @@ std::optional<uint32_t> poll::get_vote_count(uint32_t answer_id) const noexcept 
 	return 0;
 }
 
-
+void from_json(const json& j, interaction_metadata_type& i) {
+	i.id = snowflake_not_null(&j, "id");
+	i.interacted_message_id = snowflake_not_null(&j, "interacted_message_id");
+	i.original_response_message_id = snowflake_not_null(&j, "original_response_message_id");
+	i.type = j["type"];
+	i.usr = j["usr"];
+}
 
 embed::~embed() = default;
 
 embed::embed() : timestamp(0) {
 }
 
-message::message() : managed(0), channel_id(0), guild_id(0), sent(0), edited(0), webhook_id(0),
+message::message() : managed(0), channel_id(0), guild_id(0), sent(0), edited(0), webhook_id(0), interaction_metadata{},
 	owner(nullptr), type(mt_default), flags(0), pinned(false), tts(false), mention_everyone(false)
 {
 	message_reference.channel_id = 0;
@@ -1330,6 +1336,11 @@ message& message::fill_from_json(json* d, cache_policy_t cp) {
 			this->author = *authoruser;
 		}
 	}
+
+	if (auto it = d->find("interaction_medata"); it != d->end()) {
+		it->get_to(this->interaction_metadata);
+	}
+
 	if (d->find("interaction") != d->end()) {
 		json& inter = (*d)["interaction"];
 		interaction.id = snowflake_not_null(&inter, "id");

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -23,7 +23,8 @@
 #include <dpp/json.h>
 #include <dpp/stringops.h>
 #include <dpp/cache.h>
-#include <iostream>
+#include <algorithm>
+#include <iterator>
 
 namespace dpp {
 
@@ -73,6 +74,14 @@ slashcommand& slashcommand::fill_from_json_impl(nlohmann::json* j) {
 
 	type = (slashcommand_contextmenu_type)int8_not_null(j, "type");
 	set_object_array_not_null<command_option>(j, "options", options); // command_option fills recursive
+	
+	if (auto it = j->find("integration_types"); it != j->end()) {
+		it->get_to(this->integration_types);
+	}
+
+	if (auto it = j->find("contexts"); it != j->end()) {
+		it->get_to(this->contexts);
+	}
 	return *this;
 }
 
@@ -251,6 +260,15 @@ void to_json(json& j, const slashcommand& p) {
 		}
 	}
 
+	if (p.integration_types.size()) {
+		j["integration_types"] = p.integration_types;
+	}
+
+	// TODO: Maybe a std::optional is better to differentiate
+	if (p.contexts.size()) {
+		j["contexts"] = p.contexts;
+	}
+
 	// DEPRECATED
 	// j["default_permission"] = p.default_permission;
 	j["application_id"] = std::to_string(p.application_id);
@@ -290,6 +308,11 @@ slashcommand& slashcommand::set_description(const std::string &d) {
 
 slashcommand& slashcommand::set_application_id(snowflake i) {
 	application_id = i;
+	return *this;
+}
+
+slashcommand& slashcommand::set_interaction_contexts(std::vector<interaction_context_type> contexts) {
+	this->contexts = std::move(contexts);
 	return *this;
 }
 
@@ -725,6 +748,14 @@ void from_json(const nlohmann::json& j, interaction& i) {
 			j.at("data").get_to(ai);
 			i.data = ai;
 		}
+	}
+
+	if (auto it = j.find("context"); it != j.end()) {
+		i.context = static_cast<interaction_context_type>(*it);
+	}
+
+	if (auto it = j.find("authorizing_integration_owners"); it != j.end()) {
+		it->get_to(i.authorizing_integration_owners);
 	}
 
 	if(j.contains("entitlements")) {

--- a/src/userapptest/userapp.cpp
+++ b/src/userapptest/userapp.cpp
@@ -47,13 +47,10 @@ int main() {
 		}
 	});
 
-	bot.on_slashcommand([](const auto& e) {
+	bot.register_command("userapp", [](const dpp::slashcommand_t& e) {
 		/**
 		 * Simple test output that shows the context of the command
 		 */
-		if (e.command.get_command_name() != "userapp") {
-			return;
-		}
 		e.reply("This is the `/userapp` command." + std::string(
 			e.command.is_user_app_interaction() ?
 			" Executing as a user interaction owned by user: <@" + e.command.get_authorizing_integration_owner(dpp::ait_user_install).str() + ">" :

--- a/src/userapptest/userapp.cpp
+++ b/src/userapptest/userapp.cpp
@@ -1,0 +1,65 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 Craig Edwards and D++ contributors 
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+
+#include <dpp/dpp.h>
+#include <iostream>
+
+int main() {
+	char* t = getenv("DPP_UNIT_TEST_TOKEN");
+
+	if (!t) {
+		std::cerr << "Missing DPP_UNIT_TEST_TOKEN\n";
+		exit(1);
+	}
+
+	dpp::cluster bot(t, dpp::i_default_intents);
+	bot.on_log(dpp::utility::cout_logger());
+
+	bot.on_ready([&bot](const auto& event) {
+		if (dpp::run_once<struct boot_t>()) {
+			/**
+			 * Create a slash command which has interaction context 'itc_private_channel'.
+			 * This is a user-app command which can be executed anywhere and is added to the user's profile.
+			 */
+			bot.global_bulk_command_create({
+				dpp::slashcommand("userapp", "Test user app command", bot.me.id)
+				.set_interaction_contexts({dpp::itc_guild, dpp::itc_bot_dm, dpp::itc_private_channel})
+			});
+		}
+	});
+
+	bot.on_slashcommand([](const auto& e) {
+		/**
+		 * Simple test output that shows the context of the command
+		 */
+		if (e.command.get_command_name() != "userapp") {
+			return;
+		}
+		e.reply("This is the `/userapp` command." + std::string(
+			e.command.is_user_app_interaction() ?
+			" Executing as a user interaction owned by user: <@" + e.command.get_authorizing_integration_owner(dpp::ait_user_install).str() + ">" :
+			" Executing as a guild interaction on guild id " + e.command.guild_id.str()
+		));
+	});
+
+	bot.start(dpp::st_wait);
+}


### PR DESCRIPTION
Finishes off support for user apps. Adds a few interaction methods, and fixes the interaction json parse to not die.
Fom original PR by Ray21

Documentation and examples to go into docs once this reaches master. For a working example see src/userapptest/userapp.cpp

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
