### PR TITLE
Persist and move the voice connections on shard reconnection.

### DIFF
--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -232,6 +232,11 @@ public:
 	 * @return reference to self
 	 */
 	voiceconn& disconnect();
+
+	/**
+	 * @brief Reassigns the owner to the given discord_client.
+	 */
+	void reassign_owner(class discord_client* o);
 };
 
 /** @brief Implements a discord client. Each discord_client connects to one shard and derives from a websocket client. */


### PR DESCRIPTION
# Description

Don't disconnect active voice connections when shards reconnect. Reuse them and assign a new owner.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
