### PR TITLE
fix redefinition of DPP_NO_CORO

### DIFF
--- a/include/dpp/export.h
+++ b/include/dpp/export.h
@@ -33,13 +33,15 @@
 	#error "D++ Requires a C++17 compatible C++ compiler. Please ensure that you have enabled C++17 in your compiler flags."
 #endif
 
-/* If not using c++20, define DPP_CPP17_COMPAT and DPP_NO_CORO.
+/* If not using c++20, define DPP_CPP17_COMPAT and DPP_NO_CORO if DPP_NO_CORO is not already defined.
  */
 #if !(defined(__cplusplus) && __cplusplus >= 202002L) && !(defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
-#  define DPP_CPP17_COMPAT
-#  if !defined(DPP_CORO) || !DPP_CORO // Allow overriding this because why not
-#    define DPP_NO_CORO
-#  endif
+	#define DPP_CPP17_COMPAT
+	#if !defined(DPP_CORO) || !DPP_CORO // Allow overriding this because why not
+		#ifndef DPP_NO_CORO
+			#define DPP_NO_CORO
+		#endif
+	#endif
 #endif
 
 #ifndef DPP_STATIC


### PR DESCRIPTION
1) Building DPP on systems that are C++17 only is very noisy, outputs redefinition warnings with every source file. This fixes it
2) Indentation style now matches other ifdef blocks in the project

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
