### PR TITLE
fix BUILD_VOICE_SUPPORT=OFF static build

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -411,17 +411,20 @@ if(DPP_FORMATTERS)
 endif()
 
 if (NOT BUILD_SHARED_LIBS)
-	add_library(dppstatic STATIC
+	if (HAVE_VOICE)
+		add_library(dppstatic STATIC
 			$<TARGET_OBJECTS:dpp>
 			$<TARGET_OBJECTS:hpke>
 			$<TARGET_OBJECTS:tls_syntax>
 			$<TARGET_OBJECTS:mls_vectors>
 			$<TARGET_OBJECTS:mlspp>
 			$<TARGET_OBJECTS:bytes>
-	)
-	if (HAVE_VOICE)
+	        )
 		target_link_libraries(dppstatic ${ZLIB_LIBRARIES} ${OPENSSL_LIBRARIES} ${OPUS_LIBRARIES} -static-libgcc -static-libstdc++)
 	else()
+ 		add_library(dppstatic STATIC
+			$<TARGET_OBJECTS:dpp>
+	        )
 		target_link_libraries(dppstatic ${ZLIB_LIBRARIES} ${OPENSSL_LIBRARIES})
 	endif()
 endif()


### PR DESCRIPTION
Building DPP statically with BUILD_VOICE_SUPPORT=OFF fails with undefined targets (related to HAVE_VOICE), so i put these targets in a if condition.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
