### PR TITLE
fix: thread safety for event objects (10.1 only)

### DIFF
--- a/docpages/example_code/collect_reactions.cpp
+++ b/docpages/example_code/collect_reactions.cpp
@@ -11,7 +11,7 @@ public:
 	/* Override the "completed" event and then output the number of collected reactions as a message. */
 	virtual void completed(const std::vector<dpp::collected_reaction>& list) override {
 		if (list.size()) {
-			owner->message_create(dpp::message(list[0].react_channel->id, "I collected " + std::to_string(list.size()) + " reactions!"));
+			owner->message_create(dpp::message(list[0].react_channel.id, "I collected " + std::to_string(list.size()) + " reactions!"));
 		} else {
 			owner->message_create(dpp::message("... I got nothin'."));
 		}

--- a/include/dpp/collector.h
+++ b/include/dpp/collector.h
@@ -166,27 +166,27 @@ public:
 	/**
 	 * @brief Reacting user.
 	 */
-	user react_user;
+	user react_user{};
 
 	/**
 	 * @brief Reacting guild.
 	 */
-	guild* react_guild{};
+	guild react_guild{};
 
 	/**
 	 * @brief Reacting guild member.
 	 */
-	guild_member react_member;
+	guild_member react_member{};
 
 	/**
 	 * @brief Reacting channel.
 	 */
-	channel* react_channel{};
+	channel react_channel{};
 
 	/**
 	 * @brief Reacted emoji.
 	 */
-	emoji react_emoji;
+	emoji react_emoji{};
 
 	/**
 	 * @brief Optional: ID of the user who authored the message which was reacted to.
@@ -351,7 +351,7 @@ public:
 	 * @param element element to filter
 	 * @return Returned item to add to the list, or nullptr to skip adding this element
 	 */
-	virtual const dpp::channel* filter(const dpp::channel_create_t& element) { return element.created; }
+	virtual const dpp::channel* filter(const dpp::channel_create_t& element) { return &element.created; }
 
 	/**
 	 * @brief Destroy the channel collector object
@@ -425,7 +425,7 @@ public:
 	 * @param element element to filter
 	 * @return Returned item to add to the list, or nullptr to skip adding this element
 	 */
-	virtual const dpp::role* filter(const dpp::guild_role_create_t& element) { return element.created; }
+	virtual const dpp::role* filter(const dpp::guild_role_create_t& element) { return &element.created; }
 
 	/**
 	 * @brief Destroy the role collector object

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -903,7 +903,7 @@ struct DPP_EXPORT guild_stickers_update_t : public event_dispatch_t {
 	/**
 	 * @brief Updating guild
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief stickers being updated
@@ -939,7 +939,7 @@ struct DPP_EXPORT channel_delete_t : public event_dispatch_t {
 	/**
 	 * @brief guild channel is being deleted from
 	 */
-	guild* deleting_guild = nullptr;
+	guild deleting_guild;
 
 	/**
 	 * @brief channel being deleted
@@ -957,12 +957,12 @@ struct DPP_EXPORT channel_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild channel is being updated on
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief channel being updated
 	 */
-	channel* updated = nullptr;
+	channel updated;
 };
 
 /**
@@ -1028,7 +1028,7 @@ struct DPP_EXPORT guild_member_remove_t : public event_dispatch_t {
 	/**
 	 * @brief guild user is being removed from
 	 */
-	guild* removing_guild = nullptr;
+	guild removing_guild;
 
 	/**
 	 * @brief Guild ID removed from
@@ -1069,12 +1069,12 @@ struct DPP_EXPORT guild_role_create_t : public event_dispatch_t {
 	/**
 	 * @brief guild role is being created on
 	 */
-	guild* creating_guild = nullptr;
+	guild creating_guild;
 
 	/**
 	 * @brief role being created
 	 */
-	role* created = nullptr;
+	role created;
 };
 
 /**
@@ -1087,18 +1087,18 @@ struct DPP_EXPORT typing_start_t : public event_dispatch_t {
 	/**
 	 * @brief guild user is typing on
 	 */
-	guild* typing_guild = nullptr;
+	guild typing_guild;
 
 	/**
 	 * @brief channel user is typing on
 	 */
-	channel* typing_channel = nullptr;
+	channel typing_channel;
 
 	/**
 	 * @brief user who is typing.
 	 * Can be nullptr if user is not cached
 	 */
-	user* typing_user = nullptr;
+	user typing_user;
 
 	/**
 	 * @brief User id of user typing.
@@ -1141,7 +1141,7 @@ struct DPP_EXPORT message_reaction_add_t : public event_dispatch_t {
 	/**
 	 * @brief Guild reaction occurred on
 	 */
-	guild* reacting_guild = nullptr;
+	guild reacting_guild;
 
 	/**
 	 * @brief User who reacted
@@ -1162,7 +1162,7 @@ struct DPP_EXPORT message_reaction_add_t : public event_dispatch_t {
 	 * @brief channel the reaction happened on (Optional)
 	 * @note only filled when the channel is cached
 	 */
-	channel* reacting_channel = nullptr;
+	channel reacting_channel;
 
 	/**
 	 * @brief emoji of reaction
@@ -1190,12 +1190,12 @@ struct DPP_EXPORT guild_members_chunk_t : public event_dispatch_t {
 	/**
 	 * @brief guild the members chunk is for
 	 */
-	guild* adding = nullptr;
+	guild adding;
 
 	/**
 	 * @brief list of members in the chunk
 	 */
