### PR TITLE
feat: ssl context management

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -942,7 +942,7 @@ protected:
 	 * @brief Get a resolved object from the resolved set
 	 * 
 	 * @tparam T type of object to retrieve
-	 * @tparam C container defintion for resolved container
+	 * @tparam C container definition for resolved container
 	 * @param id Snowflake ID
 	 * @param resolved_set container for the type
 	 * @return const T& retrieved type

--- a/include/dpp/http_server.h
+++ b/include/dpp/http_server.h
@@ -25,6 +25,7 @@
 #include <dpp/cluster.h>
 #include <dpp/socket_listener.h>
 #include <dpp/http_server_request.h>
+#include <dpp/ssl_context.h>
 
 namespace dpp {
 
@@ -39,6 +40,11 @@ struct http_server : public socket_listener<http_server_request> {
 	 * @brief Request handler callback to use for all incoming HTTP(S) requests
 	 */
 	http_server_request_event request_handler;
+
+	/**
+	 * @brief Port we are listening on
+	 */
+	uint16_t bound_port;
 
 	/**
 	 * @brief Constructor for creation of a HTTP(S) server
@@ -56,6 +62,13 @@ struct http_server : public socket_listener<http_server_request> {
 	 * @param newfd file descriptor of new request
 	 */
 	void emplace(socket newfd) override;
+
+	/**
+	 * @brief Destructor
+	 */
+	virtual ~http_server() {
+		detail::release_ssl_context(bound_port);
+	}
 };
 
 }

--- a/include/dpp/http_server_request.h
+++ b/include/dpp/http_server_request.h
@@ -165,12 +165,13 @@ public:
 	 * have a file descriptor.
 	 * @param creator creating owner
 	 * @param fd file descriptor
+	 * @param port Port the connection came in on
 	 * @param plaintext_downgrade true if plaintext, false if SSL
 	 * @param private_key if SSL, the path to the private key PEM
 	 * @param public_key if SSL, the path to the public key PEM
 	 * @param handle_request request handler callback
 	 */
-        http_server_request(cluster* creator, socket fd, bool plaintext_downgrade, const std::string& private_key, const std::string& public_key, http_server_request_event handle_request);
+        http_server_request(cluster* creator, socket fd, uint16_t port, bool plaintext_downgrade, const std::string& private_key, const std::string& public_key, http_server_request_event handle_request);
 
 	/**
 	 * @brief Destroy the https client object

--- a/include/dpp/ssl_context.h
+++ b/include/dpp/ssl_context.h
@@ -1,0 +1,52 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#pragma once
+#include <string>
+#include <cstdint>
+
+namespace dpp::detail {
+
+struct wrapped_ssl_ctx;
+
+/**
+ * @brief Generate a new wrapped SSL context.
+ * If an SSL context already exists for the given port number, it will be returned, else a new one will be
+ * generated and cached. Contexts with port = 0 will be considered client contexts. There can only be one
+ * client context at a time and it covers all SSL client connections. There can be many SSL server contexts,
+ * individual ones can be cached per-port, each with their own loaded SSL private and public key PEM certificate.
+ *
+ * @param port Port number. Pass zero to create or get the client context.
+ * @param private_key Private key PEM pathname for server contexts
+ * @param public_key Public key PEM pathname for server contexts
+ * @return wrapped SSL context
+ */
+wrapped_ssl_ctx* generate_ssl_context(uint16_t port = 0, const std::string &private_key = "", const std::string &public_key = "");
+
+/**
+ * @brief Release an SSL context
+ * @warning Only do this if you are certain no SSL connections remain that use this context.
+ * As OpenSSL is a C library it is impossible for us to track this on its behalf. Be careful!
+ * @param port port number to release
+ */
+void release_ssl_context(uint16_t port = 0);
+
+};

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -311,11 +311,12 @@ public:
 	 * @brief Accept a new connection from listen()/accept() socket
 	 * @param creator Creating cluster
 	 * @param fd Socket file descriptor assigned by accept()
