### PR TITLE
Change SOVERSION from full version to major version

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -264,7 +264,7 @@ foreach (fullmodname ${subdirlist})
 	set_target_properties(${modname} 
 		PROPERTIES
 		VERSION ${CMAKE_PROJECT_VERSION}
-		SOVERSION ${CMAKE_PROJECT_VERSION}
+		SOVERSION ${DPP_VERSION_MAJOR}
 		POSITION_INDEPENDENT_CODE true
 	)
 	target_include_directories(${modname} PUBLIC 


### PR DESCRIPTION
I'm packaging this library for Debian right now. The only change I need to make is that `SOVERSION` is supposed to just be the major version. The library will still be built with the version in `VERSION`, but with a symlink to the version in `SOVERSION`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
