### PR TITLE
build: update actions to remove some use of 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           # Replaced with self-hosted runner
           # - {name: "ARM64", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARM64ToolChain.cmake}
           # - {name: "ARMv7 HF", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARMv7ToolChain.cmake}
-          - {name: "Linux x86", os: ubuntu-22.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/LINUXx86ToolChain.cmake -DBUILD_VOICE_SUPPORT=OFF}
+          - {name: "Linux x86", os: ubuntu-24.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/LINUXx86ToolChain.cmake -DBUILD_VOICE_SUPPORT=OFF}
           - {name: "ARMv6", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARMv6ToolChain.cmake}
 
     name: ${{matrix.cfg.name}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,11 @@ jobs:
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-18, cpp: clang++, version: 18, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: 'clang-19 libc++-19-dev libc++abi-19-dev', cpp: clang++, version: 19, cmake-flags: '-DDPP_CORO=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"', cpack: 'no', ctest: 'no', mold: 'yes', name-extra: ' libc++', llvm-apt: 'yes' }
           # g++
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: g++-13, cpp: g++, version: 13, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'no', mold: 'yes' }
+          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: g++-13, cpp: g++, version: 13, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'yes', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: g++-14, cpp: g++, version: 14, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: g++-12, cpp: g++, version: 12, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: g++-11, cpp: g++, version: 11, cmake-flags: '-DDPP_CORO=ON', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: g++-10, cpp: g++, version: 10, cmake-flags: '', cpack: 'yes', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-20.04, package: g++-9, cpp: g++, version: 9, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-20.04, package: g++-8, cpp: g++, version: 8, cmake-flags: '', cpack: 'no', ctest: 'yes', mold: 'yes' }
           # Self hosted
           - { arch: 'arm7hf', concurrency: 4, os: [self-hosted, linux, ARM], package: g++-12, cpp: g++, version: 12, cmake-flags: '', cpack: 'yes', ctest: 'no', mold: 'no' }
           - { arch: 'arm64', concurrency: 4, os: [self-hosted, linux, ARM64], package: g++-12, cpp: g++, version: 12, cmake-flags: '', cpack: 'yes', ctest: 'no', mold: 'yes' }
@@ -247,7 +245,7 @@ jobs:
           # Replaced with self-hosted runner
           # - {name: "ARM64", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARM64ToolChain.cmake}
           # - {name: "ARMv7 HF", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARMv7ToolChain.cmake}
-          - {name: "Linux x86", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/LINUXx86ToolChain.cmake -DBUILD_VOICE_SUPPORT=OFF}
+          - {name: "Linux x86", os: ubuntu-22.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/LINUXx86ToolChain.cmake -DBUILD_VOICE_SUPPORT=OFF}
           - {name: "ARMv6", os: ubuntu-20.04, cmake-options: -DCMAKE_TOOLCHAIN_FILE=cmake/ARMv6ToolChain.cmake}
 
     name: ${{matrix.cfg.name}}

--- a/cmake/LINUXx86ToolChain.cmake
+++ b/cmake/LINUXx86ToolChain.cmake
@@ -15,7 +15,7 @@ SET(COMPILER_ROOT /usr/bin)
 
 INCLUDE_DIRECTORIES(/usr/include/i386-linux-gnu)
 
-SET(ZLIB_LIBRARY /lib/i386-linux-gnu/libz.so.1.2.11)
+SET(ZLIB_LIBRARY /lib/i386-linux-gnu/libz.so)
 SET(OPENSSL_CRYPTO_LIBRARY /usr/lib/i386-linux-gnu/libcrypto.so)
 SET(OPENSSL_SSL_LIBRARY /usr/lib/i386-linux-gnu/libssl.so)
 

--- a/cmake/LINUXx86ToolChain.cmake
+++ b/cmake/LINUXx86ToolChain.cmake
@@ -2,8 +2,8 @@ SET(CMAKE_SYSTEM_NAME Linux)
 # Possibly needed tweak
 #SET(CMAKE_SYSTEM_PROCESSOR i386)
 
-SET(CMAKE_C_COMPILER gcc-10)
-SET(CMAKE_CXX_COMPILER g++-10)
+SET(CMAKE_C_COMPILER gcc-12)
+SET(CMAKE_CXX_COMPILER g++-12)
 
 # Below call is necessary to avoid non-RT problem.
 SET(CMAKE_LIBRARY_ARCHITECTURE i386-linux-gnu)
@@ -13,8 +13,7 @@ SET(CPACK_RPM_PACKAGE_ARCHITECTURE i686)
 #If you have installed cross compiler to somewhere else, please specify that path.
 SET(COMPILER_ROOT /usr/bin) 
 
-INCLUDE_DIRECTORIES(
-	/usr/include/i386-linux-gnu)
+INCLUDE_DIRECTORIES(/usr/include/i386-linux-gnu)
 
 SET(ZLIB_LIBRARY /lib/i386-linux-gnu/libz.so.1.2.11)
 SET(OPENSSL_CRYPTO_LIBRARY /usr/lib/i386-linux-gnu/libcrypto.so)
@@ -26,7 +25,7 @@ set(T_AVX_EXITCODE "0" CACHE STRING INTERNAL FORCE)
 
 EXECUTE_PROCESS(COMMAND sudo dpkg --add-architecture i386)
 EXECUTE_PROCESS(COMMAND sudo apt-get update)
-EXECUTE_PROCESS(COMMAND sudo apt-get install -qq -y g++-10 gcc-10-multilib glibc-*:i386 libc6-dev-i386 g++-10-multilib zlib1g-dev:i386 libssl-dev:i386 libopus-dev:i386)
+EXECUTE_PROCESS(COMMAND sudo apt-get install -qq -y g++-12 gcc-12-multilib glibc-*:i386 libc6-dev-i386 g++-12-multilib zlib1g-dev:i386 libssl-dev:i386 libopus-dev:i386)
 EXECUTE_PROCESS(COMMAND export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")


### PR DESCRIPTION
move unit tests to g++13 version, bump x86 cross to 24.04 and remove g++8 and 9 builds
The only build remaining on g++8 and ubuntu 20.04 is the arm6 build.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
