### PR TITLE
feat: Added follow_up, co_follow_up functions and documentation improvements

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1650,7 +1650,7 @@ public:
 	void interaction_response_get_original(const std::string &token, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Create a followup message to a slash command
+	 * @brief Create a followup message for an interaction
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response
 	 * @param token Token for the interaction webhook
@@ -1661,7 +1661,7 @@ public:
 	void interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Edit original followup message to a slash command
+	 * @brief Edit original followup message for an interaction
 	 * This is an alias for cluster::interaction_response_edit
 	 * @see cluster::interaction_response_edit
 	 * 
@@ -1683,7 +1683,7 @@ public:
 	void interaction_followup_delete(const std::string &token, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Edit followup message to a slash command
+	 * @brief Edit followup message for an interaction
 	 * The message ID in the message you pass should be correctly set to that of a followup message you previously sent
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#edit-followup-message
@@ -1695,7 +1695,7 @@ public:
 	void interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Get the followup message to a slash command
+	 * @brief Get the followup message for an interaction
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#get-followup-message
 	 * @param token Token for the interaction webhook
@@ -1706,7 +1706,7 @@ public:
 	void interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback);
 	
 	/**
-	 * @brief Get the original followup message to a slash command
+	 * @brief Get the original followup message for an interaction
 	 * This is an alias for cluster::interaction_response_get_original
 	 * @see cluster::interaction_response_get_original
 	 * 

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -570,6 +570,22 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void reply(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
+	 * @brief Create a follow-up message for this interaction.
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * @param callback User function to execute when the api call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void follow_up(const message& m, command_completion_event_t callback = utility::log_error()) const;
+	
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 * @param mt The string value to send, for simple text only messages
+	 * @param callback User function to execute when the api call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void follow_up(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
+
+	/**
 	 * @brief Reply to interaction with a dialog box
 	 *
 	 * @param mr Dialog box response to send
@@ -680,6 +696,22 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& mt) const;
+
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 *
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(const message& m) const;
+
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 *
+	 * @param mt The string value to send, for simple text only messages
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(const std::string& mt) const;
 
 	/**
 	 * @brief Reply to interaction with a dialog box

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -216,6 +216,14 @@ void interaction_create_t::reply(const std::string& mt, command_completion_event
 	this->reply(ir_channel_message_with_source, dpp::message(this->command.channel_id, mt, mt_application_command), callback);
 }
 
+void interaction_create_t::follow_up(const message& m, command_completion_event_t callback) const {
+	owner->interaction_followup_create(this->command.token, m, std::move(callback));
+}
+
+void interaction_create_t::follow_up(const std::string& mt, command_completion_event_t callback) const {
+	owner->interaction_followup_create(this->command.token, dpp::message(this->command.channel_id, mt, mt_application_command), std::move(callback));
+}
+
 void interaction_create_t::edit_response(const message& m, command_completion_event_t callback) const {
 	owner->interaction_response_edit(this->command.token, m, std::move(callback));
 }
@@ -237,7 +245,7 @@ void interaction_create_t::edit_original_response(const message& m, command_comp
 	std::vector<std::string> file_contents{};
 	std::vector<std::string> file_mimetypes{};
 
-	for(message_file_data data : m.file_data) {
+	for(const message_file_data& data : m.file_data) {
 		file_names.push_back(data.name);
 		file_contents.push_back(data.content);
 		file_mimetypes.push_back(data.mimetype);
@@ -278,6 +286,14 @@ async<confirmation_callback_t> interaction_create_t::co_reply(const message& m) 
 
 async<confirmation_callback_t> interaction_create_t::co_reply(const std::string& mt) const {
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> interaction_create_t::co_follow_up(const message& m) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(m, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> interaction_create_t::co_follow_up(const std::string& mt) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_dialog(const interaction_modal_response& mr) const {


### PR DESCRIPTION
This PR introduces `follow_up` and `co_follow_up` functions on `dpp::interaction_create_t`. 

This change also includes two improvements found during implementation:
- **Documentation:** Corrected several doxygen comments in `dpp/cluster.h` that incorrectly referred to "slash commands" instead of the more general "interactions" for interaction-related functions, since follow ups naturally work for other interactions such as button interactions as well.
- **Performance:** The for-loop in `edit_original_response` now uses `const&` to avoid expensive copies of file data when editing a message with attachments.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
