### PR TITLE
refactor(async): Modernize coroutine helpers and add follow_up functions

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -606,6 +606,36 @@ public:
 	interaction_modal_response(const std::string& _custom_id, const std::string& _title, const std::vector<component> _components = {});
 
 	/**
+	 * @brief Copy constructor
+	 *
+	 * @param other The object to copy from
+	 */
+	interaction_modal_response(const interaction_modal_response& other) = default;
+
+	/**
+	 * @brief Copy assignment operator
+	 *
+	 * @param other The object to copy from
+	 * @return interaction_modal_response& reference to self
+	 */
+	interaction_modal_response& operator=(const interaction_modal_response& other) = default;
+
+	/**
+	 * @brief Move constructor
+	 *
+	 * @param other The object to move from
+	 */
+	interaction_modal_response(interaction_modal_response&& other) noexcept = default;
+
+	/**
+	 * @brief Move assignment operator
+	 *
+	 * @param other The object to move from
+	 * @return interaction_modal_response& reference to self
+	 */
+	interaction_modal_response& operator=(interaction_modal_response&& other) noexcept = default;
+
+	/**
 	 * @brief Set the custom id
 	 * 
 	 * @param _custom_id custom id to set

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1650,7 +1650,7 @@ public:
 	void interaction_response_get_original(const std::string &token, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Create a followup message to a slash command
+	 * @brief Create a followup message for an interaction
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response
 	 * @param token Token for the interaction webhook
@@ -1661,7 +1661,7 @@ public:
 	void interaction_followup_create(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Edit original followup message to a slash command
+	 * @brief Edit original followup message for an interaction
 	 * This is an alias for cluster::interaction_response_edit
 	 * @see cluster::interaction_response_edit
 	 * 
@@ -1683,7 +1683,7 @@ public:
 	void interaction_followup_delete(const std::string &token, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Edit followup message to a slash command
+	 * @brief Edit followup message for an interaction
 	 * The message ID in the message you pass should be correctly set to that of a followup message you previously sent
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#edit-followup-message
@@ -1695,7 +1695,7 @@ public:
 	void interaction_followup_edit(const std::string &token, const message &m, command_completion_event_t callback = utility::log_error());
 
 	/**
-	 * @brief Get the followup message to a slash command
+	 * @brief Get the followup message for an interaction
 	 *
 	 * @see https://discord.com/developers/docs/interactions/receiving-and-responding#get-followup-message
 	 * @param token Token for the interaction webhook
@@ -1706,7 +1706,7 @@ public:
 	void interaction_followup_get(const std::string &token, snowflake message_id, command_completion_event_t callback);
 	
 	/**
-	 * @brief Get the original followup message to a slash command
+	 * @brief Get the original followup message for an interaction
 	 * This is an alias for cluster::interaction_response_get_original
 	 * @see cluster::interaction_response_get_original
 	 * 

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -761,6 +761,14 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(const message& m) const;
 
 	/**
+	 * @brief Edit original response message for this interaction
+	 *
+	 * @param mt The string value to send, for simple text only messages
+	 * On success the result will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(const std::string& mt) const;
+
+	/**
 	 * @brief Delete original response message for this interaction. This cannot be used on an ephemeral interaction response.
 	 *
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -570,6 +570,22 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	void reply(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
 
 	/**
+	 * @brief Create a follow-up message for this interaction.
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * @param callback User function to execute when the api call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void follow_up(const message& m, command_completion_event_t callback = utility::log_error()) const;
+	
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 * @param mt The string value to send, for simple text only messages
+	 * @param callback User function to execute when the api call completes.
+	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void follow_up(const std::string& mt, command_completion_event_t callback = utility::log_error()) const;
+
+	/**
 	 * @brief Reply to interaction with a dialog box
 	 *
 	 * @param mr Dialog box response to send
@@ -680,6 +696,22 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& mt) const;
+
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 *
+	 * @param m Message object to send. Not all fields are supported by Discord.
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(const message& m) const;
+
+	/**
+	 * @brief Create a follow-up message for this interaction.
+	 *
+	 * @param mt The string value to send, for simple text only messages
+	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(const std::string& mt) const;
 
 	/**
 	 * @brief Reply to interaction with a dialog box

--- a/include/dpp/dispatcher.h
+++ b/include/dpp/dispatcher.h
@@ -668,7 +668,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param m Message object to send. Not all fields are supported by Discord.
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, const message& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, message m) const;
 
 	/**
 	 * @brief Send a reply for this interaction
@@ -677,7 +677,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, const std::string& mt) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(interaction_response_type t, std::string mt) const;
 
 	/**
 	 * @brief Send a reply for this interaction.
@@ -686,7 +686,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param m Message object to send. Not all fields are supported by Discord.
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(const message& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(message m) const;
 
 	/**
 	 * @brief Send a reply for this interaction.
@@ -695,7 +695,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& mt) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(std::string mt) const;
 
 	/**
 	 * @brief Create a follow-up message for this interaction.
@@ -703,7 +703,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param m Message object to send. Not all fields are supported by Discord.
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_follow_up(const message& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(message m) const;
 
 	/**
 	 * @brief Create a follow-up message for this interaction.
@@ -711,7 +711,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_follow_up(const std::string& mt) const;
+	dpp::async<dpp::confirmation_callback_t> co_follow_up(std::string mt) const;
 
 	/**
 	 * @brief Reply to interaction with a dialog box
@@ -719,7 +719,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mr Dialog box response to send
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_dialog(const interaction_modal_response& mr) const;
+	dpp::async<dpp::confirmation_callback_t> co_dialog(interaction_modal_response mr) const;
 
 	/**
 	 * @brief Edit the response for this interaction
@@ -727,7 +727,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param m Message object to send. Not all fields are supported by Discord.
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_edit_response(const message& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_edit_response(message m) const;
 
 	/**
 	 * @brief Edit the response for this interaction
@@ -735,7 +735,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_edit_response(const std::string& mt) const;
+	dpp::async<dpp::confirmation_callback_t> co_edit_response(std::string mt) const;
 
 	/**
 	 * @brief Set the bot to 'thinking' state where you have up to 15 minutes to respond
@@ -758,7 +758,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param m Message object to send. Not all fields are supported by Discord.
 	 * On success the result will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(const message& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(message m) const;
 
 	/**
 	 * @brief Edit original response message for this interaction
@@ -766,7 +766,7 @@ struct DPP_EXPORT interaction_create_t : public event_dispatch_t {
 	 * @param mt The string value to send, for simple text only messages
 	 * On success the result will contain a dpp::message object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(const std::string& mt) const;
+	dpp::async<dpp::confirmation_callback_t> co_edit_original_response(std::string mt) const;
 
 	/**
 	 * @brief Delete original response message for this interaction. This cannot be used on an ephemeral interaction response.
@@ -1797,7 +1797,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param m Text to send
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_send(const std::string& m) const;
+	dpp::async<dpp::confirmation_callback_t> co_send(std::string m) const;
 
 	/**
 	 * @brief Send a message to the same channel as the channel_id in received event.
@@ -1805,15 +1805,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param msg Message to send
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_send(const message& msg) const;
-
-	/**
-	 * @brief Send a message to the same channel as the channel_id in received event.
-	 * 
-	 * @param msg Message to send
-	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	dpp::async<dpp::confirmation_callback_t> co_send(message&& msg) const;
+	dpp::async<dpp::confirmation_callback_t> co_send(message msg) const;
 
 	/**
 	 * @brief Reply to the message received in the event.
@@ -1822,7 +1814,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(const std::string& m, bool mention_replied_user = false) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(std::string m, bool mention_replied_user = false) const;
 
 	/**
 	 * @brief Reply to the message received in the event.
@@ -1831,16 +1823,7 @@ struct DPP_EXPORT message_create_t : public event_dispatch_t {
 	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
 	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(const message& msg, bool mention_replied_user = false) const;
-
-	/**
-	 * @brief Reply to the message received in the event.
-	 * 
-	 * @param msg Message to send as a reply.
-	 * @param mention_replied_user mentions (pings) the author of message replied to, if true
-	 * On success the result will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
-	 */
-	dpp::async<dpp::confirmation_callback_t> co_reply(message&& msg, bool mention_replied_user = false) const;
+	dpp::async<dpp::confirmation_callback_t> co_reply(message msg, bool mention_replied_user = false) const;
 #endif /* DPP_NO_CORO */
 };
 

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -115,27 +115,27 @@ void message_create_t::reply(message&& msg, bool mention_replied_user, command_c
 
 #ifndef DPP_NO_CORO
 async<confirmation_callback_t> message_create_t::co_send(const std::string& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(m, std::forward<T>(cb)); }};
