### PR TITLE
Don't always run php for DPP_CORO

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -128,6 +128,13 @@ if (UNIX)
 			COMMAND php buildtools/emojis.php
 		)
 		set_source_files_properties( "${CMAKE_CURRENT_SOURCE_DIR}/../include/dpp/unicode_emojis.h" PROPERTIES GENERATED TRUE )
+
+  		if (DPP_CORO)
+			execute_process(
+				WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.."
+				COMMAND php buildtools/make_struct.php "\\Dpp\\Generator\\CoroGenerator"
+			)
+		endif()
 	else()
 		message("-- Autogeneration is not available")
  	endif()
@@ -410,8 +417,6 @@ if(DPP_CORO)
 		endif()
 	endif()
 	target_compile_definitions(dpp PUBLIC DPP_CORO)
-	execute_process(WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.."
-					COMMAND php buildtools/make_struct.php "\\Dpp\\Generator\\CoroGenerator")
 endif()
 
 if(DPP_FORMATTERS)


### PR DESCRIPTION
If DPP_CORO is configured to be true, the make_struct.php will *always* be run, even if not on UNIX or if PHP isn't found. This PR moves the relevant execute_process to where the other php files are run.

(and no, I'm not able to retarget or reopen the other PR)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
