### PR TITLE
security: bump minimum tls version for openssl to TLS 1.3

### DIFF
--- a/src/dpp/ssl_context.cpp
+++ b/src/dpp/ssl_context.cpp
@@ -73,10 +73,10 @@ wrapped_ssl_ctx* generate_ssl_context(uint16_t port, const std::string &private_
 	}
 
 	/* This sets the allowed SSL/TLS versions for the connection.
-	 * Do not allow SSL 3.0, TLS 1.0 or 1.1
+	 * Do not allow SSL 3.0, TLS < 1.3
 	 * https://www.packetlabs.net/posts/tls-1-1-no-longer-secure/
 	 */
-	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_2_VERSION)) {
+	if (!SSL_CTX_set_min_proto_version(context->context, TLS1_3_VERSION)) {
 		throw dpp::connection_exception(err_ssl_version, "Failed to set minimum SSL version!");
 	}
 


### PR DESCRIPTION
After raising this with Discord they have enabled support for TLS 1.3 on discord.media websocket endpoints. This now allows all of D++ to use TLS 1.3 as a minimum TLS version. 

Unit tests now pass with this set.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