+	 * @param port Port the new fd came from
 	 * @param plaintext_downgrade Set to true to connect using plaintext only, without initialising SSL.
 	 * @param private_key if plaintext_downgrade is set to false, a private key PEM file for SSL connections
 	 * @param public_key if plaintext_downgrade is set to false, a public key PEM file for SSL connections
 	 */
-	ssl_connection(cluster* creator, socket fd, bool plaintext_downgrade = false, const std::string& private_key = "", const std::string& public_key = "");
+	ssl_connection(cluster* creator, socket fd, uint16_t port, bool plaintext_downgrade = false, const std::string& private_key = "", const std::string& public_key = "");
 
 	/**
 	 * @brief Set up non blocking I/O and configure on_read, on_write and on_error.

--- a/include/dpp/wrapped_ssl_ctx.h
+++ b/include/dpp/wrapped_ssl_ctx.h
@@ -1,0 +1,90 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/exception.h>
+#include <openssl/ssl.h>
+#pragma once
+
+namespace dpp::detail {
+
+/**
+ * @brief This class wraps a raw SSL_CTX pointer, managing moving,
+ * creation, and RAII destruction.
+ */
+struct wrapped_ssl_ctx {
+
+	/**
+	 * @brief SSL_CTX pointer, raw C pointer nastiness
+	 */
+	SSL_CTX *context{nullptr};
+
+	/**
+	 * @brief Create a wrapped SSL context
+	 * @param is_server true to create a server context, false to create a client context
+	 * @throws dpp::connection_exception if context could not be created
+	 */
+	explicit wrapped_ssl_ctx(bool is_server = false) : context(SSL_CTX_new(is_server ? TLS_server_method() : TLS_client_method())) {
+		if (context == nullptr) {
+			throw dpp::connection_exception(err_ssl_context, "Failed to create SSL client context!");
+		}
+	}
+
+	/**
+	 * @brief Copy constructor
+	 * @note Intentionally deleted
+	 */
+	wrapped_ssl_ctx(const wrapped_ssl_ctx&) = delete;
+
+	/**
+	 * @brief Copy assignment operator
+	 * @note Intentionally deleted
+	 */
+	wrapped_ssl_ctx& operator=(const wrapped_ssl_ctx&) = delete;
+
+	/**
+	 * @brief Move constructor
+	 * @param other source context
+	 */
+	wrapped_ssl_ctx(wrapped_ssl_ctx&& other) noexcept : context(other.context) {
+		other.context = nullptr;
+	}
+
+	/**
+	 * @brief Move assignment operator
+	 * @param other source context
+	 * @return self
+	 */
+	wrapped_ssl_ctx& operator=(wrapped_ssl_ctx&& other) noexcept {
+		if (this != &other) {
+			/* Free current context if any and transfer ownership */
+			SSL_CTX_free(context);
+			context = other.context;
+			other.context = nullptr;
+		}
+		return *this;
+	}
+
+	~wrapped_ssl_ctx() {
+		SSL_CTX_free(context);
+	}
+};
+
+};

--- a/src/dpp/http_server.cpp
+++ b/src/dpp/http_server.cpp
@@ -25,12 +25,12 @@
 namespace dpp {
 
 http_server::http_server(cluster* owner, const std::string_view address, uint16_t port, http_server_request_event handle_request, const std::string& private_key, const std::string& public_key)
- : socket_listener<http_server_request>(owner, address, port, private_key.empty() ? li_plaintext : li_ssl, private_key, public_key), request_handler(handle_request)
+ : socket_listener<http_server_request>(owner, address, port, private_key.empty() ? li_plaintext : li_ssl, private_key, public_key), request_handler(handle_request), bound_port(port)
 {
 }
 
 void http_server::emplace(socket newfd) {
-	connections.emplace(newfd, std::make_unique<http_server_request>(creator, newfd, plaintext, private_key_file, public_key_file, request_handler));
+	connections.emplace(newfd, std::make_unique<http_server_request>(creator, newfd, bound_port, plaintext, private_key_file, public_key_file, request_handler));
 }
 
 }

