### PR TITLE
fix: oauth2_install_params in current_application_get() could not be parsed

### DIFF
--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -216,7 +216,7 @@ public:
  * @brief Configuration object for an app installation
  */
 struct DPP_EXPORT integration_configuration {
-		std::optional<application_install_params> oauth2_install_params;
+		application_install_params oauth2_install_params;
 };
 
 /**

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -33,7 +33,7 @@ namespace dpp {
 /**
  * @brief Where an app can be installed, also called its supported installation contexts.
  */
-enum application_integration_types {
+enum application_integration_types : uint8_t {
 	/**
 	* @brief Installable to servers
 	*/
@@ -47,7 +47,7 @@ enum application_integration_types {
 /**
  * @brief Integration types
  */
-enum integration_type {
+enum integration_type : uint8_t {
 	/**
 	 * @brief Twitch integration
 	 */
@@ -72,7 +72,7 @@ enum integration_type {
 /**
  * @brief Integration flags
  */
-enum integration_flags {
+enum integration_flags : uint8_t {
 	/**
 	 * @brief Is this integration enabled?
 	 */

--- a/mlspp/include/namespace.h
+++ b/mlspp/include/namespace.h
@@ -1,4 +1,0 @@
-#pragma once
-
-// Configurable top-level MLS namespace
-#define MLS_NAMESPACE mls

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -1024,8 +1024,14 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			});
 
 			bot.on_ready([&ready_promise, &bot, dpp_logo](const dpp::ready_t &event) {
+
 				set_test(CONNECTION, true);
 				ready_promise.set_value();
+
+				set_test(GETAPP, false);
+				bot.current_application_get([&bot](const auto& res) {
+					set_test(GETAPP, !res.is_error() && (std::get<dpp::application>(res.value)).id == bot.me.id);
+				});
 
 				set_test(APPCOMMAND, false);
 				set_test(LOGGER, false);
@@ -1084,7 +1090,15 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			bot.on_log([](const dpp::log_t &event) {
 				if (event.severity > dpp::ll_trace) {
 					std::lock_guard<std::mutex> locker(loglock);
-					std::cout << "[" << std::fixed << std::setprecision(3) << (dpp::utility::time_f() - get_start_time()) << "]: [\u001b[36m" << dpp::utility::loglevel(event.severity) << "\u001b[0m] " << event.message << "\n";
+					std::cout << "[" << std::fixed << std::setprecision(3) << (dpp::utility::time_f() - get_start_time()) << "]: ";
+					if (event.severity == dpp::ll_error) {
+						/* Errors are red */
+						std::cout << "[\u001b[31m" << dpp::utility::loglevel(event.severity);
+					} else {
+						/* All other generic logger are cyan */
+						std::cout << "[\u001b[36m" << dpp::utility::loglevel(event.severity);
+					}
+					std::cout << "\u001b[0m] " << event.message << "\n";
 				}
 				if (event.message == "Test log message") {
 					set_test(LOGGER, true);

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -94,6 +94,7 @@ DPP_TEST(BOTSTART, "cluster::start method", tf_online);
 DPP_TEST(CONNECTION, "Connection to client websocket", tf_online);
 DPP_TEST(APPCOMMAND, "Creation of application command", tf_online);
 DPP_TEST(DELCOMMAND, "Deletion of application command", tf_online);
+DPP_TEST(GETAPP, "cluster::current_application_get()", tf_online);
 DPP_TEST(LOGGER, "Log events", tf_online);
 DPP_TEST(MESSAGECREATE, "Creation of a channel message", tf_online);
 DPP_TEST(MESSAGEEDIT, "Editing a channel message", tf_online);


### PR DESCRIPTION
* Fix bug with parsing of oauth2_install_params in current_application_get()
* Remove autogenerated mlspp namespace.h (it is already in gitignore)
* Add unit test for current_application_get()
* Change logger errors in unit tests to red prefix

Note: Instead of a map with always two std::optional in application::integration_types_config, the map now only contains keyed values for non-empty integration types instead of using std::optional. e.g. if your bot only has a guild invite, the map will only contain one value keyed to ait_guild_install. This is simpler and matches the way other things in dpp work.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
