### PR TITLE
fix: dont allow bot.start on a started cluster

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -209,6 +209,10 @@ void cluster::add_reconnect(uint32_t shard_id) {
 
 void cluster::start(start_type return_after) {
 
+	if (start_time != 0) {
+		throw dpp::logic_error("Cluster already started");
+	}
+
 	auto event_loop = [this]() -> void {
 		auto reconnect_monitor = numshards != NO_SHARDS ? start_timer([this](auto t) {
 			time_t now = time(nullptr);

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -210,7 +210,7 @@ void cluster::add_reconnect(uint32_t shard_id) {
 void cluster::start(start_type return_after) {
 
 	if (start_time != 0) {
-		throw dpp::logic_error("Cluster already started");
+		throw dpp::logic_exception("Cluster already started");
 	}
 
 	auto event_loop = [this]() -> void {


### PR DESCRIPTION
it is possible to call bot.start twice if you specify dpp::st_return

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
