### PR TITLE
fix: deny user ability to set certain headers

### DIFF
--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -54,7 +54,7 @@ void https_client::connect()
 	std::string map_headers;
 	for (auto& [k,v] : request_headers) {
 		std::string lower_header = dpp::lowercase(k);
-		if (lower_header == "connection" && lower_header == "content-length" && lower_header == "host") {
+		if (lower_header == "connection" || lower_header == "content-length" || lower_header == "host") {
 			owner->log(ll_warning, "Detected unnecessary duplicate header '" + k + "' in HTTP request to '" + hostname + "', which has been discarded.");
 		}
 		map_headers += k + ": " + v + "\r\n";

--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -53,7 +53,10 @@ void https_client::connect()
 	state = HTTPS_HEADERS;
 	std::string map_headers;
 	for (auto& [k,v] : request_headers) {
-		map_headers += k + ": " + v + "\r\n";
+		std::string lower_header = dpp::lowercase(k);
+		if (lower_header != "connection" && lower_header != "content-length" && lower_header != "host") {
+			map_headers += k + ": " + v + "\r\n";
+		}
 	}
 
 	if (this->sfd != SOCKET_ERROR) {

--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -56,6 +56,7 @@ void https_client::connect()
 		std::string lower_header = dpp::lowercase(k);
 		if (lower_header == "connection" || lower_header == "content-length" || lower_header == "host") {
 			owner->log(ll_warning, "Detected unnecessary duplicate header '" + k + "' in HTTP request to '" + hostname + "', which has been discarded.");
+			continue;
 		}
 		map_headers += k + ": " + v + "\r\n";
 	}

--- a/src/dpp/httpsclient.cpp
+++ b/src/dpp/httpsclient.cpp
@@ -54,9 +54,10 @@ void https_client::connect()
 	std::string map_headers;
 	for (auto& [k,v] : request_headers) {
 		std::string lower_header = dpp::lowercase(k);
-		if (lower_header != "connection" && lower_header != "content-length" && lower_header != "host") {
-			map_headers += k + ": " + v + "\r\n";
+		if (lower_header == "connection" && lower_header == "content-length" && lower_header == "host") {
+			owner->log(ll_warning, "Detected unnecessary duplicate header '" + k + "' in HTTP request to '" + hostname + "', which has been discarded.");
 		}
+		map_headers += k + ": " + v + "\r\n";
 	}
 
 	if (this->sfd != SOCKET_ERROR) {


### PR DESCRIPTION
If the user tries to set multiple Content-Length, Host, or Connection HTTP headers, that conflict with those DPP sends, servers can exhibit non-deterministic behaviour. How they react is server specific, and can include closing the connection, returning the wrong page, etc.

We now filter these out.

Fixes #1382

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
