### PR TITLE
Attempt a full reconnection when a resume attempt failed.

### DIFF
--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -230,6 +230,11 @@ private:
  */
 using privacy_code_callback_t = std::function<void(const std::string&)>;
 
+/**
+ * @brief A callback for a full reconnection after the voice client disconnects due to error.
+ */
+using full_reconnection_callback_t = std::function<void()>;
+
 /** @brief Implements a discord voice connection.
  * Each discord_voice_client connects to one voice channel and derives from a websocket client.
  */
@@ -709,6 +714,8 @@ public:
 	 */
 	class dpp::cluster* creator{};
 
+	full_reconnection_callback_t reconnection_callback;
+
 	/**
 	 * @brief True when the thread is shutting down
 	 */
@@ -872,6 +879,7 @@ public:
 
 	/** Constructor takes shard id, max shards and token.
 	 * @param _cluster The cluster which owns this voice connection, for related logging, REST requests etc
+	 * @param _reconnection_callback The callback this voice client calls if the voice connection was closed due to error
 	 * @param _channel_id The channel id to identify the voice connection as
 	 * @param _server_id The server id (guild id) to identify the voice connection as
 	 * @param _token The voice session token to use for identifying to the websocket
@@ -881,7 +889,7 @@ public:
 	 * @throw dpp::voice_exception Opus failed to initialise, or D++ is not compiled with voice support
 	 * @warning DAVE E2EE is an EXPERIMENTAL feature!
 	 */
