### PR TITLE
breaking: Updated dpp::role comparison operators to now consider role IDs

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2170,8 +2170,8 @@ public:
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @param c Channel to set permissions for
 	 * @param overwrite_id Overwrite to change (a user or role ID)
-	 * @param allow allow permissions bitmask
-	 * @param deny deny permissions bitmask
+	 * @param allow Bitmask of allowed permissions (refer to enum dpp::permissions)
+	 * @param deny Bitmask of denied permissions (refer to enum dpp::permissions)
 	 * @param member true if the overwrite_id is a user id, false if it is a channel id
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
@@ -2185,8 +2185,8 @@ public:
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @param channel_id ID of the channel to set permissions for
 	 * @param overwrite_id Overwrite to change (a user or role ID)
-	 * @param allow allow permissions bitmask
-	 * @param deny deny permissions bitmask
+	 * @param allow Bitmask of allowed permissions (refer to enum dpp::permissions)
+	 * @param deny Bitmask of denied permissions (refer to enum dpp::permissions)
 	 * @param member true if the overwrite_id is a user id, false if it is a channel id
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().

--- a/include/dpp/cluster_sync_calls.h
+++ b/include/dpp/cluster_sync_calls.h
@@ -590,8 +590,8 @@ DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev
  * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
  * @param c Channel to set permissions for
  * @param overwrite_id Overwrite to change (a user or role ID)
