### PR TITLE
fix: unitialized sent_stop_frames causing nasty pause/play playback confusion

### DIFF
--- a/src/dpp/voice/enabled/constructor.cpp
+++ b/src/dpp/voice/enabled/constructor.cpp
@@ -41,6 +41,7 @@ discord_voice_client::discord_voice_client(dpp::cluster* _cluster, snowflake _ch
 	ssrc(0),
 	timescale(1000000),
 	paused(false),
+	sent_stop_frames(false),
 	encoder(nullptr),
 	repacketizer(nullptr),
 	fd(INVALID_SOCKET),


### PR DESCRIPTION
# FIX BOOG 🐛 🐛 🐛 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
