### PR TITLE
fix: add thread safety primitives to internal shard list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,7 @@
 	"version": "0.2",
 	"language": "en-GB",
 	"words": [
+		"merperson",
 		"EVFILT",
 		"fflags",
 		"udata",

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -153,6 +153,11 @@ class DPP_EXPORT cluster {
 	std::shared_mutex named_commands_mutex;
 
 	/**
+	 * @brief Mutex for protection of shards list
+	 */
+	mutable std::shared_mutex shards_mutex;
+
+	/**
 	 * @brief Typedef for slashcommand handler type
 	 */
 	using slashcommand_handler_t = std::function<void(const slashcommand_t &)>;
@@ -558,9 +563,9 @@ public:
 	/**
 	 * @brief Get the list of shards
 	 *
-	 * @return shard_list& Reference to map of shards for this cluster
+	 * @return shard_list map of shards for this cluster
 	 */
-	const shard_list& get_shards();
+	shard_list get_shards() const;
 
 	/**
 	 * @brief Sets the request timeout.

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -229,7 +229,11 @@ void cluster::start(start_type return_after) {
 				if (now >= shard_reconnect_time) {
 					/* This shard needs to be reconnected */
 					reconnections.erase(reconnect);
-					discord_client* old = shards[shard_id];
+					discord_client* old = nullptr;
+					{
+						std::shared_lock lk(shards_mutex);
+						old = shards[shard_id];
+					}
 					/* These values must be copied to the new connection
 					 * to attempt to resume it
 					 */
@@ -238,6 +242,7 @@ void cluster::start(start_type return_after) {
 					log(ll_info, "Reconnecting shard " + std::to_string(shard_id));
 					/* Make a new resumed connection based off the old one */
 					try {
+						std::unique_lock lk(shards_mutex);
 						if (shards[shard_id] != nullptr) {
 							log(ll_trace, "Attempting resume...");
 							shards[shard_id] = nullptr;
@@ -255,6 +260,7 @@ void cluster::start(start_type return_after) {
 						shards[shard_id]->run();
 					}
 					catch (const std::exception& e) {
+						std::unique_lock lk(shards_mutex);
 						log(ll_info, "Exception when reconnecting shard " + std::to_string(shard_id) + ": " + std::string(e.what()));
 						delete shards[shard_id];
 						delete old;
@@ -340,6 +346,7 @@ void cluster::start(start_type return_after) {
 				if (s % maxclusters == cluster_id) {
 					/* Each discord_client is inserted into the socket engine when we call run() */
 					try {
+						std::unique_lock lk(shards_mutex);
 						this->shards[s] = new discord_client(this, s, numshards, token, intents, compressed, ws_mode);
 						this->shards[s]->run();
 					}
@@ -455,6 +462,7 @@ void cluster::shutdown() {
 		next_timer = {};
 	}
 
+	std::unique_lock lk(shards_mutex);
 	/* Terminate shards */
 	for (const auto& sh : shards) {
 		delete sh.second;
@@ -581,6 +589,7 @@ void cluster::set_presence(const dpp::presence &p) {
 	}
 
 	json pres = p.to_json();
+	std::shared_lock lk(shards_mutex);
 	for (auto& s : shards) {
 		if (s.second->is_connected()) {
 			s.second->queue_message(s.second->jsonobj_to_string(pres));
@@ -610,15 +619,16 @@ std::string cluster::get_audit_reason() {
 }
 
 discord_client* cluster::get_shard(uint32_t id) const {
+	std::shared_lock lk(shards_mutex);
 	auto i = shards.find(id);
 	if (i != shards.end()) {
 		return i->second;
-	} else {
-		return nullptr;
 	}
+	return nullptr;
 }
 
-const shard_list& cluster::get_shards() {
+shard_list cluster::get_shards() const {
+	std::shared_lock lk(shards_mutex);
 	return shards;
 }
 


### PR DESCRIPTION
fix adds shared lock to shards list so that accessing the shards list doesnt risk crashing the lib. Has never crashed in production for me but still the issue exists and should be patched.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