-	guild_member_map* members = nullptr;
+	guild_member_map members;
 };
 
 /**
@@ -1208,7 +1208,7 @@ struct DPP_EXPORT message_reaction_remove_t : public event_dispatch_t {
 	/**
 	 * @brief Guild reaction occurred on
 	 */
-	guild* reacting_guild = nullptr;
+	guild reacting_guild;
 
 	/**
 	 * @brief User who reacted
@@ -1224,7 +1224,7 @@ struct DPP_EXPORT message_reaction_remove_t : public event_dispatch_t {
 	 * @brief channel the reaction happened on (optional)
 	 * @note only filled when the channel is cached
 	 */
-	channel* reacting_channel = nullptr;
+	channel reacting_channel;
 
 	/**
 	 * @brief emoji of reaction
@@ -1247,7 +1247,7 @@ struct DPP_EXPORT guild_create_t : public event_dispatch_t {
 	/**
 	 * @brief guild that was created
 	 */
-	guild* created = nullptr;
+	guild created;
 
 	/**
 	 * @brief List of presences of all users on the guild.
@@ -1288,12 +1288,12 @@ struct DPP_EXPORT channel_create_t : public event_dispatch_t {
 	/**
 	 * @brief guild channel was created on
 	 */
-	guild* creating_guild = nullptr;
+	guild creating_guild;
 
 	/**
 	 * @brief channel that was created
 	 */
-	channel* created = nullptr;
+	channel created;
 };
 
 /**
@@ -1306,7 +1306,7 @@ struct DPP_EXPORT message_reaction_remove_emoji_t : public event_dispatch_t {
 	/**
 	 * @brief Guild reaction occurred on
 	 */
-	guild* reacting_guild = nullptr;
+	guild reacting_guild;
 
 	/**
 	 * @brief Channel ID the reactions was removed in
@@ -1317,7 +1317,7 @@ struct DPP_EXPORT message_reaction_remove_emoji_t : public event_dispatch_t {
 	 * @brief channel the reaction happened on (optional)
 	 * @note only filled when the channel is cached
 	 */
-	channel* reacting_channel = nullptr;
+	channel reacting_channel;
 
 	/**
 	 * @brief emoji of reaction
@@ -1340,17 +1340,17 @@ struct DPP_EXPORT message_delete_bulk_t : public event_dispatch_t {
 	/**
 	 * @brief guild messages are being deleted upon
 	 */
-	guild* deleting_guild = nullptr;
+	guild deleting_guild;
 
 	/**
 	 * @brief user who is deleting the messages
 	 */
-	user* deleting_user = nullptr;
+	user deleting_user;
 
 	/**
 	 * @brief channel messages are being deleted from
 	 */
-	channel* deleting_channel = nullptr;
+	channel deleting_channel;
 
 	/**
 	 * @brief list of message ids of deleted messages
@@ -1368,12 +1368,12 @@ struct DPP_EXPORT guild_role_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where roles are being updated
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief the role being updated
 	 */
-	role* updated = nullptr;
+	role updated;
 };
 
 /**
@@ -1386,12 +1386,12 @@ struct DPP_EXPORT guild_role_delete_t : public event_dispatch_t {
 	/**
 	 * @brief guild where role is being deleted
 	 */
-	guild* deleting_guild = nullptr;
+	guild deleting_guild;
 
 	/**
 	 * @brief role being deleted
 	 */
-	role* deleted = nullptr;
+	role deleted;
 
 	/**
 	 * @brief ID of the deleted role
@@ -1409,12 +1409,12 @@ struct DPP_EXPORT channel_pins_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where message is being pinned
 	 */
-	guild* pin_guild = nullptr;
+	guild pin_guild;
 
 	/**
 	 * @brief channel where message is being pinned
 	 */
-	channel* pin_channel = nullptr;
+	channel pin_channel;
 
 	/**
 	 * @brief timestamp of pin
@@ -1432,7 +1432,7 @@ struct DPP_EXPORT message_reaction_remove_all_t : public event_dispatch_t {
 	/**
 	 * @brief Guild reaction occurred on
 	 */
-	guild* reacting_guild = nullptr;
+	guild reacting_guild;
 
 	/**
 	 * @brief Channel ID the reactions was removed in
@@ -1443,7 +1443,7 @@ struct DPP_EXPORT message_reaction_remove_all_t : public event_dispatch_t {
 	 * @brief channel the reaction happened on (optional)
 	 * @note only filled when the channel is cached
 	 */
-	channel* reacting_channel = nullptr;
+	channel reacting_channel;
 
 	/**
 	 * @brief message id of the message reacted upon
@@ -1490,7 +1490,7 @@ struct DPP_EXPORT guild_emojis_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where emojis are being updated
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 };
 
 /**
@@ -1517,12 +1517,12 @@ struct DPP_EXPORT webhooks_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where webhooks are being updated
 	 */
-	guild* webhook_guild = nullptr;
+	guild webhook_guild;
 
 	/**
 	 * @brief channel where webhooks are being updated
 	 */
-	channel* webhook_channel = nullptr;
+	channel webhook_channel;
 };
 
 /**
@@ -1535,7 +1535,7 @@ struct DPP_EXPORT guild_member_add_t : public event_dispatch_t {
 	/**
 	 * @brief guild which gained new member
 	 */
-	guild* adding_guild = nullptr;
+	guild adding_guild;
 
 	/**
 	 * @brief member which was added
@@ -1566,7 +1566,7 @@ struct DPP_EXPORT guild_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild being updated
 	 */