-	discord_voice_client(dpp::cluster* _cluster, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave = false);
+	discord_voice_client(dpp::cluster* _cluster, full_reconnection_callback_t _reconnection_callback, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave = false);
 
 	/**
 	 * @brief Destroy the discord voice client object

--- a/src/dpp/events/voice_server_update.cpp
+++ b/src/dpp/events/voice_server_update.cpp
@@ -49,11 +49,12 @@ void voice_server_update::handle(discord_client* client, json &j, const std::str
 		auto v = client->connecting_voice_channels.find(vsu.guild_id);
 		/* Check to see if there is a connection in progress for a voice channel on this guild */
 		if (v != client->connecting_voice_channels.end()) {
-			if (!v->second->is_ready()) {
-				v->second->token = vsu.token;
-				v->second->websocket_hostname = vsu.endpoint;
-				if (!v->second->is_active()) {
-					v->second->connect(vsu.guild_id);
+			voiceconn& connection = *v->second;
+			if (!connection.is_ready()) {
+				connection.token = vsu.token;
+				connection.websocket_hostname = vsu.endpoint;
+				if (!connection.is_active()) {
+					connection.connect();
 				}
 			}
 		}

--- a/src/dpp/events/voice_state_update.cpp
+++ b/src/dpp/events/voice_state_update.cpp
@@ -75,9 +75,10 @@ void voice_state_update::handle(discord_client* client, json &j, const std::stri
 			auto v = client->connecting_voice_channels.find(vsu.state.guild_id);
 			/* Check to see if we have a connection to a voice channel in progress on this guild */
 			if (v != client->connecting_voice_channels.end()) {
-				v->second->session_id = vsu.state.session_id;
-				if (v->second->is_ready() && !v->second->is_active()) {
-					v->second->connect(vsu.state.guild_id);
+				voiceconn& connection = *v->second;
+				connection.session_id = vsu.state.session_id;
+				if (connection.is_ready() && !connection.is_active()) {
+					connection.connect();
 				}
 			}
 		}

--- a/src/dpp/voice/enabled/constructor.cpp
+++ b/src/dpp/voice/enabled/constructor.cpp
@@ -32,7 +32,7 @@
 
 namespace dpp {
 
-discord_voice_client::discord_voice_client(dpp::cluster* _cluster, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave)
+discord_voice_client::discord_voice_client(dpp::cluster* _cluster, full_reconnection_callback_t _reconnection_callback, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave)
 	: websocket_client(_cluster, _host.substr(0, _host.find(':')), _host.substr(_host.find(':') + 1, _host.length()), "/?v=" + std::to_string(voice_protocol_version), OP_TEXT),
 	connect_time(0),
 	mixer(std::make_unique<audio_mixer>()),
@@ -54,6 +54,7 @@ discord_voice_client::discord_voice_client(dpp::cluster* _cluster, snowflake _ch
 	tracks(0),
 	dave_version(enable_dave ? dave_version_1 : dave_version_none),
 	creator(_cluster),
+	reconnection_callback(std::move(_reconnection_callback)),
 	terminating(false),
 	heartbeat_interval(0),
 	last_heartbeat(time(nullptr)),

--- a/src/dpp/voice/enabled/handle_frame.cpp
+++ b/src/dpp/voice/enabled/handle_frame.cpp
@@ -343,9 +343,6 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 					this->heartbeat_interval = j["d"]["heartbeat_interval"].get<uint32_t>();
 				}
 
-				/* Reset receive_sequence on HELLO */
-				receive_sequence = -1;
-
 				if (!modes.empty()) {
 					log(dpp::ll_debug, "Resuming voice session " + this->sessionid + "...");
 					json obj = {
@@ -362,6 +359,8 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 					};
 					this->write(obj.dump(-1, ' ', false, json::error_handler_t::replace), OP_TEXT);
 				} else {
+					/* Reset receive_sequence on HELLO */
+					receive_sequence = -1;
 					log(dpp::ll_debug, "Connecting new voice session (DAVE: " + std::string(dave_version == dave_version_1 ? "Enabled" : "Disabled") + ")...");
 					json obj = {
 						{ "op", voice_opcode_connection_identify },

--- a/src/dpp/voice/enabled/thread.cpp
+++ b/src/dpp/voice/enabled/thread.cpp
@@ -45,7 +45,8 @@ void discord_voice_client::on_disconnect() {
 
 	/* If we've looped 5 or more times, abort the loop. */
 	if (terminating || times_looped >= 5) {
-		log(dpp::ll_warning, "Reached max loops whilst attempting to read from the websocket. Aborting websocket.");
+		log(dpp::ll_warning, "Reached max loops whilst attempting to read from the websocket. Starting a full reconnection.");
+		owner->queue_work(1, reconnection_callback);
 		return;
 	}
 	last_loop_time = current_time;

--- a/src/dpp/voice/stub/stubs.cpp
+++ b/src/dpp/voice/stub/stubs.cpp
@@ -27,7 +27,7 @@
 
 namespace dpp {
 
-	discord_voice_client::discord_voice_client(dpp::cluster* _cluster, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave)
+	discord_voice_client::discord_voice_client(dpp::cluster* _cluster, full_reconnection_callback_t _reconnect_callback, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave)
 		: websocket_client(_cluster, _host.substr(0, _host.find(':')), _host.substr(_host.find(':') + 1, _host.length()), "/?v=" + std::to_string(voice_protocol_version), OP_TEXT)
 	{
 		throw dpp::voice_exception(err_no_voice_support, "Voice support not enabled in this build of D++");


### PR DESCRIPTION
```txt
As instructed in Discord documentation, if resuming did not succeed,
the bot should attempt to reconnect from scratch.
```

## Why do we need to reconnect from scratch?

It seems that a resume does not have to succeed after voice connection closes. See Discord documentation [Voice#Buffered Resume](https://discord.com/developers/docs/topics/voice-connections#buffered-resume)

> The resume may be unsuccessful if the voice gateway buffer for the session no longer contains a message that has been missed. In this case the session will be closed and you should then follow the [Connecting](https://discord.com/developers/docs/topics/voice-connections#connecting-to-voice) flow to reconnect.

## What changed?

In this change I made `discord_client` pass a callback into `voiceconn` for initiating the voice connection. `voiceconn` also passes a callback into its owning `discord_voice_client` to execute when resuming fails. This callback will make `voiceconn` reinitiate the voice connection through its `creator` (the `discord_client`). This works even after shard reconnects.

## Testing

I left the bot running in a voice channel for 2 days. Verified in the log that full voice reconnection, and shard reconnection were both triggered. Finally, I joined the voice channel myself and talked, the bot still receives my voice data.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
