### PR TITLE
fix user::get_avatar_decoration_url() and parsing of the field

### DIFF
--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -115,9 +115,9 @@ std::string user::get_default_avatar_url() const {
 }
 
 std::string user::get_avatar_decoration_url(uint16_t size) const {
-	if (this->id) {
+	if (!this->avatar_decoration.to_string().empty()) {
 		return utility::cdn_endpoint_url_hash({ i_png },
-			"avatar-decorations/" + std::to_string(this->id), this->avatar_decoration.to_string(),
+			"avatar-decoration-presets", this->avatar_decoration.to_string(),
 			i_png, size);
 	} else {
 		return std::string();
@@ -284,9 +284,11 @@ void from_json(const nlohmann::json& j, user& u) {
 	}
 	u.avatar = av;
 
-	u.avatar_decoration = string_not_null(&j, "avatar_decoration");
+	if (j.contains("avatar_decoration_data") && !j.at("avatar_decoration_data").is_null()) {
+		u.avatar_decoration = string_not_null(&j["avatar_decoration_data"], "asset");
+	}
 
-	u.discriminator = (uint16_t)snowflake_not_null(&j, "discriminator");
+	u.discriminator = int16_not_null(&j, "discriminator");
 
 	u.flags |= bool_not_null(&j, "bot") ? dpp::u_bot : 0;
 	u.flags |= bool_not_null(&j, "system") ? dpp::u_system : 0;

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -288,7 +288,7 @@ void from_json(const nlohmann::json& j, user& u) {
 		u.avatar_decoration = string_not_null(&j["avatar_decoration_data"], "asset");
 	}
 
-	u.discriminator = int16_not_null(&j, "discriminator");
+	u.discriminator = (uint16_t)snowflake_not_null(&j, "discriminator");
 
 	u.flags |= bool_not_null(&j, "bot") ? dpp::u_bot : 0;
 	u.flags |= bool_not_null(&j, "system") ? dpp::u_system : 0;


### PR DESCRIPTION
## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.

The endpoint for the avatar decoration seems to have changed: https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints.

Same for the json structure: https://discord.com/developers/docs/resources/user#user-object-user-structure.



fix #1418
