### PR TITLE
fix(breaking): voice connect doesnt break after a shard reconnect

### DIFF
--- a/docpages/example_code/join_voice.cpp
+++ b/docpages/example_code/join_voice.cpp
@@ -49,7 +49,7 @@ int main() {
 				/* Attempt to connect to a voice channel, returns false if we fail to connect. */
 
 				/* The user issuing the command is not on any voice channel, we can't do anything */
-				if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+				if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 					event.reply("You don't seem to be in a voice channel!");
 					return;
 				}

--- a/docpages/example_code/mp3.cpp
+++ b/docpages/example_code/mp3.cpp
@@ -66,7 +66,7 @@ int main() {
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
 			/* Attempt to connect to a voice channel, returns false if we fail to connect. */
-			if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+			if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 				event.reply("You don't seem to be in a voice channel!");
 				return;
 			}

--- a/docpages/example_code/oggopus.cpp
+++ b/docpages/example_code/oggopus.cpp
@@ -29,7 +29,7 @@ int main(int argc, char const *argv[]) {
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
 			/* Attempt to connect to a voice channel, returns false if we fail to connect. */
-			if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+			if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 				event.reply("You don't seem to be in a voice channel!");
 				return;
 			}

--- a/docpages/example_code/oggopus2.cpp
+++ b/docpages/example_code/oggopus2.cpp
@@ -28,7 +28,7 @@ int main() {
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
 			/* Attempt to connect to a voice channel, returns false if we fail to connect. */
-			if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+			if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 				event.reply("You don't seem to be in a voice channel!");
 				return;
 			}

--- a/docpages/example_code/record_user.cpp
+++ b/docpages/example_code/record_user.cpp
@@ -28,7 +28,7 @@ int main() {
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
 			/* Attempt to connect to a voice channel, returns false if we fail to connect. */
-			if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+			if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 				event.reply("You don't seem to be in a voice channel!");
 				return;
 			}

--- a/docpages/example_code/soundboard.cpp
+++ b/docpages/example_code/soundboard.cpp
@@ -38,7 +38,7 @@ int main() {
 			dpp::guild* g = dpp::find_guild(event.command.guild_id);
 
 			/* Attempt to connect to a voice channel, returns false if we fail to connect. */
-			if (!g->connect_member_voice(event.command.get_issuing_user().id)) {
+			if (!g->connect_member_voice(*event.owner, event.command.get_issuing_user().id)) {
 				event.reply("You don't seem to be in a voice channel!");
 				return;
 			}

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -553,7 +553,7 @@ public:
 	 * @param id Shard ID
 	 * @return discord_client* shard, or null
 	 */
-	discord_client* get_shard(uint32_t id);
+	discord_client* get_shard(uint32_t id) const;
 
 	/**
 	 * @brief Get the list of shards

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -34,6 +34,7 @@
 namespace dpp {
 
 class channel;
+class cluster;
 
 /* Note from Archie: I'd like to move this soon (dpp::guild::region) and allow users to use a region enum.
  * This would make it easier for people to be able to alter a channel region without having to get the text right.
@@ -1285,6 +1286,7 @@ public:
 	/**
 	 * @brief Connect to a voice channel another guild member is in
 	 *
+	 * @param owner Cluster the user's shard is on
 	 * @param user_id User id to join
 	 * @param self_mute True if the bot should mute itself
 	 * @param self_deaf True if the bot should deafen itself
@@ -1295,7 +1297,7 @@ public:
 	 * as we have to wait for the connection to the voice server to be established!
 	 * e.g. wait for dpp::cluster::on_voice_ready event, and then send the audio within that event.
 	 */
-	bool connect_member_voice(snowflake user_id, bool self_mute = false, bool self_deaf = false, bool dave = false);
+	bool connect_member_voice(const cluster& owner, snowflake user_id, bool self_mute = false, bool self_deaf = false, bool dave = false);
 
 	/**
 	 * @brief Get the banner url of the guild if it have one, otherwise returns an empty string

--- a/include/dpp/voicestate.h
+++ b/include/dpp/voicestate.h
@@ -89,7 +89,7 @@ public:
 	/**
 	 * @brief Owning shard.
 	 */
-	class discord_client* shard;
+	int32_t shard_id{0};
 
 	/**
 	 * @brief Optional: The guild id this voice state is for.

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -609,7 +609,7 @@ std::string cluster::get_audit_reason() {
 	return r;
 }
 
-discord_client* cluster::get_shard(uint32_t id) {
+discord_client* cluster::get_shard(uint32_t id) const {
 	auto i = shards.find(id);
 	if (i != shards.end()) {
 		return i->second;

--- a/src/dpp/events/voice_state_update.cpp
+++ b/src/dpp/events/voice_state_update.cpp
@@ -42,7 +42,7 @@ void voice_state_update::handle(discord_client* client, json &j, const std::stri
 	json& d = j["d"];
 	dpp::voice_state_update_t vsu(client->owner, client->shard_id, raw);
 	vsu.state = dpp::voicestate().fill_from_json(&d);
-	vsu.state.shard = client;
+	vsu.state.shard_id = client->shard_id;
 
 	/* Update guild voice states */
 	dpp::guild* g = dpp::find_guild(vsu.state.guild_id);

--- a/src/dpp/voicestate.cpp
+++ b/src/dpp/voicestate.cpp
@@ -27,7 +27,7 @@ namespace dpp {
 
 using json = nlohmann::json;
 
-voicestate::voicestate() : shard(nullptr), guild_id(0), channel_id(0), user_id(0), request_to_speak(0)
+voicestate::voicestate() : shard_id(0), guild_id(0), channel_id(0), user_id(0), request_to_speak(0)
 {
 }
 


### PR DESCRIPTION
If you attempt to connect a voice connection after the shard has resumed or reconnected, the pointer is invalid. We shouldn't be storing pointers to shards, this was fixed everywhere else for 10.1 and this was *forgor*.

Reported by magistermaks on Discord.

**Breaking change as it adds a mandatory extra parameter for the cluster to the connect_member_voice function for looking up the shard** 

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
