### PR TITLE
feat: Add avatar_url override for webhook struct, resolves #1416

### DIFF
--- a/include/dpp/webhook.h
+++ b/include/dpp/webhook.h
@@ -114,6 +114,7 @@ public:
 	/**
 	 * @brief The default avatar of the webhook.
 	 *
+	 * @note This value will not have any effect when `avatar_url` is set, they are mutually exclusive.
 	 * @note This may be empty.
 	 */
 	utility::iconhash avatar;
@@ -121,6 +122,7 @@ public:
 	/**
 	 * @brief Avatar URL to use instead of the default if it is set.
 	 *
+	 * @note This will override `avatar` if it is set, they are mutually exclusive.
 	 * @note This may be empty.
 	 */
 	std::string avatar_url;

--- a/include/dpp/webhook.h
+++ b/include/dpp/webhook.h
@@ -119,6 +119,13 @@ public:
 	utility::iconhash avatar;
 
 	/**
+	 * @brief Avatar URL to use instead of the default if it is set.
+	 *
+	 * @note This may be empty.
+	 */
+	std::string avatar_url;
+
+	/**
 	 * @brief The secure token of the webhook (returned for Incoming Webhooks).
 	 *
 	 * @note This field is optional.

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -73,7 +73,7 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"with_components", true},
 	});
 	std::string body;
-	if (!thread_name.empty() || !wh.avatar.to_string().empty() || !wh.avatar_url.empty() || !wh.name.empty()) { // only use json::parse if thread_name is set
+	if (!thread_name.empty() || !wh.avatar.to_string().empty() || !wh.avatar_url.empty() || !wh.name.empty()) { // only use json::parse if a value needs to be changed
 		json j = m.to_json(false);
 		if (!thread_name.empty()) {
 			j["thread_name"] = thread_name;

--- a/src/dpp/cluster/webhook.cpp
+++ b/src/dpp/cluster/webhook.cpp
@@ -73,12 +73,14 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"with_components", true},
 	});
 	std::string body;
-	if (!thread_name.empty() || !wh.avatar.to_string().empty() || !wh.name.empty()) { // only use json::parse if thread_name is set
+	if (!thread_name.empty() || !wh.avatar.to_string().empty() || !wh.avatar_url.empty() || !wh.name.empty()) { // only use json::parse if thread_name is set
 		json j = m.to_json(false);
 		if (!thread_name.empty()) {
 			j["thread_name"] = thread_name;
 		}
-		if (!wh.avatar.to_string().empty()) {
+		if (!wh.avatar_url.empty()) {
+			j["avatar_url"] = wh.avatar_url;
+		} else if (!wh.avatar.to_string().empty()) {
 			j["avatar_url"] = wh.avatar.to_string();
 		}
 		if (!wh.name.empty()) {


### PR DESCRIPTION
This is a fix for #1416, adding a new property to the webhook struct to allow for custom avatar urls.

If an avatar_url is set, it will be used instead of the custom uploaded avatar.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
