### PR TITLE
fix: socket readiness fixes for windows, doesnt get stuck in reconnect loops any more

### DIFF
--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -237,6 +237,20 @@ protected:
 
 	virtual void on_buffer_drained();
 
+	/**
+	 * @brief Start connecting to a TCP socket.
+	 * This simply calls connect() and checks for error return, as the timeout is now handled in the main
+	 * IO events for the ssl_connection class.
+	 *
+	 * @param sockfd socket descriptor
+	 * @param addr address to connect to
+	 * @param addrlen address length
+	 * @param timeout_ms timeout in milliseconds
+	 * @return int -1 on error, 0 on success just like POSIX connect()
+	 * @throw dpp::connection_exception on failure
+	 */
+	int start_connecting(dpp::socket sockfd, const struct sockaddr *addr, socklen_t addrlen);
+
 public:
 	/**
 	 * @brief For low-level debugging, calling this function will

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -363,8 +363,7 @@ void discord_client::error(uint32_t errorcode)
 	if (i != errortext.end()) {
 		error = i->second;
 	}
-	log(dpp::ll_warning, "OOF! Error from underlying websocket: " + std::to_string(errorcode) + ": " + error);
-	this->close();
+	throw dpp::connection_exception("OOF! Error from underlying websocket: " + std::to_string(errorcode) + ": " + error);
 }
 
 void discord_client::log(dpp::loglevel severity, const std::string &msg) const

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -162,7 +162,7 @@ int start_connecting(dpp::socket sockfd, const struct sockaddr *addr, socklen_t 
 		throw connection_exception(err_connect_failure, strerror(errno));
 	} else if (rc == 0) {
 		/* We are ready RIGHT NOW, connection already succeeded */
-		on_read(sfd, socket_events{ sfd, WANT_READ | WANT_WRITE | WANT_ERROR });
+		on_write(sockfd, socket_events{ sockfd, WANT_READ | WANT_WRITE | WANT_ERROR });
 	}
 	return 0;
 }

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -140,7 +140,7 @@ int ssl_connection::start_connecting(dpp::socket sockfd, const struct sockaddr *
 	ULONG non_blocking = 1;
 	ioctlsocket(sockfd, FIONBIO, &non_blocking);
 	int rc = WSAConnect(sockfd, addr, addrlen, nullptr, nullptr, nullptr, nullptr);
-	int err = (rc == SOCKET_ERROR ? WSAGetLastError() : 0);
+	int err = ((rc == SOCKET_ERROR) ? WSAGetLastError() : 0);
 #else
 	/* Standard POSIX connection behaviour */
 	int rc = (::connect(sockfd, addr, addrlen));

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -146,7 +146,11 @@ int ssl_connection::start_connecting(dpp::socket sockfd, const struct sockaddr *
 	int rc = (::connect(sockfd, addr, addrlen));
 	int err = errno;
 #endif
-	if (rc == -1 && err != EWOULDBLOCK && err != EINPROGRESS) {
+	if (rc == -1
+#ifdef _WIN32
+		&& err != WSAEWOULDBLOCK
+#endif
+		&& err != EWOULDBLOCK && err != EINPROGRESS) {
 		throw connection_exception(err_connect_failure, strerror(errno));
 	} else if (rc == 0) {
 		/* We are ready RIGHT NOW, connection already succeeded */
@@ -209,7 +213,7 @@ ssl_connection::ssl_connection(cluster* creator, const std::string &_hostname, c
 	try {
 		ssl_connection::connect();
 	}
-	catch (std::exception&) {
+	catch (const std::exception&) {
 		cleanup();
 		throw;
 	}


### PR DESCRIPTION
We now throw when receiving a discord client websocket error. This is vital to push the unwind up the stack and make it reconnect properly like we do for ft_reconnect.
Also connects immediately if connect() returns 0 and properly picks up `WSAEINPROGRESS` (10035)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
