### PR TITLE
Add coroutine support functions to message_create_t (co_send, co_reply)

### DIFF
--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -1695,6 +1695,59 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @note confirmation_callback_t::value contains a message object on success. On failure, value is undefined and confirmation_callback_t::is_error() is true.
 	 */
 	void reply(message&& msg, bool mention_replied_user = false, command_completion_event_t callback = utility::log_error()) const;
+
+#ifdef DPP_CORO
+	/**
+	 * @brief Send a text to the same channel as the channel_id in received event.
+	 * 
+	 * @param m Text to send
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_send(const std::string& m) const;
+
+	/**
+	 * @brief Send a message to the same channel as the channel_id in received event.
+	 * 
+	 * @param msg Message to send
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_send(const message& msg) const;
+
+	/**
+	 * @brief Send a message to the same channel as the channel_id in received event.
+	 * 
+	 * @param msg Message to send
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_send(message&& msg) const;
+
+	/**
+	 * @brief Reply to the message received in the event.
+	 *
+	 * @param m Text to send as a reply.
+	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& m, bool mention_replied_user = false) const;
+
+	/**
+	 * @brief Reply to the message received in the event.
+	 *
+	 * @param msg Message to send as a reply.
+	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_reply(const message& msg, bool mention_replied_user = false) const;
+
+	/**
+	 * @brief Reply to the message received in the event.
+	 * 
+	 * @param msg Message to send as a reply.
+	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_reply(message&& msg, bool mention_replied_user = false) const;
+#endif /* DPP_CORO */
 };
 
 /**

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -111,6 +111,32 @@ void message_create_t::reply(message&& msg, bool mention_replied_user, command_c
 	owner->message_create(std::move(msg), std::move(callback));
 }
 
+#ifdef DPP_CORO
+async<confirmation_callback_t> message_create_t::co_send(const std::string& m) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(m, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> message_create_t::co_send(const message& msg) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(msg, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> message_create_t::co_send(message&& msg) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(std::move(msg), std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> message_create_t::co_reply(const std::string& m, bool mention_replied_user) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(m, mention_replied_user, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> message_create_t::co_reply(const message& msg, bool mention_replied_user) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(msg, mention_replied_user, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> message_create_t::co_reply(message&& msg, bool mention_replied_user) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(std::move(msg), mention_replied_user, std::forward<T>(cb)); }};
+}
+#endif /* DPP_CORO */
+
 void interaction_create_t::reply(interaction_response_type t, const message& m, command_completion_event_t callback) const {
 	owner->interaction_response_create(this->command.id, this->command.token, dpp::interaction_response(t, m), std::move(callback));
 }


### PR DESCRIPTION
The `message_create_t` type was missing direct coroutine function variations. So I have implemented functions and overloads for both `co_send()` and `co_reply()` functions. This PR improves code consistency and usability.

(Similar coroutine functions have already been implemented for `interaction_create_t` before, but not for `message_create_t`)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.


## Single-File Test Bot
```cpp
#include <dpp/dpp.h>
#include <dpp/coro.h>
#include <coroutine>
#include <iostream>

const std::string BOT_TOKEN = "your bot token here";

int main() {
    dpp::cluster bot(BOT_TOKEN, dpp::i_default_intents | dpp::i_message_content);

    bot.on_log(dpp::utility::cout_logger());

    /*
    This example demonstrates the use of co_reply and co_send functions on the dpp::message_create_t event.
    You can test them by sending !test1, !test2, !test3, and !test4 in a channel the bot is in.
    The first 3 tests each perform a co_reply with different overloads, the 4th test performs a co_send with all overloads.
    */

    bot.on_message_create([](const dpp::message_create_t& event) -> dpp::task<void> {

        std::cout << "Received message: " << event.msg.content << std::endl;

        if (event.msg.content == "!test1") {
            dpp::confirmation_callback_t result = co_await event.co_reply("This is a test reply.", true);
            if (!result.is_error()) {
                std::cout << "1st co_reply with string succeeded!" << std::endl;
            } else {
                std::cout << "1st co_reply with string failed: " << result.get_error().message << std::endl;
            }
        }

        if (event.msg.content == "!test2") {
            dpp::message msg("This is a test reply.");
            dpp::confirmation_callback_t result = co_await event.co_reply(msg, false);
            if (!result.is_error()) {
                std::cout << "2nd co_reply with message obj succeeded!" << std::endl;
            } else {
                std::cout << "2nd co_reply with message obj failed: " << result.get_error().message << std::endl;
            }
        }

        if (event.msg.content == "!test3") {
            dpp::message msg("This is a test reply.");
            dpp::confirmation_callback_t result = co_await event.co_reply(std::move(msg), true);
            if (!result.is_error()) {
                std::cout << "3rd co_thinking with moved message obj succeeded!" << std::endl;
            } else {
                std::cout << "3rd co_thinking with moved message obj failed: " << result.get_error().message << std::endl;
            }
        }

        // Test all of the co_send overloads
        if (event.msg.content == "!test4") {
            dpp::confirmation_callback_t result1 = co_await event.co_send("This is a test send.");
            if (!result1.is_error()) {
                std::cout << "1st co_send with string succeeded!" << std::endl;
            } else {
                std::cout << "1st co_send with string failed: " << result1.get_error().message << std::endl;
            }

            dpp::message msg("This is a test send.");
            dpp::confirmation_callback_t result2 = co_await event.co_send(msg);
            if (!result2.is_error()) {
                std::cout << "2nd co_send with message obj succeeded!" << std::endl;
            } else {
                std::cout << "2nd co_send with message obj failed: " << result2.get_error().message << std::endl;
            }

            dpp::message msg2("This is a test send.");
            dpp::confirmation_callback_t result3 = co_await event.co_send(std::move(msg2));
            if (!result3.is_error()) {
                std::cout << "3rd co_send with moved message obj succeeded!" << std::endl;
            } else {
                std::cout << "3rd co_send with moved message obj failed: " << result3.get_error().message << std::endl;
            }
        }

    });

    bot.start(dpp::st_wait);
}```
