### PR TITLE
refactor: make method and path in http_server_request protected instead of private

### DIFF
--- a/include/dpp/http_server_request.h
+++ b/include/dpp/http_server_request.h
@@ -44,17 +44,6 @@ using http_server_request_event = std::function<void(class http_server_request*)
  * @note plaintext HTTP without SSL is also supported via a "downgrade" setting
  */
 class DPP_EXPORT http_server_request : public ssl_connection {
-
-	/**
-	 * @brief The type of the request, e.g. GET, POST
-	 */
-	std::string request_type;
-
-	/**
-	 * @brief Path part of URL for HTTPS connection
-	 */
-	std::string path;
-
 	/**
 	 * @brief The request body, e.g. form data
 	 */
@@ -86,6 +75,16 @@ class DPP_EXPORT http_server_request : public ssl_connection {
 	std::string response_body;
 
 protected:
+
+	/**
+	 * @brief The type of the request, e.g. GET, POST
+	 */
+	std::string request_type;
+
+	/**
+	 * @brief Path part of URL for HTTPS connection
+	 */
+	std::string path;
 
 	/**
 	 * @brief Current connection state

--- a/src/dpp/http_server_request.cpp
+++ b/src/dpp/http_server_request.cpp
@@ -144,9 +144,11 @@ bool http_server_request::handle_buffer(std::string &buffer)
 						return true;
 					}
 					std::string req_verb = uppercase(verb_path_protocol[0]);
+					request_type = req_verb;
 					std::string req_path = verb_path_protocol[1];
+					path = req_path
 					std::string protocol = uppercase(verb_path_protocol[2]);
-
+					
 					h.erase(h.begin());
 
 					if (protocol.substr(0, 5) != "HTTP/") {
@@ -204,7 +206,7 @@ bool http_server_request::handle_buffer(std::string &buffer)
 }
 
 void http_server_request::on_buffer_drained() {
-	if (state == HTTPS_DONE && status > 0 && !handler) {
+	if ( == HTTPS_DONE && status > 0 && !handler) {
 		this->close();
 	}
 }

--- a/src/dpp/http_server_request.cpp
+++ b/src/dpp/http_server_request.cpp
@@ -206,7 +206,7 @@ bool http_server_request::handle_buffer(std::string &buffer)
 }
 
 void http_server_request::on_buffer_drained() {
-	if ( == HTTPS_DONE && status > 0 && !handler) {
+	if (state == HTTPS_DONE && status > 0 && !handler) {
 		this->close();
 	}
 }

--- a/src/dpp/http_server_request.cpp
+++ b/src/dpp/http_server_request.cpp
@@ -146,7 +146,7 @@ bool http_server_request::handle_buffer(std::string &buffer)
 					std::string req_verb = uppercase(verb_path_protocol[0]);
 					request_type = req_verb;
 					std::string req_path = verb_path_protocol[1];
-					path = req_path
+					path = req_path;
 					std::string protocol = uppercase(verb_path_protocol[2]);
 					
 					h.erase(h.begin());


### PR DESCRIPTION
Putting path and request_type to protected (making them available to retrieve in case of handle other request type than "POST")

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
