### PR TITLE
Added user_id to message_reaction_add_t

### DIFF
--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -1149,6 +1149,12 @@ struct DPP_EXPORT message_reaction_add_t : public event_dispatch_t {
 	user reacting_user = {};
 
 	/**
+	 * @brief User id of user who reacted.
+	 * Always set regardless of caching
+	 */
+	snowflake user_id = {};
+
+	/**
 	 * @brief member data of user who reacted
 	 */
 	guild_member reacting_member = {};

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -1149,12 +1149,6 @@ struct DPP_EXPORT message_reaction_add_t : public event_dispatch_t {
 	user reacting_user = {};
 
 	/**
-	 * @brief User id of user who reacted.
-	 * Always set regardless of caching
-	 */
-	snowflake user_id = {};
-
-	/**
 	 * @brief member data of user who reacted
 	 */
 	guild_member reacting_member = {};

--- a/src/dpp/events/message_reaction_add.cpp
+++ b/src/dpp/events/message_reaction_add.cpp
@@ -42,6 +42,7 @@ void message_reaction_add::handle(discord_client* client, json &j, const std::st
 		dpp::message_reaction_add_t mra(client->owner, client->shard_id, raw);
 		snowflake guild_id = snowflake_not_null(&d, "guild_id");
 		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		snowflake user_id = snowflake_not_null(&d, "user_id");
 
 		guild* g = find_guild(guild_id);
 		channel* c = find_channel(channel_id);
@@ -50,6 +51,7 @@ void message_reaction_add::handle(discord_client* client, json &j, const std::st
 		mra.reacting_guild.id = guild_id;
 
 		mra.reacting_user = dpp::user().fill_from_json(&(d["member"]["user"]));
+		mra.reacting_user.id = user_id;
 		mra.reacting_member = dpp::guild_member().fill_from_json(&(d["member"]), guild_id, mra.reacting_user.id);
 
 		mra.channel_id = channel_id;

--- a/src/dpp/events/message_reaction_add.cpp
+++ b/src/dpp/events/message_reaction_add.cpp
@@ -42,10 +42,12 @@ void message_reaction_add::handle(discord_client* client, json &j, const std::st
 		dpp::message_reaction_add_t mra(client->owner, client->shard_id, raw);
 		snowflake guild_id = snowflake_not_null(&d, "guild_id");
 		snowflake channel_id = snowflake_not_null(&d, "channel_id");
+		snowflake user_id = snowflake_not_null(&d, "user_id");
 
 		guild* g = find_guild(guild_id);
 		channel* c = find_channel(channel_id);
 
+		mra.user_id = user_id;
 		mra.reacting_guild = g ? *g : guild{};
 		mra.reacting_guild.id = guild_id;
 

--- a/src/dpp/events/message_reaction_add.cpp
+++ b/src/dpp/events/message_reaction_add.cpp
@@ -42,12 +42,10 @@ void message_reaction_add::handle(discord_client* client, json &j, const std::st
 		dpp::message_reaction_add_t mra(client->owner, client->shard_id, raw);
 		snowflake guild_id = snowflake_not_null(&d, "guild_id");
 		snowflake channel_id = snowflake_not_null(&d, "channel_id");
-		snowflake user_id = snowflake_not_null(&d, "user_id");
 
 		guild* g = find_guild(guild_id);
 		channel* c = find_channel(channel_id);
 
-		mra.user_id = user_id;
 		mra.reacting_guild = g ? *g : guild{};
 		mra.reacting_guild.id = guild_id;
 


### PR DESCRIPTION
Adds an user_id field to message_reaction_add_t.
When we get the callback from adding a reaction in a DM, the payload is as follows:

```
{
	"t": "MESSAGE_REACTION_ADD",
	"s": 4,
	"op": 0,
	"d": {
		"user_id": "0000000000000000000",
		"type": 0,
		"message_id": "0000000000000000000",
		"message_author_id": "0000000000000000000",
		"emoji": {
			"name": "âœ…",
			"id": null
		},
		"channel_id": "0000000000000000",
		"burst": false
	}
}
```

This has no member or user information to fill the corresponding classes, making it impossible to get the user_id of the user that reacted.

Test code:

```
#include <cassert>
#include <memory>
#include <dpp/dpp.h>

#define TOKEN "ADD_BOT_TOKEN"
#define USER_ID ADD_USER_ID

class TestBot final {
public:
	TestBot() {
		bot_.on_ready([this](dpp::ready_t const& ready) { OnReady(ready); });
		bot_.on_message_reaction_add([this](dpp::message_reaction_add_t const& message_reaction_add) { OnMessageReactionAdd(message_reaction_add); });
	}
	~TestBot() = default;

	void Start() noexcept {
		bot_.start(dpp::st_wait);
	}

private:
	void OnMessageReactionAdd(dpp::message_reaction_add_t const& message_reaction_add) noexcept {
		assert(message_reaction_add.user_id == bot_.me.id);
	}

	void OnReady(dpp::ready_t const& ready) noexcept {
		bot_.direct_message_create(USER_ID, dpp::message("Test"), [this](dpp::confirmation_callback_t const& confirmation_callback) {
			auto const sent_message = confirmation_callback.get<dpp::message>();
			bot_.message_add_reaction(sent_message, "✅");
		});
	}

private:
	dpp::cluster bot_ = dpp::cluster(TOKEN, dpp::i_default_intents);
};

int main(const int argc, char const* const* const argv) {
	TestBot bot;
	bot.Start();

	return 0;
}
```

## Code change checklist

- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [X] I tested that my change works before raising the PR.
- [X] I have ensured that I did not break any existing API calls.
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
