### PR TITLE
fix: make sure write events go out as soon as they can

### DIFF
--- a/src/dpp/sslclient.cpp
+++ b/src/dpp/sslclient.cpp
@@ -247,6 +247,7 @@ void ssl_client::socket_write(const std::string_view data) {
 	 */
 	std::lock_guard<std::mutex> lock(out_mutex);
 	obuffer += data;
+	owner->socketengine->inplace_modify_fd(sfd, WANT_WRITE);
 }
 
 void ssl_client::one_second_timer() {

--- a/src/dpp/wsclient.cpp
+++ b/src/dpp/wsclient.cpp
@@ -131,8 +131,6 @@ void websocket_client::write(const std::string_view data, ws_opcode _opcode)
 		ssl_client::socket_write(header);
 		ssl_client::socket_write(data);
 	}
-
-	owner->socketengine->inplace_modify_fd(sfd, WANT_WRITE);
 }
 
 bool websocket_client::handle_buffer(std::string& buffer)


### PR DESCRIPTION
We must set WANT_WRITE whenever we append to the write buffer of an ssl_client based object. This is the proper fix for the issue patched by @Neko-Life where voice wasn't sending via socketengine events. If the opcode 4 was not sent soon enough, then the connection would not succeed, this seems oddly temporal now. Setting WANT_WRITE in the ssl_client::write() function ensures all writes occur as soon as they possibly can.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
