### PR TITLE
fix: two segmentation faults in cluster::guild_edit_member and cluster::tick_timers/cluster::shutdown

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -319,6 +319,7 @@ void cluster::shutdown() {
 		delete t.second;
 	}
 	timer_list.clear();
+	next_timer.clear();
 	/* Terminate shards */
 	for (const auto& sh : shards) {
 		log(ll_info, "Terminating shard id " + std::to_string(sh.second->shard_id));

--- a/src/dpp/cluster/guild_member.cpp
+++ b/src/dpp/cluster/guild_member.cpp
@@ -30,7 +30,7 @@ void cluster::guild_add_member(const guild_member& gm, const std::string &access
 
 
 void cluster::guild_edit_member(const guild_member& gm, command_completion_event_t callback) {
-	this->post_rest(API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_patch, gm.build_json(), [this, &gm, callback](json &j, const http_request_completion_t& http) {
+	this->post_rest(API_PATH "/guilds", std::to_string(gm.guild_id), "members/" + std::to_string(gm.user_id), m_patch, gm.build_json(), [this, gm, callback](json &j, const http_request_completion_t& http) {
 		if (callback) {
 			callback(confirmation_callback_t(this, guild_member().fill_from_json(&j, gm.guild_id, gm.user_id), http));
 		}


### PR DESCRIPTION
`cluster::guild_edit_member` accesses invalid memory in its callback if the guild_member object is deallocated before the `post_rest` makes a call to the callback. Capturing the object as copy fixes this issue.

`cluster::shutdown` does not clear the `next_timer` map which causes segfaults in `cluster::tick_timers` if the timers are not removed before shutdown. Clearing the map after all timers are deleted resolves this.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.