+	return dpp::async{[m, this] <typename T> (T&& cb) { this->send(m, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> message_create_t::co_send(const message& msg) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(msg, std::forward<T>(cb)); }};
+	return dpp::async{[msg, this] <typename T> (T&& cb) { this->send(msg, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> message_create_t::co_send(message&& msg) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->send(std::move(msg), std::forward<T>(cb)); }};
+	return dpp::async{[msg = std::move(msg), this] <typename T> (T&& cb) { this->send(std::move(msg), std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> message_create_t::co_reply(const std::string& m, bool mention_replied_user) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(m, mention_replied_user, std::forward<T>(cb)); }};
+	return dpp::async{[m, mention_replied_user, this] <typename T> (T&& cb) { this->reply(m, mention_replied_user, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> message_create_t::co_reply(const message& msg, bool mention_replied_user) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(msg, mention_replied_user, std::forward<T>(cb)); }};
+	return dpp::async{[msg, mention_replied_user, this] <typename T> (T&& cb) { this->reply(msg, mention_replied_user, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> message_create_t::co_reply(message&& msg, bool mention_replied_user) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(std::move(msg), mention_replied_user, std::forward<T>(cb)); }};
+	return dpp::async{[msg = std::move(msg), mention_replied_user, this] <typename T> (T&& cb) { this->reply(std::move(msg), mention_replied_user, std::forward<T>(cb)); }};
 }
 #endif /* DPP_NO_CORO */
 
@@ -273,55 +273,59 @@ async<confirmation_callback_t> interaction_create_t::co_reply() const {
 }
 
 async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, const message& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(t, m, std::forward<T>(cb)); }};
+	return dpp::async{[t, m, this] <typename T> (T&& cb) { this->reply(t, m, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, const std::string& mt) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(t, mt, std::forward<T>(cb)); }};
+	return dpp::async{[t, mt, this] <typename T> (T&& cb) { this->reply(t, mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_reply(const message& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(m, std::forward<T>(cb)); }};
+	return dpp::async{[m, this] <typename T> (T&& cb) { this->reply(m, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_reply(const std::string& mt) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
+	return dpp::async{[mt, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_follow_up(const message& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(m, std::forward<T>(cb)); }};
+	return dpp::async{[m, this] <typename T> (T&& cb) { this->follow_up(m, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_follow_up(const std::string& mt) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(mt, std::forward<T>(cb)); }};
+	return dpp::async{[mt, this] <typename T> (T&& cb) { this->follow_up(mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_dialog(const interaction_modal_response& mr) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->dialog(mr, std::forward<T>(cb)); }};
+	return dpp::async{[mr, this] <typename T> (T&& cb) { this->dialog(mr, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_edit_response(const message& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->edit_response(m, std::forward<T>(cb)); }};
+	return dpp::async{[m, this] <typename T> (T&& cb) { this->edit_response(m, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_edit_response(const std::string& mt) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->edit_response(mt, std::forward<T>(cb)); }};
+	return dpp::async{[mt, this] <typename T> (T&& cb) { this->edit_response(mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_thinking(bool ephemeral) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->thinking(ephemeral, std::forward<T>(cb)); }};
+	return dpp::async{[ephemeral, this] <typename T> (T&& cb) { this->thinking(ephemeral, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_get_original_response() const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->get_original_response(std::forward<T>(cb)); }};
+	return dpp::async{[this] <typename T> (T&& cb) { this->get_original_response(std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_edit_original_response(const message& m) const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->edit_original_response(m, std::forward<T>(cb)); }};
+	return dpp::async{[m, this] <typename T> (T&& cb) { this->edit_original_response(m, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> interaction_create_t::co_edit_original_response(const std::string& mt) const {
+	return dpp::async{[mt, this] <typename T> (T&& cb) { this->edit_original_response(dpp::message(this->command.channel_id, mt, mt_application_command), std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_delete_original_response() const {
-	return dpp::async{[&, this] <typename T> (T&& cb) { this->delete_original_response(std::forward<T>(cb)); }};
+	return dpp::async{[this] <typename T> (T&& cb) { this->delete_original_response(std::forward<T>(cb)); }};
 }
 #endif /* DPP_NO_CORO */
 

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -216,6 +216,14 @@ void interaction_create_t::reply(const std::string& mt, command_completion_event
 	this->reply(ir_channel_message_with_source, dpp::message(this->command.channel_id, mt, mt_application_command), callback);
 }
 
+void interaction_create_t::follow_up(const message& m, command_completion_event_t callback) const {
+	owner->interaction_followup_create(this->command.token, m, std::move(callback));
+}
+
+void interaction_create_t::follow_up(const std::string& mt, command_completion_event_t callback) const {
+	owner->interaction_followup_create(this->command.token, dpp::message(this->command.channel_id, mt, mt_application_command), std::move(callback));
+}
+
 void interaction_create_t::edit_response(const message& m, command_completion_event_t callback) const {
 	owner->interaction_response_edit(this->command.token, m, std::move(callback));
 }
@@ -237,7 +245,7 @@ void interaction_create_t::edit_original_response(const message& m, command_comp
 	std::vector<std::string> file_contents{};
 	std::vector<std::string> file_mimetypes{};
 
-	for(message_file_data data : m.file_data) {
+	for(const message_file_data& data : m.file_data) {
 		file_names.push_back(data.name);
 		file_contents.push_back(data.content);
 		file_mimetypes.push_back(data.mimetype);
@@ -278,6 +286,14 @@ async<confirmation_callback_t> interaction_create_t::co_reply(const message& m) 
 
 async<confirmation_callback_t> interaction_create_t::co_reply(const std::string& mt) const {
 	return dpp::async{[&, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> interaction_create_t::co_follow_up(const message& m) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(m, std::forward<T>(cb)); }};
+}
+
+async<confirmation_callback_t> interaction_create_t::co_follow_up(const std::string& mt) const {
+	return dpp::async{[&, this] <typename T> (T&& cb) { this->follow_up(mt, std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_dialog(const interaction_modal_response& mr) const {

--- a/src/dpp/dispatcher.cpp
+++ b/src/dpp/dispatcher.cpp
@@ -114,27 +114,19 @@ void message_create_t::reply(message&& msg, bool mention_replied_user, command_c
 }
 
 #ifndef DPP_NO_CORO
-async<confirmation_callback_t> message_create_t::co_send(const std::string& m) const {
-	return dpp::async{[m, this] <typename T> (T&& cb) { this->send(m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> message_create_t::co_send(std::string m) const {
+	return dpp::async{[m = std::move(m), this] <typename T> (T&& cb) { this->send(std::move(m), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> message_create_t::co_send(const message& msg) const {
-	return dpp::async{[msg, this] <typename T> (T&& cb) { this->send(msg, std::forward<T>(cb)); }};
-}
-
-async<confirmation_callback_t> message_create_t::co_send(message&& msg) const {
+async<confirmation_callback_t> message_create_t::co_send(message msg) const {
 	return dpp::async{[msg = std::move(msg), this] <typename T> (T&& cb) { this->send(std::move(msg), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> message_create_t::co_reply(const std::string& m, bool mention_replied_user) const {
-	return dpp::async{[m, mention_replied_user, this] <typename T> (T&& cb) { this->reply(m, mention_replied_user, std::forward<T>(cb)); }};
+async<confirmation_callback_t> message_create_t::co_reply(std::string m, bool mention_replied_user) const {
+	return dpp::async{[m = std::move(m), mention_replied_user, this] <typename T> (T&& cb) { this->reply(std::move(m), mention_replied_user, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> message_create_t::co_reply(const message& msg, bool mention_replied_user) const {
-	return dpp::async{[msg, mention_replied_user, this] <typename T> (T&& cb) { this->reply(msg, mention_replied_user, std::forward<T>(cb)); }};
-}
-
-async<confirmation_callback_t> message_create_t::co_reply(message&& msg, bool mention_replied_user) const {
+async<confirmation_callback_t> message_create_t::co_reply(message msg, bool mention_replied_user) const {
 	return dpp::async{[msg = std::move(msg), mention_replied_user, this] <typename T> (T&& cb) { this->reply(std::move(msg), mention_replied_user, std::forward<T>(cb)); }};
 }
 #endif /* DPP_NO_CORO */
@@ -272,40 +264,40 @@ async<confirmation_callback_t> interaction_create_t::co_reply() const {
 	return dpp::async{[this] <typename T> (T&& cb) { this->reply(std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, const message& m) const {
-	return dpp::async{[t, m, this] <typename T> (T&& cb) { this->reply(t, m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, message m) const {
+	return dpp::async{[t, m = std::move(m), this] <typename T> (T&& cb) { this->reply(t, std::move(m), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, const std::string& mt) const {
-	return dpp::async{[t, mt, this] <typename T> (T&& cb) { this->reply(t, mt, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_reply(interaction_response_type t, std::string mt) const {
+	return dpp::async{[t, mt = std::move(mt), this] <typename T> (T&& cb) { this->reply(t, std::move(mt), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(const message& m) const {
-	return dpp::async{[m, this] <typename T> (T&& cb) { this->reply(m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_reply(message m) const {
+	return dpp::async{[m = std::move(m), this] <typename T> (T&& cb) { this->reply(std::move(m), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_reply(const std::string& mt) const {
-	return dpp::async{[mt, this] <typename T> (T&& cb) { this->reply(mt, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_reply(std::string mt) const {
+	return dpp::async{[mt = std::move(mt), this] <typename T> (T&& cb) { this->reply(std::move(mt), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_follow_up(const message& m) const {
-	return dpp::async{[m, this] <typename T> (T&& cb) { this->follow_up(m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_follow_up(message m) const {
+	return dpp::async{[m = std::move(m), this] <typename T> (T&& cb) { this->follow_up(std::move(m), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_follow_up(const std::string& mt) const {
-	return dpp::async{[mt, this] <typename T> (T&& cb) { this->follow_up(mt, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_follow_up(std::string mt) const {
+	return dpp::async{[mt = std::move(mt), this] <typename T> (T&& cb) { this->follow_up(std::move(mt), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_dialog(const interaction_modal_response& mr) const {
-	return dpp::async{[mr, this] <typename T> (T&& cb) { this->dialog(mr, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_dialog(interaction_modal_response mr) const {
+	return dpp::async{[mr = std::move(mr), this] <typename T> (T&& cb) { this->dialog(mr, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_edit_response(const message& m) const {
-	return dpp::async{[m, this] <typename T> (T&& cb) { this->edit_response(m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_edit_response(message m) const {
+	return dpp::async{[m = std::move(m), this] <typename T> (T&& cb) { this->edit_response(std::move(m), std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_edit_response(const std::string& mt) const {
-	return dpp::async{[mt, this] <typename T> (T&& cb) { this->edit_response(mt, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_edit_response(std::string mt) const {
+	return dpp::async{[mt = std::move(mt), this] <typename T> (T&& cb) { this->edit_response(std::move(mt), std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_thinking(bool ephemeral) const {
@@ -316,12 +308,12 @@ async<confirmation_callback_t> interaction_create_t::co_get_original_response() 
 	return dpp::async{[this] <typename T> (T&& cb) { this->get_original_response(std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_edit_original_response(const message& m) const {
-	return dpp::async{[m, this] <typename T> (T&& cb) { this->edit_original_response(m, std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_edit_original_response(message m) const {
+	return dpp::async{[m = std::move(m), this] <typename T> (T&& cb) { this->edit_original_response(m, std::forward<T>(cb)); }};
 }
 
-async<confirmation_callback_t> interaction_create_t::co_edit_original_response(const std::string& mt) const {
-	return dpp::async{[mt, this] <typename T> (T&& cb) { this->edit_original_response(dpp::message(this->command.channel_id, mt, mt_application_command), std::forward<T>(cb)); }};
+async<confirmation_callback_t> interaction_create_t::co_edit_original_response(std::string mt) const {
+	return dpp::async{[mt = std::move(mt), this] <typename T> (T&& cb) { this->edit_original_response(dpp::message(this->command.channel_id, std::move(mt), mt_application_command), std::forward<T>(cb)); }};
 }
 
 async<confirmation_callback_t> interaction_create_t::co_delete_original_response() const {


### PR DESCRIPTION
## Summary
This is a refactoring and stability improvement for the coroutine helper functions on `message_create_t` and `interaction_create_t`.

Following a review discussion, all relevant `co_` helpers have been updated to use the modern "pass-by-value and move" C++ idiom. This change achieves two primary goals:
1. It fixes a critical dangling reference bug present in the original implementations that could lead to use-after-free errors and crashes.
2. It simplifies the API by replacing redundant `const&` and `&&` overloads with a single, more efficient signature.

To support this refactoring, `interaction_modal_response` was also made fully copyable and movable by implementing the Rule of 5.
> While the Rule of 0 would be preferred, this was not possible due to the class's explicitly declared virtual destructor.

This PR also introduces the `follow_up` function as originally intended and includes several other minor improvements discovered during implementation.
## Changes

- **Refactoring & Bug Fix:**
  - Refactored all `co_` helpers (`co_reply`, `co_send`, `co_edit_response`, etc.) to take parameters by value. This corrects a systemic dangling reference bug and modernizes the API.
  - Explicitly defaulted the Rule of 5 (copy/move constructors and assignment operators) for `interaction_modal_response` to make it a properly movable type, enabling its use with the new pass-by-value pattern.
- **New Feature:**
  - Added `follow_up` and `co_follow_up` functions to `interaction_create_t`.
- **Other Improvements:**
  - **API Consistency:** Added a `co_edit_original_response` overload that accepts a `std::string` for better consistency with similar functions.
  - **Performance:** The for-loop in `edit_original_response` now uses `const&` to avoid unnecessary copies of file data.
- **Documentation:** Corrected several doxygen comments that incorrectly referred to "slash commands" instead of the more general "interactions."

## Testing
All changes were thoroughly tested with a local bot, covering both lvalue (copy) and rvalue (move) call patterns for all refactored functions to ensure correctness and prevent regressions.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.