--- a/src/dpp/http_server_request.cpp
+++ b/src/dpp/http_server_request.cpp
@@ -43,8 +43,8 @@ constexpr std::array verb {
 	"TRACE",
 };
 
-http_server_request::http_server_request(cluster* creator, socket fd, bool plaintext_downgrade, const std::string& private_key, const std::string& public_key, http_server_request_event handle_request)
-	: ssl_connection(creator, fd, plaintext_downgrade, private_key, public_key),
+http_server_request::http_server_request(cluster* creator, socket fd, uint16_t port, bool plaintext_downgrade, const std::string& private_key, const std::string& public_key, http_server_request_event handle_request)
+	: ssl_connection(creator, fd, port, plaintext_downgrade, private_key, public_key),
 	  timeout(time(nullptr) + 10),
 	  handler(handle_request),
 	  state(HTTPS_HEADERS),

--- a/src/dpp/ssl_context.cpp
+++ b/src/dpp/ssl_context.cpp
@@ -1,0 +1,88 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+#include <dpp/ssl_context.h>
+#include <dpp/exception.h>
+#include <vector>
+#include <memory>
+#include <openssl/ssl.h>
+#include <mutex>
+#include <shared_mutex>
+#include <dpp/wrapped_ssl_ctx.h>
+
+namespace dpp::detail {
+
+/**
+ * @brief The vector of pairs of wrapped contexts is efficient for small numbers of contexts.
+ * In a real world production application we expect to have 2 to 5 at most contexts, and for
+ * most bots that do not use server ports, there will be only one context on port 0.
+ * This is O(n), but in the most common situation of having one entry, it is O(1).
+ */
+static std::vector<std::pair<uint16_t, std::unique_ptr<wrapped_ssl_ctx>>> contexts;
+
+/**
+ * @brief Managing SSL contexts is thread-safe.
+ */
+static std::shared_mutex context_mutex;
+
+void release_ssl_context(uint16_t port) {
+	std::unique_lock lock(context_mutex);
+	auto it = std::remove_if(contexts.begin(), contexts.end(), [port](const auto& entry) { return entry.first == port; });
+	if (it != contexts.end()) {
+		contexts.erase(it, contexts.end());
+	}
+}
+
+wrapped_ssl_ctx* generate_ssl_context(uint16_t port, const std::string &private_key, const std::string &public_key) {
+	{
+		std::shared_lock lock(context_mutex);
+		for (const auto& [p, ctx] : contexts) {
+			if (p == port) {
+				return ctx.get();
+			}
+		}
+	}
+
+	std::unique_ptr<wrapped_ssl_ctx> context = std::make_unique<wrapped_ssl_ctx>(port != 0);
+
+	if (port != 0) {
+		if (SSL_CTX_use_certificate_file(context->context, public_key.c_str(), SSL_FILETYPE_PEM) <= 0) {
+			throw dpp::connection_exception(err_ssl_context, "Failed to set public key certificate");
+		}
+		if (SSL_CTX_use_PrivateKey_file(context->context, private_key.c_str(), SSL_FILETYPE_PEM) <= 0) {
+			throw dpp::connection_exception(err_ssl_context, "Failed to set private key certificate");
+		}
+	}
+
+	/* This sets the allowed SSL/TLS versions for the connection.
+	 * Do not allow SSL 3.0, TLS 1.0 or 1.1
+	 * https://www.packetlabs.net/posts/tls-1-1-no-longer-secure/
+	 */
+	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_2_VERSION)) {
+		throw dpp::connection_exception(err_ssl_version, "Failed to set minimum SSL version!");
+	}
+
+	std::unique_lock lock(context_mutex);
+	contexts.emplace_back(port, std::move(context));
+	return contexts.back().second.get();
+}
+
+}


### PR DESCRIPTION
Instead of creating a new ssl context for every connection, we only need:

* one SSL context for all client connections
* one for each listening port, with the SSL private key and public key loaded into it

This saves on memory of having to keep copies of the context around, and also massively cuts down on cpu use. Creating an SSL context from scratch means loading the cert store and root certs, generating things, loading private and public keys from disk and more.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