- * @param allow allow permissions bitmask
- * @param deny deny permissions bitmask
+ * @param allow Bitmask of allowed permissions (refer to enum dpp::permissions)
+ * @param deny Bitmask of denied permissions (refer to enum dpp::permissions)
  * @param member true if the overwrite_id is a user id, false if it is a channel id
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
@@ -610,8 +610,8 @@ DPP_DEPRECATED("Please use coroutines instead of sync functions: https://dpp.dev
  * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
  * @param channel_id ID of the channel to set permissions for
  * @param overwrite_id Overwrite to change (a user or role ID)
- * @param allow allow permissions bitmask
- * @param deny deny permissions bitmask
+ * @param allow Bitmask of allowed permissions (refer to enum dpp::permissions)
+ * @param deny Bitmask of denied permissions (refer to enum dpp::permissions)
  * @param member true if the overwrite_id is a user id, false if it is a channel id
  * @return confirmation returned object on completion
  * \memberof dpp::cluster

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -324,19 +324,8 @@ public:
 	 * @param lhs first role to compare
 	 * @param rhs second role to compare
 	 * @return true if lhs is less than rhs
-	 *
-	 * @throws std::invalid_argument when roles of two different guilds are passed
 	 */
 	friend inline bool operator< (const role& lhs, const role& rhs) {
-        if (lhs.guild_id != rhs.guild_id) {
-	        throw std::invalid_argument("cannot compare roles from two different guilds");
-        }
-
-		// the @everyone role is always the lowest role in hierarchy
-		if (lhs.id == lhs.guild_id) {
-			return rhs.id != lhs.guild_id;
-		}
-
 		if (lhs.position == rhs.position) {
 			// the higher the IDs are, the lower the position
 			return lhs.id > rhs.id;
@@ -351,8 +340,6 @@ public:
 	 * @param lhs first role to compare
 	 * @param rhs second role to compare
 	 * @return true if lhs is greater than rhs
-	 *
-	 * @throws std::invalid_argument when roles of two different guilds are passed
 	 */
 	friend inline bool operator> (const role& lhs, const role& rhs) {
 		return !(lhs < rhs);
@@ -365,7 +352,7 @@ public:
 	 * @return true if is equal to other
 	 */
 	inline bool operator== (const role& other) const {
-		return this->position == other.position;
+		return this->id == other.id;
 	}
 
 	/**
@@ -375,7 +362,7 @@ public:
 	 * @return true if is not equal to other
 	 */
 	inline bool operator!= (const role& other) const {
-		return this->position != other.position;
+		return this->id != other.id;
 	}
 
 	/**

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -345,22 +345,13 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 	{
 		set_test(ROLE_COMPARE, false);
 		dpp::role role_1, role_2;
+		role_1.id = 99;
 		role_1.position = 1;
 		role_1.guild_id = 123;
+		role_1.id = 98;
 		role_2.position = 2;
 		role_2.guild_id = 123;
 		set_test(ROLE_COMPARE, role_1 < role_2 && !(role_1 > role_2) && role_1 != role_2);
-	}
-	{
-		set_test(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, false);
-		dpp::role role_1, role_2;
-		role_1.id = 123;
-		role_1.position = 2;
-		role_1.guild_id = 123;
-		role_2.id = 124;
-		role_2.position = 2;
-		role_2.guild_id = 123;
-		set_test(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, role_1 < role_2 && !(role_1 > role_2));
 	}
 	{
 		set_test(ROLE_COMPARE_CONSIDERING_ID, false);

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -342,11 +342,37 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 	set_test(TIMESTAMPTOSTRING, false);
 	set_test(TIMESTAMPTOSTRING, dpp::ts_to_string(1642611864) == "2022-01-19T17:04:24Z");
 
-	set_test(ROLE_COMPARE, false);
-	dpp::role role_1, role_2;
-	role_1.position = 1;
-	role_2.position = 2;
-	set_test(ROLE_COMPARE, role_1 < role_2 && role_1 != role_2);
+	{
+		set_test(ROLE_COMPARE, false);
+		dpp::role role_1, role_2;
+		role_1.position = 1;
+		role_1.guild_id = 123;
+		role_2.position = 2;
+		role_2.guild_id = 123;
+		set_test(ROLE_COMPARE, role_1 < role_2 && !(role_1 > role_2) && role_1 != role_2);
+	}
+	{
+		set_test(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, false);
+		dpp::role role_1, role_2;
+		role_1.id = 123;
+		role_1.position = 2;
+		role_1.guild_id = 123;
+		role_2.id = 124;
+		role_2.position = 2;
+		role_2.guild_id = 123;
+		set_test(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, role_1 < role_2 && !(role_1 > role_2));
+	}
+	{
+		set_test(ROLE_COMPARE_CONSIDERING_ID, false);
+		dpp::role role_1, role_2;
+		role_1.id = 99;
+		role_1.position = 2;
+		role_1.guild_id = 123;
+		role_2.id = 98;
+		role_2.position = 2;
+		role_2.guild_id = 123;
+		set_test(ROLE_COMPARE_CONSIDERING_ID, role_1 < role_2 && !(role_1 > role_2));
+	}
 
 	set_test(WEBHOOK, false);
 	try {

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -206,7 +206,6 @@ DPP_TEST(UTILITY_CDN_ENDPOINT_URL_HASH, "utility::cdn_endpoint_url_hash", tf_off
 DPP_TEST(STICKER_GET_URL, "sticker::get_url aka utility::cdn_endpoint_url_sticker", tf_offline);
 DPP_TEST(EMOJI_GET_URL, "emoji::get_url", tf_offline);
 DPP_TEST(ROLE_COMPARE, "role::operator<", tf_offline);
-DPP_TEST(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, "role::operator<", tf_offline);
 DPP_TEST(ROLE_COMPARE_CONSIDERING_ID, "role::operator<", tf_offline);
 DPP_TEST(ROLE_CREATE, "cluster::role_create", tf_online);
 DPP_TEST(ROLE_EDIT, "cluster::role_edit", tf_online);

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -206,6 +206,8 @@ DPP_TEST(UTILITY_CDN_ENDPOINT_URL_HASH, "utility::cdn_endpoint_url_hash", tf_off
 DPP_TEST(STICKER_GET_URL, "sticker::get_url aka utility::cdn_endpoint_url_sticker", tf_offline);
 DPP_TEST(EMOJI_GET_URL, "emoji::get_url", tf_offline);
 DPP_TEST(ROLE_COMPARE, "role::operator<", tf_offline);
+DPP_TEST(ROLE_COMPARE_CONSIDERING_EVERYONE_ROLE, "role::operator<", tf_offline);
+DPP_TEST(ROLE_COMPARE_CONSIDERING_ID, "role::operator<", tf_offline);
 DPP_TEST(ROLE_CREATE, "cluster::role_create", tf_online);
 DPP_TEST(ROLE_EDIT, "cluster::role_edit", tf_online);
 DPP_TEST(ROLE_DELETE, "cluster::role_delete", tf_online);


### PR DESCRIPTION
This is a **breaking change** for anyone using the comparison operators of the `dpp::role` class!

If two roles have the same position, their IDs are compared to find out which role is higher in the hierarchy. The higher the IDs are, the lower they are. Previously, only the position was compared.

Documentation: https://discord.com/developers/docs/topics/permissions#role-object-role-structure

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