-	guild* updated = nullptr;
+	guild updated;
 };
 
 /**
@@ -1579,7 +1579,7 @@ struct DPP_EXPORT guild_integrations_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where integrations are being updated
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 };
 
 /**
@@ -1592,7 +1592,7 @@ struct DPP_EXPORT guild_member_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where member is being updated
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief member being updated
@@ -1786,7 +1786,7 @@ struct DPP_EXPORT guild_ban_add_t : public event_dispatch_t {
 	/**
 	 * @brief guild where ban was added
 	 */
-	guild* banning_guild = nullptr;
+	guild banning_guild;
 
 	/**
 	 * @brief user being banned
@@ -1804,7 +1804,7 @@ struct DPP_EXPORT guild_ban_remove_t : public event_dispatch_t {
 	/**
 	 * @brief guild where ban is being removed
 	 */
-	guild* unbanning_guild = nullptr;
+	guild unbanning_guild;
 
 	/**
 	 * @brief user being unbanned
@@ -1861,7 +1861,7 @@ struct DPP_EXPORT thread_create_t : public event_dispatch_t {
 	/**
 	 * @brief guild where thread was created
 	 */
-	guild* creating_guild = nullptr;
+	guild creating_guild;
 
 	/**
 	 * @brief thread created
@@ -1879,7 +1879,7 @@ struct DPP_EXPORT thread_update_t : public event_dispatch_t {
 	/**
 	 * @brief guild where thread was updated
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief thread updated
@@ -1897,7 +1897,7 @@ struct DPP_EXPORT thread_delete_t : public event_dispatch_t {
 	/**
 	 * @brief guild where thread was deleted
 	 */
-	guild* deleting_guild = nullptr;
+	guild deleting_guild;
 
 	/**
 	 * @brief thread deleted
@@ -1915,7 +1915,7 @@ struct DPP_EXPORT thread_list_sync_t : public event_dispatch_t {
 	/**
 	 * @brief guild where thread list was synchronised
 	 */
