### PR TITLE
feat: support for pre-generated component json, in the same way we support pre-generated embed json

### DIFF
--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2390,6 +2390,12 @@ public:
 	std::vector<dpp::component> components;
 
 	/**
+	 * @brief Pre-generated components as JSON. This overrides the components
+	 * array if it is set.
+	 */
+	json components_json;
+
+	/**
 	 * @brief When this message was sent.
 	 */
 	time_t sent;
@@ -2826,6 +2832,17 @@ public:
 	 * @return message& reference to self
 	 */
 	message& add_component(const component& c);
+
+	/**
+	 * @brief Add pre-generated components to a message
+	 *
+	 * @note This is intended to accept pre-generated component
+	 * json from external tools such as https://discord.builders
+	 *
+	 * @param c components json to add. The JSON will be validated
+	 * @return message& reference to self
+	 */
+	message& add_json_components(const std::string& json);
 
 	/**
 	 * @brief Add a component to a message

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2839,7 +2839,7 @@ public:
 	 * @note This is intended to accept pre-generated component
 	 * json from external tools such as https://discord.builders
 	 *
-	 * @param c components json to add. The JSON will be validated
+	 * @param json components json to add. The JSON will be validated
 	 * @return message& reference to self
 	 */
 	message& add_json_components(const std::string& json);


### PR DESCRIPTION
This adds a new method to `dpp::message` that accepts a string containing json, which can be used to pre-generate component designs at sites such as https://discord.builders in a library agnostic way.

We have had ways to do this with embeds since version 1.0 and earlier, and this is used quite effectively in production bots. As such providing a facility to do the same for components makes a lot of sense, as it allows for component designs to be stored in external json files, which can be localised etc.

The new method does not parse into the object, but attaches the array as-is to the components member of the json sent, so that if there are features the lib does not support for some reason, this can be done via this new method.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
