### PR TITLE
fix: dl.dpp.dev was not downloading rpms any more

### DIFF
--- a/docpages/dl.dpp.dev/index.php
+++ b/docpages/dl.dpp.dev/index.php
@@ -8,7 +8,7 @@ header("Pragma: no-cache");
 header("Status: 200 OK");
 
 // Split up url and set defaults
-list($version, $arch, $type) = explode('/', preg_replace('/https:\/\/dl\.dpp\.dev\//', '', $_SERVER['REDIRECT_SCRIPT_URI']), 3);
+list($_, $version, $arch, $type) = explode('/', preg_replace('/https:\/\/dl\.dpp\.dev\//', '', $_SERVER['REDIRECT_URL'] ?? ''), 4);
 $version = !empty($version) ? $version : 'latest';
 $arch = !empty($arch) ? $arch : 'linux-x64';
 $type = !empty($type) ? $type : 'deb';


### PR DESCRIPTION
this is already live on dl.dpp.dev as there is no automatic deployment of this code.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
