### PR TITLE
fix: commands should no longer crash when no context is defined

### DIFF
--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -74,14 +74,19 @@ slashcommand& slashcommand::fill_from_json_impl(nlohmann::json* j) {
 
 	type = (slashcommand_contextmenu_type)int8_not_null(j, "type");
 	set_object_array_not_null<command_option>(j, "options", options); // command_option fills recursive
-	
-	if (auto it = j->find("integration_types"); it != j->end()) {
-		it->get_to(this->integration_types);
+
+	if(j->contains("integration_types")) {
+		if (auto it = j->find("integration_types"); it != j->end() && !it->is_null()) {
+			it->get_to(this->integration_types);
+		}
 	}
 
-	if (auto it = j->find("contexts"); it != j->end()) {
-		it->get_to(this->contexts);
+	if(j->contains("contexts")) {
+		if (auto it = j->find("contexts"); it != j->end() && !it->is_null()) {
+			it->get_to(this->contexts);
+		}
 	}
+
 	return *this;
 }
 


### PR DESCRIPTION
This PR fixes #1310, fixing a crash when `contexts` is null (usually when a basic command is made).

Closes #1310 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
