### PR TITLE
add TCP_NODELAY to connections to speed up SSL handshakes

### DIFF
--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -30,6 +30,7 @@
 	/* Anything other than Windows (e.g. sane OSes) */
 	#include <sys/socket.h>
 	#include <unistd.h>
+	#include <netinet/tcp.h>
 #endif
 #include <csignal>
 #include <sys/types.h>
@@ -106,6 +107,7 @@ bool close_socket(dpp::socket sfd)
 
 bool set_nonblocking(dpp::socket sockfd, bool non_blocking)
 {
+	static int enable{1};
 #ifdef _WIN32
 	u_long mode = non_blocking ? 1 : 0;
 	int result = ioctlsocket(sockfd, FIONBIO, &mode);
@@ -123,6 +125,7 @@ bool set_nonblocking(dpp::socket sockfd, bool non_blocking)
 		return false;
 	}
 #endif
+	setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&enable), sizeof(int));
 	return true;
 }
 

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -107,7 +107,7 @@ bool close_socket(dpp::socket sfd)
 
 bool set_nonblocking(dpp::socket sockfd, bool non_blocking)
 {
-	static int enable{1};
+	const int enable{1};
 #ifdef _WIN32
 	u_long mode = non_blocking ? 1 : 0;
 	int result = ioctlsocket(sockfd, FIONBIO, &mode);
@@ -125,7 +125,7 @@ bool set_nonblocking(dpp::socket sockfd, bool non_blocking)
 		return false;
 	}
 #endif
-	setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&enable), sizeof(int));
+	setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&enable), sizeof(int));
 	return true;
 }
 


### PR DESCRIPTION
Setting TCP_NODELAY massively improves the speed of SSL handshakes, this is a big benefit when we make lots of outgoing HTTPS requests constantly for REST API. 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
