### PR TITLE
Fix: timers stop firing if the reactor has no sockets, only happens on bots that have little activity

### DIFF
--- a/src/dpp/socketengines/epoll.cpp
+++ b/src/dpp/socketengines/epoll.cpp
@@ -77,14 +77,6 @@ struct DPP_EXPORT socket_engine_epoll : public socket_engine_base {
 
 	void process_events() final {
 		const int sleep_length = 1000;
-		if (sockets == 0) {
-			/* epoll_wait() on empty set waits forever (or until another thread inserts a socket into the set.
-			 * We can't trust that this is going to happen, and it may deadlock the cluster, so in the event the
-			 * set is empty, we wait a millisecond (so it isn't a busy-wait) and return.
-			 */
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			return;
-		}
 		int i = epoll_wait(epoll_handle, events.data(), MAX_EVENTS, sleep_length);
 
 		for (int j = 0; j < i; j++) {

--- a/src/dpp/socketengines/kqueue.cpp
+++ b/src/dpp/socketengines/kqueue.cpp
@@ -63,6 +63,7 @@ struct DPP_EXPORT socket_engine_kqueue : public socket_engine_base {
 
 		int i = kevent(kqueue_handle, nullptr, 0, ke_list.data(), static_cast<int>(ke_list.size()), &ts);
 		if (i < 0) {
+			prune();
 			return;
 		}
 

--- a/src/dpp/ssl_context.cpp
+++ b/src/dpp/ssl_context.cpp
@@ -73,10 +73,10 @@ wrapped_ssl_ctx* generate_ssl_context(uint16_t port, const std::string &private_
 	}
 
 	/* This sets the allowed SSL/TLS versions for the connection.
-	 * Do not allow SSL 3.0, TLS < 1.3
+	 * Do not allow SSL 3.0, TLS 1.0 or 1.1
 	 * https://www.packetlabs.net/posts/tls-1-1-no-longer-secure/
 	 */
-	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_3_VERSION)) {
+	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_2_VERSION)) {
 		throw dpp::connection_exception(err_ssl_version, "Failed to set minimum SSL version!");
 	}
 

--- a/src/dpp/ssl_context.cpp
+++ b/src/dpp/ssl_context.cpp
@@ -73,10 +73,10 @@ wrapped_ssl_ctx* generate_ssl_context(uint16_t port, const std::string &private_
 	}
 
 	/* This sets the allowed SSL/TLS versions for the connection.
-	 * Do not allow SSL 3.0, TLS 1.0 or 1.1
+	 * Do not allow SSL 3.0, TLS < 1.3
 	 * https://www.packetlabs.net/posts/tls-1-1-no-longer-secure/
 	 */
-	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_2_VERSION)) {
+	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_3_VERSION)) {
 		throw dpp::connection_exception(err_ssl_version, "Failed to set minimum SSL version!");
 	}
 


### PR DESCRIPTION
Fix: timers stop firing if the reactor has no sockets, only happens on bots that have little activity

~~Improvement (unrelated): Bump minimum TLS version to 1.3~~ - rolled back - voice websockets do not support TLS 1.3!

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
