### PR TITLE
Attempt a full reconnection when a resume attempt failed.

### DIFF
--- a/src/dpp/voice/enabled/handle_frame.cpp
+++ b/src/dpp/voice/enabled/handle_frame.cpp
@@ -343,10 +343,11 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 					this->heartbeat_interval = j["d"]["heartbeat_interval"].get<uint32_t>();
 				}
 
-				/* Reset receive_sequence on HELLO */
-				receive_sequence = -1;
-
 				if (!modes.empty()) {
+					// We will get the modes again when the voice connection is ready,
+					// but more importantly, if we failed to resume, the next time we
+					// shall try a full reconnection.
+					modes.clear();
 					log(dpp::ll_debug, "Resuming voice session " + this->sessionid + "...");
 					json obj = {
 						{ "op", voice_opcode_connection_resume },
@@ -362,6 +363,8 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 					};
 					this->write(obj.dump(-1, ' ', false, json::error_handler_t::replace), OP_TEXT);
 				} else {
+					/* Reset receive_sequence on HELLO */
+					receive_sequence = -1;
 					log(dpp::ll_debug, "Connecting new voice session (DAVE: " + std::string(dave_version == dave_version_1 ? "Enabled" : "Disabled") + ")...");
 					json obj = {
 						{ "op", voice_opcode_connection_identify },


### PR DESCRIPTION
```txt
To fix "Voice session error: 1002 on channel <channel id>: Endpoint
received a malformed frame" error on voice resuming.
```

It seems that a resume does not have to succeed after voice connection closes. See Discord documentation [Voice#Buffered Resume](https://discord.com/developers/docs/topics/voice-connections#buffered-resume)

> The resume may be unsuccessful if the voice gateway buffer for the session no longer contains a message that has been missed. In this case the session will be closed and you should then follow the [Connecting](https://discord.com/developers/docs/topics/voice-connections#connecting-to-voice) flow to reconnect.

In that case, let's clear the `modes` to cause the next reconnection to be a full reconnection rather than a resume.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