-	guild* updating_guild = nullptr;
+	guild updating_guild;
 
 	/**
 	 * @brief list of threads (channels) synchronised

--- a/src/davetest/dave.cpp
+++ b/src/davetest/dave.cpp
@@ -78,8 +78,8 @@ int main() {
 
 
 	dave_test.on_guild_create([&](const dpp::guild_create_t & event) {
-		if (event.created->id == TEST_GUILD_ID) {
-			dpp::discord_client* s = dave_test.get_shard(0);
+		if (event.created.id == TEST_GUILD_ID) {
+			dpp::discord_client* s = event.from();
 			bool muted = false, deaf = false, enable_dave = true;
 			s->connect_voice(TEST_GUILD_ID, TEST_VC_ID, muted, deaf, enable_dave);
 		}

--- a/src/dpp/events/channel_create.cpp
+++ b/src/dpp/events/channel_create.cpp
@@ -39,11 +39,16 @@ void channel_create::handle(discord_client* client, json &j, const std::string &
 	dpp::channel newchannel;
 	dpp::channel* c = nullptr;
 	dpp::guild* g = nullptr;
-	
+	dpp::guild tmp_guild;
+
 	if (client->creator->cache_policy.channel_policy == cp_none) {
 		newchannel.fill_from_json(&d);
 		c = &newchannel;
 		g = dpp::find_guild(c->guild_id);
+		if (g == nullptr) {
+			g = &tmp_guild;
+			tmp_guild.id = c->guild_id;
+		}
 		if (c->recipients.size()) {
 			for (auto & u : c->recipients) {
 				client->creator->set_dm_channel(u, c->id);
@@ -68,8 +73,8 @@ void channel_create::handle(discord_client* client, json &j, const std::string &
 	}
 	if (!client->creator->on_channel_create.empty()) {
 		dpp::channel_create_t cc(client->owner, client->shard_id, raw);
-		cc.created = c;
-		cc.creating_guild = g;
+		cc.created = *c;
+		cc.creating_guild = *g;
 		client->creator->queue_work(1, [c = client->creator, cc]() {
 			c->on_channel_create.call(cc);
 		});

--- a/src/dpp/events/channel_delete.cpp
+++ b/src/dpp/events/channel_delete.cpp
@@ -50,7 +50,8 @@ void channel_delete::handle(discord_client* client, json &j, const std::string &
 	if (!client->creator->on_channel_delete.empty()) {
 		channel_delete_t cd(client->owner, client->shard_id, raw);
 		cd.deleted = c;
-		cd.deleting_guild = g;
+		cd.deleting_guild = g ? *g : guild{};
+		cd.deleting_guild.id = c.guild_id;
 		client->creator->queue_work(1, [c = client->creator, cd]() {
 			c->on_channel_delete.call(cd);
 		});

--- a/src/dpp/events/channel_update.cpp
+++ b/src/dpp/events/channel_update.cpp
@@ -50,9 +50,13 @@ void channel_update::handle(discord_client* client, json &j, const std::string &
 		}
 	}
 	if (!client->creator->on_channel_update.empty()) {
-		dpp::channel_update_t cu(client->owner, client->shard_id, raw);
-		cu.updated = c;
-		cu.updating_guild = dpp::find_guild(c->guild_id);
+		channel_update_t cu(client->owner, client->shard_id, raw);
+		guild* g = find_guild(c->guild_id);
+
+		cu.updated = *c;
+		cu.updating_guild = g ? *g : guild{};
+		cu.updating_guild.id = c->guild_id;
+
 		client->creator->queue_work(1, [c = client->creator, cu]() {
 			c->on_channel_update.call(cu);
 		});

--- a/src/dpp/events/guild_ban_add.cpp
+++ b/src/dpp/events/guild_ban_add.cpp
@@ -42,7 +42,14 @@ void guild_ban_add::handle(discord_client* client, json &j, const std::string &r
 	if (!client->creator->on_guild_ban_add.empty()) {
 		json &d = j["d"];
 		dpp::guild_ban_add_t gba(client->owner, client->shard_id, raw);
-		gba.banning_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
+		snowflake gid = snowflake_not_null(&d, "guild_id");
+		guild* t = dpp::find_guild(gid);
+		if (t == nullptr) {
+			gba.banning_guild = {};
+			gba.banning_guild.id = gid;
+		} else {
+			gba.banning_guild = *t;
+		}
 		gba.banned = dpp::user().fill_from_json(&(d["user"]));
 		client->creator->queue_work(1, [c = client->creator, gba]() {
 			c->on_guild_ban_add.call(gba);

--- a/src/dpp/events/guild_ban_remove.cpp
+++ b/src/dpp/events/guild_ban_remove.cpp
@@ -42,8 +42,14 @@ void guild_ban_remove::handle(discord_client* client, json &j, const std::string
 	if (!client->creator->on_guild_ban_remove.empty()) {
 		json &d = j["d"];
 		dpp::guild_ban_remove_t gbr(client->owner, client->shard_id, raw);
-		gbr.unbanning_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		guild* g = find_guild(guild_id);
+
+		gbr.unbanning_guild = g ? *g : guild{};
+		gbr.unbanning_guild.id = guild_id;
+
 		gbr.unbanned = dpp::user().fill_from_json(&(d["user"]));
+
 		client->creator->queue_work(1, [c = client->creator, gbr]() {
 			c->on_guild_ban_remove.call(gbr);
 		});

--- a/src/dpp/events/guild_create.cpp
+++ b/src/dpp/events/guild_create.cpp
@@ -148,7 +148,7 @@ void guild_create::handle(discord_client* client, json &j, const std::string &ra
 
 	if (!client->creator->on_guild_create.empty()) {
 		dpp::guild_create_t gc(client->owner, client->shard_id, raw);
-		gc.created = g;
+		gc.created = *g;
 
 		/* Fill presences if there are any */
 		if (d.find("presences") != d.end()) {

--- a/src/dpp/events/guild_emojis_update.cpp
+++ b/src/dpp/events/guild_emojis_update.cpp
@@ -73,7 +73,8 @@ void guild_emojis_update::handle(discord_client* client, json &j, const std::str
 	if (!client->creator->on_guild_emojis_update.empty()) {
 		dpp::guild_emojis_update_t geu(client->owner, client->shard_id, raw);
 		geu.emojis = emojis;
-		geu.updating_guild = g;
+		geu.updating_guild = g ? *g : guild{};
+		geu.updating_guild.id = guild_id;
 		client->creator->queue_work(1, [c = client->creator, geu]() {
 			c->on_guild_emojis_update.call(geu);
 		});

--- a/src/dpp/events/guild_integrations_update.cpp
+++ b/src/dpp/events/guild_integrations_update.cpp
@@ -40,7 +40,10 @@ void guild_integrations_update::handle(class discord_client* client, json &j, co
 	if (!client->creator->on_guild_integrations_update.empty()) {
 		json& d = j["d"];
 		dpp::guild_integrations_update_t giu(client->owner, client->shard_id, raw);
-		giu.updating_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
+		snowflake gid = snowflake_not_null(&d, "guild_id");
+		guild* g = dpp::find_guild(gid);
+		giu.updating_guild = g ? *g : guild{};
+		giu.updating_guild.id = gid;
 		client->creator->queue_work(1, [c = client->creator, giu]() {
 			c->on_guild_integrations_update.call(giu);
 		});

--- a/src/dpp/events/guild_member_add.cpp
+++ b/src/dpp/events/guild_member_add.cpp
@@ -46,7 +46,8 @@ void guild_member_add::handle(discord_client* client, json &j, const std::string
 		gm.fill_from_json(&d, guild_id, snowflake_not_null(&(d["user"]), "id"));
 		gmr.added = gm;
 		if (!client->creator->on_guild_member_add.empty()) {
-			gmr.adding_guild = g;
+			gmr.adding_guild = g ? *g : guild{};
+			gmr.adding_guild.id = guild_id;
 			client->creator->queue_work(1, [c = client->creator, gmr]() {
 				c->on_guild_member_add.call(gmr);
 			});
@@ -70,7 +71,8 @@ void guild_member_add::handle(discord_client* client, json &j, const std::string
 			gmr.added = g->members.find(u->id)->second;
 		}
 		if (!client->creator->on_guild_member_add.empty()) {
-			gmr.adding_guild = g;
+			gmr.adding_guild = g ? *g : guild{};
+			gmr.adding_guild.id = guild_id;
 			client->creator->queue_work(1, [c = client->creator, gmr]() {
 				c->on_guild_member_add.call(gmr);
 			});

--- a/src/dpp/events/guild_member_remove.cpp
+++ b/src/dpp/events/guild_member_remove.cpp
@@ -42,7 +42,9 @@ void guild_member_remove::handle(discord_client* client, json &j, const std::str
 	dpp::guild_member_remove_t gmr(client->owner, client->shard_id, raw);
 	gmr.removed.fill_from_json(&(d["user"]));
 	gmr.guild_id = snowflake_not_null(&d, "guild_id");
-	gmr.removing_guild = dpp::find_guild(gmr.guild_id);
+	guild* g = dpp::find_guild(gmr.guild_id);
+	gmr.removing_guild = g ? *g : guild{};
+	gmr.removing_guild.id = gmr.guild_id;
 
 	if (!client->creator->on_guild_member_remove.empty()) {
 		client->creator->queue_work(1, [c = client->creator, gmr]() {
@@ -50,9 +52,10 @@ void guild_member_remove::handle(discord_client* client, json &j, const std::str
 		});
 	}
 
-	if (client->creator->cache_policy.user_policy != dpp::cp_none && gmr.removing_guild) {
-		auto i = gmr.removing_guild->members.find(gmr.removed.id);
-		if (i != gmr.removing_guild->members.end()) {
+	/* NOTE: This operates on the cached pointer of the guild */
+	if (client->creator->cache_policy.user_policy != dpp::cp_none && g) {
+		auto i = g->members.find(gmr.removed.id);
+		if (i != g->members.end()) {
 			dpp::user* u = dpp::find_user(gmr.removed.id);
 			if (u) {
 				u->refcount--;
@@ -60,7 +63,7 @@ void guild_member_remove::handle(discord_client* client, json &j, const std::str
 					dpp::get_user_cache()->remove(u);
 				}
 			}
-			gmr.removing_guild->members.erase(i);
+			g->members.erase(i);
 		}
 	}
 }

--- a/src/dpp/events/guild_member_update.cpp
+++ b/src/dpp/events/guild_member_update.cpp
@@ -41,7 +41,8 @@ void guild_member_update::handle(discord_client* client, json &j, const std::str
 		dpp::user u;
 		u.fill_from_json(&(d["user"]));
 		dpp::guild_member_update_t gmu(client->owner, client->shard_id, raw);
-		gmu.updating_guild = g;
+		gmu.updating_guild = g ? *g : guild{};
+		gmu.updating_guild.id = guild_id;
 		if (!client->creator->on_guild_member_update.empty()) {
 			guild_member m;
 			auto& user = d; // d contains roles and other member stuff already
@@ -63,7 +64,8 @@ void guild_member_update::handle(discord_client* client, json &j, const std::str
 
 			if (!client->creator->on_guild_member_update.empty()) {
 				dpp::guild_member_update_t gmu(client->owner, client->shard_id, raw);
-				gmu.updating_guild = g;
+				gmu.updating_guild = g ? *g : guild{};
+				gmu.updating_guild.id = guild_id;
 				gmu.updated = m;
 				client->creator->queue_work(0, [c = client->creator, gmu]() {
 					c->on_guild_member_update.call(gmu);

--- a/src/dpp/events/guild_members_chunk.cpp
+++ b/src/dpp/events/guild_members_chunk.cpp
@@ -40,7 +40,8 @@ namespace dpp::events {
 void guild_members_chunk::handle(discord_client* client, json &j, const std::string &raw) {
 	json &d = j["d"];
 	dpp::guild_member_map um;
-	dpp::guild* g = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
+	snowflake guild_id = snowflake_not_null(&d, "guild_id");
+	dpp::guild* g = dpp::find_guild(guild_id);
 	if (g) {
 		/* Store guild members */
 		if (client->creator->cache_policy.user_policy == cp_aggressive) {
@@ -65,8 +66,9 @@ void guild_members_chunk::handle(discord_client* client, json &j, const std::str
 	}
 	if (!client->creator->on_guild_members_chunk.empty()) {
 		dpp::guild_members_chunk_t gmc(client->owner, client->shard_id, raw);
-		gmc.adding = g;
-		gmc.members = &um;
+		gmc.adding = g ? *g : guild{};
+		gmc.adding.id = guild_id;
+		gmc.members = um;
 		client->creator->queue_work(1, [c = client->creator, gmc]() {
 			c->on_guild_members_chunk.call(gmc);
 		});

--- a/src/dpp/events/guild_role_create.cpp
+++ b/src/dpp/events/guild_role_create.cpp
@@ -47,8 +47,9 @@ void guild_role_create::handle(discord_client* client, json &j, const std::strin
 		r.fill_from_json(guild_id, &role);
 		if (!client->creator->on_guild_role_create.empty()) {
 			dpp::guild_role_create_t grc(client->owner, client->shard_id, raw);
-			grc.creating_guild = g;
-			grc.created = &r;
+			grc.creating_guild = g ? *g : guild{};
+			grc.creating_guild.id = guild_id;
+			grc.created = r;
 			client->creator->queue_work(1, [c = client->creator, grc]() {
 				c->on_guild_role_create.call(grc);
 			});
@@ -66,8 +67,9 @@ void guild_role_create::handle(discord_client* client, json &j, const std::strin
 		}
 		if (!client->creator->on_guild_role_create.empty()) {
 			dpp::guild_role_create_t grc(client->owner, client->shard_id, raw);
-			grc.creating_guild = g;
-			grc.created = r;
+			grc.creating_guild = g ? *g : guild{};
+			grc.creating_guild.id = guild_id;
+			grc.created = *r;
 			client->creator->queue_work(1, [c = client->creator, grc]() {
 				c->on_guild_role_create.call(grc);
 			});

--- a/src/dpp/events/guild_role_delete.cpp
+++ b/src/dpp/events/guild_role_delete.cpp
@@ -45,9 +45,11 @@ void guild_role_delete::handle(discord_client* client, json &j, const std::strin
 	if (client->creator->cache_policy.role_policy == dpp::cp_none) {
 		if (!client->creator->on_guild_role_delete.empty()) {
 			dpp::guild_role_delete_t grd(client->owner, client->shard_id, raw);
-			grd.deleting_guild = g;
+			grd.deleting_guild = g ? *g : guild{};
+			grd.deleting_guild.id = guild_id;
+			grd.deleted = role{};
+			grd.deleted.id = role_id;
 			grd.role_id = role_id;
-			grd.deleted = nullptr;
 			client->creator->queue_work(1, [c = client->creator, grd]() {
 				c->on_guild_role_delete.call(grd);
 			});
@@ -56,8 +58,10 @@ void guild_role_delete::handle(discord_client* client, json &j, const std::strin
 		dpp::role *r = dpp::find_role(role_id);
 		if (!client->creator->on_guild_role_delete.empty()) {
 			dpp::guild_role_delete_t grd(client->owner, client->shard_id, raw);
-			grd.deleting_guild = g;
-			grd.deleted = r;
+			grd.deleting_guild = g ? *g : guild{};
+			grd.deleting_guild.id = guild_id;
+			grd.deleted = r ? *r : role{};
+			grd.deleted.id = role_id;
 			grd.role_id = role_id;
 			client->creator->queue_work(1, [c = client->creator, grd]() {
 				c->on_guild_role_delete.call(grd);

--- a/src/dpp/events/guild_role_update.cpp
+++ b/src/dpp/events/guild_role_update.cpp
@@ -45,8 +45,9 @@ void guild_role_update::handle(discord_client* client, json &j, const std::strin
 		r.fill_from_json(guild_id, &d);
 		if (!client->creator->on_guild_role_update.empty()) {
 			dpp::guild_role_update_t gru(client->owner, client->shard_id, raw);
-			gru.updating_guild = g;
-			gru.updated = &r;
+			gru.updating_guild = g ? *g : guild{};
+			gru.updating_guild.id = guild_id;
+			gru.updated = r;
 			client->creator->queue_work(1, [c = client->creator, gru]() {
 				c->on_guild_role_update.call(gru);
 			});
@@ -58,8 +59,10 @@ void guild_role_update::handle(discord_client* client, json &j, const std::strin
 			r->fill_from_json(g->id, &role);
 			if (!client->creator->on_guild_role_update.empty()) {
 				dpp::guild_role_update_t gru(client->owner, client->shard_id, raw);
-				gru.updating_guild = g;
-				gru.updated = r;
+				gru.updating_guild = g ? *g : guild{};
+				gru.updating_guild.id = guild_id;
+				gru.updated = *r;
+				gru.updated.id = r->id;
 				client->creator->queue_work(1, [c = client->creator, gru]() {
 					c->on_guild_role_update.call(gru);
 				});

--- a/src/dpp/events/guild_stickers_update.cpp
+++ b/src/dpp/events/guild_stickers_update.cpp
@@ -48,7 +48,8 @@ void guild_stickers_update::handle(discord_client* client, json &j, const std::s
 			s.fill_from_json(&sticker);
 			gsu.stickers.emplace_back(s);
 		}
-		gsu.updating_guild = g;
+		gsu.updating_guild = g ? *g : guild{};
+		gsu.updating_guild.id = guild_id;
 		client->creator->queue_work(1, [c = client->creator, gsu]() {
 			c->on_guild_stickers_update.call(gsu);
 		});

--- a/src/dpp/events/message_delete_bulk.cpp
+++ b/src/dpp/events/message_delete_bulk.cpp
@@ -38,9 +38,22 @@ void message_delete_bulk::handle(discord_client* client, json &j, const std::str
 	if (!client->creator->on_message_delete_bulk.empty()) {
 		json& d = j["d"];
 		dpp::message_delete_bulk_t msg(client->owner, client->shard_id, raw);
-		msg.deleting_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
-		msg.deleting_channel = dpp::find_channel(snowflake_not_null(&d, "channel_id"));
-		msg.deleting_user = dpp::find_user(snowflake_not_null(&d, "user_id"));
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		snowflake user_id = snowflake_not_null(&d, "user_id");
+		guild* g = find_guild(guild_id);
+		channel* c = find_channel(channel_id);
+		user* u = find_user(user_id);
+
+		msg.deleting_guild = g ? *g : guild{};
+		msg.deleting_guild.id = guild_id;
+
+		msg.deleting_channel = c ? *c : channel{};
+		msg.deleting_channel.id = channel_id;
+
+		msg.deleting_user = u ? *u : user{};
+		msg.deleting_user.id = user_id;
+
 		for (auto& m : d["ids"]) {
 			msg.deleted.push_back(from_string<uint64_t>(m.get<std::string>()));
 		}

--- a/src/dpp/events/message_reaction_remove.cpp
+++ b/src/dpp/events/message_reaction_remove.cpp
@@ -39,14 +39,29 @@ namespace dpp::events {
 void message_reaction_remove::handle(discord_client* client, json &j, const std::string &raw) {
 	if (!client->creator->on_message_reaction_remove.empty()) {
 		json &d = j["d"];
-		dpp::message_reaction_remove_t mrr(client->owner, client->shard_id, raw);
-		dpp::snowflake guild_id = snowflake_not_null(&d, "guild_id");
-		mrr.reacting_guild = dpp::find_guild(guild_id);
-		mrr.reacting_user_id = snowflake_not_null(&d, "user_id");
-		mrr.channel_id = snowflake_not_null(&d, "channel_id");
-		mrr.reacting_channel = dpp::find_channel(mrr.channel_id);
-		mrr.message_id = snowflake_not_null(&d, "message_id");
+
+		message_reaction_remove_t mrr(client->owner, client->shard_id, raw);
+
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		snowflake user_id = snowflake_not_null(&d, "user_id");
+		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		snowflake message_id = snowflake_not_null(&d, "message_id");
+
+		guild* g = find_guild(guild_id);
+		channel* c = dpp::find_channel(mrr.channel_id);
+
+		mrr.reacting_guild = g ? *g : guild{};
+		mrr.reacting_guild.id = guild_id;
+
+		mrr.reacting_user_id = user_id;
+
+		mrr.channel_id = channel_id;
+		mrr.reacting_channel = c ? *c : channel{};
+		mrr.reacting_channel.id = channel_id;
+
+		mrr.message_id = message_id;
 		mrr.reacting_emoji = dpp::emoji().fill_from_json(&(d["emoji"]));
+
 		if (mrr.channel_id && mrr.message_id) {
 			client->creator->queue_work(1, [c = client->creator, mrr]() {
 				c->on_message_reaction_remove.call(mrr);

--- a/src/dpp/events/message_reaction_remove_all.cpp
+++ b/src/dpp/events/message_reaction_remove_all.cpp
@@ -39,11 +39,23 @@ namespace dpp::events {
 void message_reaction_remove_all::handle(discord_client* client, json &j, const std::string &raw) {
 	if (!client->creator->on_message_reaction_remove_all.empty()) {
 		json &d = j["d"];
-		dpp::message_reaction_remove_all_t mrra(client->owner, client->shard_id, raw);
-		mrra.reacting_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
-		mrra.channel_id = snowflake_not_null(&d, "channel_id");
-		mrra.reacting_channel = dpp::find_channel(mrra.channel_id);
+		message_reaction_remove_all_t mrra(client->owner, client->shard_id, raw);
+
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+
+		guild* g = find_guild(guild_id);
+		channel* c = find_channel(channel_id);
+
+		mrra.reacting_guild = g ? *g : guild{};
+		mrra.reacting_guild.id = guild_id;
+
+		mrra.channel_id = channel_id;
+		mrra.reacting_channel = c ? *c : channel{};
+		mrra.reacting_channel.id = channel_id;
+
 		mrra.message_id = snowflake_not_null(&d, "message_id");
+
 		if (mrra.channel_id && mrra.message_id) {
 			client->creator->queue_work(1, [c = client->creator, mrra]() {
 				c->on_message_reaction_remove_all.call(mrra);

--- a/src/dpp/events/message_reaction_remove_emoji.cpp
+++ b/src/dpp/events/message_reaction_remove_emoji.cpp
@@ -40,11 +40,22 @@ void message_reaction_remove_emoji::handle(discord_client* client, json &j, cons
 	if (!client->creator->on_message_reaction_remove_emoji.empty()) {
 		json &d = j["d"];
 		dpp::message_reaction_remove_emoji_t mrre(client->owner, client->shard_id, raw);
-		mrre.reacting_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
-		mrre.channel_id = snowflake_not_null(&d, "channel_id");
-		mrre.reacting_channel = dpp::find_channel(mrre.channel_id);
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		guild* g = find_guild(guild_id);
+		channel* c = find_channel(channel_id);
+
+		mrre.reacting_guild = g ? *g : guild{};
+		mrre.reacting_guild.id = guild_id;
+
+		mrre.channel_id = channel_id;
+		mrre.reacting_channel = c ? *c : channel{};
+		mrre.reacting_channel.id = channel_id;
+
 		mrre.message_id = snowflake_not_null(&d, "message_id");
+
 		mrre.reacting_emoji = dpp::emoji().fill_from_json(&(d["emoji"]));
+
 		if (mrre.channel_id && mrre.message_id) {
 			client->creator->queue_work(1, [c = client->creator, mrre]() {
 				c->on_message_reaction_remove_emoji.call(mrre);

--- a/src/dpp/events/thread_create.cpp
+++ b/src/dpp/events/thread_create.cpp
@@ -40,8 +40,11 @@ void thread_create::handle(discord_client* client, json& j, const std::string& r
 	}
 	if (!client->creator->on_thread_create.empty()) {
 		dpp::thread_create_t tc(client->owner, client->shard_id, raw);
+
 		tc.created = t;
-		tc.creating_guild = g;
+		tc.creating_guild = g ? *g : guild{};
+		tc.creating_guild.id = t.guild_id;
+
 		client->creator->queue_work(1, [c = client->creator, tc]() {
 			c->on_thread_create.call(tc);
 		});

--- a/src/dpp/events/thread_delete.cpp
+++ b/src/dpp/events/thread_delete.cpp
@@ -41,7 +41,8 @@ void thread_delete::handle(discord_client* client, json& j, const std::string& r
 	if (!client->creator->on_thread_delete.empty()) {
 		dpp::thread_delete_t td(client->owner, client->shard_id, raw);
 		td.deleted = t;
-		td.deleting_guild = g;
+		td.deleting_guild = g ? *g : guild{};
+		td.deleting_guild.id = t.guild_id;
 		client->creator->queue_work(1, [c = client->creator, td]() {
 			c->on_thread_delete.call(td);
 		});

--- a/src/dpp/events/thread_update.cpp
+++ b/src/dpp/events/thread_update.cpp
@@ -36,8 +36,11 @@ void thread_update::handle(discord_client* client, json& j, const std::string& r
 	dpp::guild* g = dpp::find_guild(t.guild_id);
 	if (!client->creator->on_thread_update.empty()) {
 		dpp::thread_update_t tu(client->owner, client->shard_id, raw);
+
 		tu.updated = t;
-		tu.updating_guild = g;
+		tu.updating_guild = g ? *g : guild{};
+		tu.updating_guild.id = t.guild_id;
+
 		client->creator->queue_work(1, [c = client->creator, tu]() {
 			c->on_thread_update.call(tu);
 		});

--- a/src/dpp/events/typing_start.cpp
+++ b/src/dpp/events/typing_start.cpp
@@ -37,11 +37,24 @@ namespace dpp::events {
 void typing_start::handle(discord_client* client, json &j, const std::string &raw) {
 	if (!client->creator->on_typing_start.empty()) {
 		json& d = j["d"];
+		snowflake guild_id = snowflake_not_null(&d, "guild_id");
+		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		snowflake user_id = snowflake_not_null(&d, "user_id");
+		guild* g = find_guild(guild_id);
+		channel* c = find_channel(channel_id);
+		user* u = find_user(user_id);
+
 		dpp::typing_start_t ts(client->owner, client->shard_id, raw);
-		ts.typing_guild = dpp::find_guild(snowflake_not_null(&d, "guild_id"));
-		ts.typing_channel = dpp::find_channel(snowflake_not_null(&d, "channel_id"));
-		ts.user_id = snowflake_not_null(&d, "user_id");
-		ts.typing_user = dpp::find_user(ts.user_id);
+		ts.typing_guild = g ? *g : guild{};
+		ts.typing_guild.id = guild_id;
+
+		ts.typing_channel = c ? *c : channel{};
+		ts.typing_channel.id = channel_id;
+
+		ts.user_id = user_id;
+		ts.typing_user = u ? *u : user{};
+		ts.typing_user.id = user_id;
+
 		ts.timestamp = ts_not_null(&d, "timestamp");
 		client->creator->queue_work(1, [c = client->creator, ts]() {
 			c->on_typing_start.call(ts);

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -988,30 +988,30 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		});
 
 		bot.on_guild_create([dpp_logo,&bot](const dpp::guild_create_t& event) {
-			dpp::guild *g = event.created;
+			dpp::guild g = event.created;
 
-			if (g->id == TEST_GUILD_ID) {
+			if (g.id == TEST_GUILD_ID) {
 				start_test(GUILD_EDIT);
-				g->set_icon(dpp::i_png, dpp_logo.data(), static_cast<uint32_t>(dpp_logo.size()));
-				bot.guild_edit(*g, [&bot](const dpp::confirmation_callback_t &result) {
+				g.set_icon(dpp::i_png, dpp_logo.data(), static_cast<uint32_t>(dpp_logo.size()));
+				bot.guild_edit(g, [&bot](const dpp::confirmation_callback_t &result) {
 					if (result.is_error()) {
 						set_status(GUILD_EDIT, ts_failed, "guild_edit 1 errored:\n" + result.get_error().human_readable);
 						return;
 					}
-					dpp::guild g = result.get<dpp::guild>();
+					dpp::guild g2 = result.get<dpp::guild>();
 
-					if (g.get_icon_url().empty()) {
+					if (g2.get_icon_url().empty()) {
 						set_status(GUILD_EDIT, ts_failed, "icon not set or not retrieved");
 						return;
 					}
-					g.remove_icon();
-					bot.guild_edit(g, [](const dpp::confirmation_callback_t &result) {
+					g2.remove_icon();
+					bot.guild_edit(g2, [](const dpp::confirmation_callback_t &result) {
 						if (result.is_error()) {
 							set_status(GUILD_EDIT, ts_failed, "guild_edit 2 errored:\n" + result.get_error().human_readable);
 							return;
 						}
-						const dpp::guild &g = result.get<dpp::guild>();
-						if (!g.get_icon_url().empty()) {
+						const dpp::guild g3 = result.get<dpp::guild>();
+						if (!g3.get_icon_url().empty()) {
 							set_status(GUILD_EDIT, ts_failed, "icon not removed");
 							return;
 						}
@@ -1136,7 +1136,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		});
 
 		bot.on_guild_create([&bot](const dpp::guild_create_t & event) {
-			if (event.created->id == TEST_GUILD_ID) {
+			if (event.created.id == TEST_GUILD_ID) {
 				set_test(GUILDCREATE, true);
 				if (event.presences.size() && event.presences.begin()->second.user_id > 0) {
 					set_test(PRESENCE, true);
@@ -1703,7 +1703,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		});
 
 		bot.on_thread_update([&thread_helper](const dpp::thread_update_t &event) {
-			if (event.updating_guild->id == TEST_GUILD_ID && event.updated.id == thread_helper.thread_id && event.updated.name == "edited") {
+			if (event.updating_guild.id == TEST_GUILD_ID && event.updated.id == thread_helper.thread_id && event.updated.name == "edited") {
 				set_test(THREAD_UPDATE_EVENT, true);
 			}
 		});
@@ -1720,7 +1720,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 		});
 
 		bot.on_thread_delete([&](const dpp::thread_delete_t &event) {
-			if (event.deleting_guild->id == TEST_GUILD_ID && event.deleted.id == message_helper.thread_id) {
+			if (event.deleting_guild.id == TEST_GUILD_ID && event.deleted.id == message_helper.thread_id) {
 				set_test(THREAD_DELETE_EVENT, true);
 			}
 		});


### PR DESCRIPTION
10.1 is much less forgiving about using temporary stack pointers from the parent function within the event objects passed into the event handler. These pointers are not valid when the event is processed later within the thread pool (classic ownership faux pas).

To make this safer, and simpler to work with, be rid of all the pointer references to things that may "yesnt" be in the cache, or on the stack, and make them copies of the cached or json parsed data object. 

This means that lib users dont have to remember how some `event.whatever` are `event->whatever` (seemingly for no reason they understand).

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
