### PR TITLE
fix: json parsing issues with string arrays in dpp::application

### DIFF
--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -116,7 +116,7 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 
 	if (j->contains("redirect_uris")) {
 		for (const auto& uri : (*j)["redirect_uris"]) {
-			this->redirect_uris.push_back(to_string(uri));
+			this->redirect_uris.push_back(uri.get<std::string>());
 		}
 	}
 
@@ -126,14 +126,14 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 	set_string_not_null(j, "event_webhooks_url", event_webhooks_url);
 	if (j->contains("event_webhooks_types")) {
 		for (const auto& event_webhook_type : (*j)["event_webhooks_types"]) {
-			this->event_webhooks_types.push_back(to_string(event_webhook_type));
+			this->event_webhooks_types.push_back(event_webhook_type.get<std::string>());
 		}
 	}
 	this->event_webhooks_status = static_cast<application_event_webhook_status>(int8_not_null(j, "event_webhooks_status"));
 
 	if (j->contains("tags")) {
 		for (const auto& tag : (*j)["tags"]) {
-			this->tags.push_back(to_string(tag));
+			this->tags.push_back(tag.get<std::string>());
 		}
 	}
 
@@ -141,7 +141,7 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 		json& p = (*j)["install_params"];
 		set_snowflake_not_null(&p, "permissions", this->install_params.permissions);
 		for (const auto& scope : p["scopes"]) {
-			this->install_params.scopes.push_back(to_string(scope));
+			this->install_params.scopes.push_back(scope.get<std::string>());
 		}
 	}
 
@@ -170,7 +170,7 @@ application& application::fill_from_json_impl(nlohmann::json* j) {
 
 	if (j->contains("interactions_event_types")) {
 		for (const auto& event_type : (*j)["interactions_event_types"]) {
-			this->interactions_event_types.push_back(to_string(event_type));
+			this->interactions_event_types.push_back(event_type.get<std::string>());
 		}
 	}
 

--- a/src/dpp/emoji.cpp
+++ b/src/dpp/emoji.cpp
@@ -41,11 +41,7 @@ emoji& emoji::fill_from_json_impl(nlohmann::json* j) {
 		user_id = snowflake_not_null(&user, "id");
 	}
 
-	if(j->contains("roles")) {
-		for (const auto& role : (*j)["roles"]) {
-			this->roles.emplace_back(to_string(role));
-		}
-	}
+	set_snowflake_array_not_null(j, "roles", this->roles);
 
 	if (bool_not_null(j, "require_colons")) {
 		flags |= e_require_colons;

--- a/src/dpp/integration.cpp
+++ b/src/dpp/integration.cpp
@@ -96,7 +96,7 @@ integration& integration::fill_from_json_impl(nlohmann::json* j)
 
 	if(j->contains("scopes")) {
 		for (const auto& scope : (*j)["scopes"]) {
-			this->scopes.push_back(to_string(scope));
+			this->scopes.push_back(scope.get<std::string>());
 		}
 	}
 


### PR DESCRIPTION
The previously used method `basic_json::to_string` adds quotation marks around the string when parsing. Replaced `basic_json::to_string` with `basic_json::get<std::string>`.

I noticed this issue in `dpp::application` and also adjusted it in `dpp::emoji` and `dpp::integration`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
