### PR TITLE
require c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@
 #
 
 cmake_minimum_required (VERSION 3.16)
-
+set(CMAKE_CXX_STANDARD 17)
+ 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_VOICE_SUPPORT "Build voice support" ON)
 option(RUN_LDCONFIG "Run ldconfig after installation" ON)
@@ -156,6 +157,5 @@ else()
 endif()
 
 if (NOT WIN32)
-	set(CMAKE_CXX_STANDARD 17)
 	target_link_libraries(dpp PRIVATE std::filesystem)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,5 +156,6 @@ else()
 endif()
 
 if (NOT WIN32)
+	set(CMAKE_CXX_STANDARD 17)
 	target_link_libraries(dpp PRIVATE std::filesystem)
 endif()


### PR DESCRIPTION
clang 16 may bug out on macos if it is not explicitly provided

added a line to require c++17 before linking std::filesystem

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
