### PR TITLE
CI: remove vs2019 from release and actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,6 @@ jobs:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:
         cfg:
-        - { name: 'x64',            arch: x64, config: Release, vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
-        - { name: 'x64',            arch: x64, config: Debug,   vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
-        - { name: 'x86',            arch: x86, config: Release, vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
-        - { name: 'x86',            arch: x86, config: Debug,   vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
         - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
         - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
         - { name: 'x86',            arch: x86, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,15 +167,15 @@ jobs:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:
         cfg:
-        - { name: 'x64',            arch: x64, config: Release, vs: '2019', os: 'windows-2019', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
-        - { name: 'x64',            arch: x64, config: Debug,   vs: '2019', os: 'windows-2019', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
-        - { name: 'x86',            arch: x86, config: Release, vs: '2019', os: 'windows-2019', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
-        - { name: 'x86',            arch: x86, config: Debug,   vs: '2019', os: 'windows-2019', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
-        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2022', vsv: '17', upload: true,  options: '' }
-        - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2022', vsv: '17', upload: true,  options: '' }
-        - { name: 'x86',            arch: x86, config: Release, vs: '2022', os: 'windows-2022', vsv: '17', upload: true,  options: '-T host=x86' }
-        - { name: 'x86',            arch: x86, config: Debug,   vs: '2022', os: 'windows-2022', vsv: '17', upload: true,  options: '-T host=x86' }
-        - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2022', vsv: '17', upload: false, options: '-T ClangCL' }
+        - { name: 'x64',            arch: x64, config: Release, vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
+        - { name: 'x64',            arch: x64, config: Debug,   vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-DDPP_NO_CORO=ON' }
+        - { name: 'x86',            arch: x86, config: Release, vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
+        - { name: 'x86',            arch: x86, config: Debug,   vs: '2019', os: 'windows-2022', vsv: '16', upload: true,  options: '-T host=x86 -DDPP_NO_CORO=ON' }
+        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
+        - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
+        - { name: 'x86',            arch: x86, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
+        - { name: 'x86',            arch: x86, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
+        - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: false, options: '-T ClangCL' }
 
     name: "Windows ${{matrix.cfg.name}}-${{matrix.cfg.config}}-vs${{matrix.cfg.vs}}"
     runs-on: ${{matrix.cfg.os}}

--- a/makerelease.sh
+++ b/makerelease.sh
@@ -23,12 +23,6 @@ mv "./libdpp - Debian Package arm64/libdpp-$NEWVER-Linux.deb" "./assets/libdpp-$
 mv "./libdpp - Debian Package arm7hf/libdpp-$NEWVER-Linux.deb" "./assets/libdpp-$NEWVER-linux-rpi-arm7hf.deb"
 mv "./libdpp - Debian Package ARMv6/libdpp-$NEWVER-Linux.deb" "./assets/libdpp-$NEWVER-linux-rpi-arm6.deb"
 
-# win vs2019
-mv "./libdpp - Windows x64-Release-vs2019/libdpp-$NEWVER-win64.zip" "./assets/libdpp-$NEWVER-win64-release-vs2019.zip"
-mv "./libdpp - Windows x64-Debug-vs2019/libdpp-$NEWVER-win64.zip" "./assets/libdpp-$NEWVER-win64-debug-vs2019.zip"
-mv "./libdpp - Windows x86-Release-vs2019/libdpp-$NEWVER-win32.zip" "./assets/libdpp-$NEWVER-win32-release-vs2019.zip"
-mv "./libdpp - Windows x86-Debug-vs2019/libdpp-$NEWVER-win32.zip" "./assets/libdpp-$NEWVER-win32-debug-vs2019.zip"
-
 # win vs2022
 mv "./libdpp - Windows x64-Release-vs2022/libdpp-$NEWVER-win64.zip" "./assets/libdpp-$NEWVER-win64-release-vs2022.zip"
 mv "./libdpp - Windows x64-Debug-vs2022/libdpp-$NEWVER-win64.zip" "./assets/libdpp-$NEWVER-win64-debug-vs2022.zip"
@@ -36,30 +30,6 @@ mv "./libdpp - Windows x86-Release-vs2022/libdpp-$NEWVER-win32.zip" "./assets/li
 mv "./libdpp - Windows x86-Debug-vs2022/libdpp-$NEWVER-win32.zip" "./assets/libdpp-$NEWVER-win32-debug-vs2022.zip"
 
 cd assets
-
-## VS2019
-
-# 64 bit windows
-mkdir -p "libdpp-$NEWVER-win64/bin"
-cp ../../win32/bin/*.dll "libdpp-$NEWVER-win64/bin"
-zip -g "libdpp-$NEWVER-win64-release-vs2019.zip" "libdpp-$NEWVER-win64/bin/"*
-rm -rf "libdpp-$NEWVER-win64"
-
-mkdir -p "libdpp-$NEWVER-win64/bin"
-cp ../../win32/bin/*.dll "libdpp-$NEWVER-win64/bin"
-zip -g "libdpp-$NEWVER-win64-debug-vs2019.zip" "libdpp-$NEWVER-win64/bin/"*
-rm -rf "libdpp-$NEWVER-win64"
-
-# 32 bit windows
-mkdir -p "libdpp-$NEWVER-win32/bin"
-cp ../../win32/32/bin/*.dll "libdpp-$NEWVER-win32/bin"
-zip -g "libdpp-$NEWVER-win32-release-vs2019.zip" "libdpp-$NEWVER-win32/bin/"*
-rm -rf "libdpp-$NEWVER-win32"
-
-mkdir -p "libdpp-$NEWVER-win32/bin"
-cp ../../win32/32/bin/*.dll "libdpp-$NEWVER-win32/bin"
-zip -g "libdpp-$NEWVER-win32-debug-vs2019.zip" "libdpp-$NEWVER-win32/bin/"*
-rm -rf "libdpp-$NEWVER-win32"
 
 ## VS2022
 


### PR DESCRIPTION
vs2019 is no longer supported on GitHub actions so we are removing it from our CI flow. This will end official support and release zips for vs2019, it may still work for you on this compiler but we don't officially test on it any longer. Now would be a good time to update to vs2022 if you can.

## Code change checklist

- [ ] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [ ] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR.
- [ ] I have ensured that I did not break any existing API calls.
- [ ] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
