### PR TITLE
ci: Only check changed files with npx cspell lint

### DIFF
--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -30,4 +30,5 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check docs spelling
-        run: npx -y cspell lint --language-id=cpp --no-progress --no-summary --show-context --show-suggestions --relative --color docpages/*.md include/dpp/*.h
+        run: git diff --name-only --diff-filter=ACMRTUXB | npx -y cspell lint --language-id=cpp --no-progress --no-summary --show-context --show-suggestions --relative --color --file-list stdin --no-must-find-file
+

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -30,5 +30,5 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check docs spelling
-        run: git diff --name-only --diff-filter=ACMRTUXB | npx -y cspell lint --language-id=cpp --no-progress --no-summary --show-context --show-suggestions --relative --color --file-list stdin --no-must-find-file
+        run: git diff origin/dev --name-only --diff-filter=ACMRTUXB | npx -y cspell lint --language-id=cpp --no-progress --no-summary --show-context --show-suggestions --relative --color --file-list stdin --no-must-find-file
 


### PR DESCRIPTION
npx cspell lint now only checks files that have changed in the commit

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
