### PR TITLE
fix: get rid of poll macro

### DIFF
--- a/include/dpp/compat.h
+++ b/include/dpp/compat.h
@@ -1,0 +1,43 @@
+/************************************************************************************
+*
+* D++, A Lightweight C++ library for Discord
+*
+* Copyright 2021 Craig Edwards and D++ contributors
+* (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+************************************************************************************/
+#pragma once
+
+#ifdef _WIN32
+	#include <WinSock2.h>
+	#include <WS2tcpip.h>
+	#include <io.h>
+	namespace dpp::compat {
+		using pollfd = WSAPOLLFD;
+		inline int poll(pollfd* fds, ULONG nfds, int timeout) {
+			return WSAPoll(fds, nfds, timeout);
+		}
+	} // namespace dpp::compat
+	#pragma comment(lib, "ws2_32")
+#else
+	#include <poll.h>
+	#include <netinet/in.h>
+	#include <sys/socket.h>
+	#include <arpa/inet.h>
+	namespace dpp::compat {
+		using ::pollfd;
+		using ::poll;
+	} // namespace dpp::compat
+#endif

--- a/include/dpp/socket.h
+++ b/include/dpp/socket.h
@@ -22,17 +22,8 @@
 #pragma once
 
 #include <dpp/export.h>
-#ifdef _WIN32
-	#include <WinSock2.h>
-	#include <WS2tcpip.h>
-	#include <io.h>
-	#define poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-	#define pollfd WSAPOLLFD
-#else
-	#include <netinet/in.h>
-	#include <sys/socket.h>
-	#include <arpa/inet.h>
-#endif
+#include <dpp/compat.h>
+
 #include <string_view>
 #include <cstdint>
 

--- a/src/dpp/socketengines/poll.cpp
+++ b/src/dpp/socketengines/poll.cpp
@@ -20,29 +20,11 @@
  ************************************************************************************/
 
 #include <dpp/cluster.h>
+#include <dpp/compat.h>
 #include <dpp/socketengine.h>
 #include <dpp/exception.h>
 #include <vector>
 #include <shared_mutex>
-#ifdef _WIN32
-/* Windows-specific sockets includes */
-	#include <WinSock2.h>
-	#include <WS2tcpip.h>
-	#include <io.h>
-	/* Windows doesn't have standard poll(), it has WSAPoll.
-	 * It's the same thing with different symbol names.
-	 * Microsoft gotta be different.
-	 */
-	#define poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-	#define pollfd WSAPOLLFD
-	/* Windows sockets library */
-	#pragma comment(lib, "ws2_32")
-#else
-/* Anything other than Windows (e.g. sane OSes) */
-	#include <poll.h>
-	#include <sys/socket.h>
-	#include <unistd.h>
-#endif
 #include <memory>
 
 namespace dpp {
@@ -81,7 +63,7 @@ struct DPP_EXPORT socket_engine_poll : public socket_engine_base {
 			}
 		}
 
-		int i = poll(out_set, static_cast<unsigned int>(poll_set.size()), poll_delay);
+		int i = dpp::compat::poll(out_set, static_cast<unsigned int>(poll_set.size()), poll_delay);
 		int processed = 0;
 
 		for (size_t index = 0; index < poll_set.size() && processed < i; index++) {

--- a/src/dpp/voice/enabled/discover_ip.cpp
+++ b/src/dpp/voice/enabled/discover_ip.cpp
@@ -22,19 +22,8 @@
 
 #include <dpp/exception.h>
 #include <dpp/discordvoiceclient.h>
+#include <dpp/compat.h>
 #include "enabled.h"
-
-#ifdef _WIN32
-	#include <WinSock2.h>
-	#include <WS2tcpip.h>
-	#include <io.h>
-	#define poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-	#define pollfd WSAPOLLFD
-#else
-	#include <poll.h>
-	#include <netinet/in.h>
-	#include <sys/socket.h>
-#endif
 
 namespace dpp {
 
@@ -164,7 +153,7 @@ std::string discord_voice_client::discover_ip() {
 		pollfd pfd{};
 		pfd.fd = socket.fd;
 		pfd.events = POLLIN;
-		int ret = ::poll(&pfd, 1, discovery_timeout);
+		int ret = dpp::compat::poll(&pfd, 1, discovery_timeout);
 		switch (ret) {
 			case -1:
 				log(ll_warning, "poll() error on IP discovery");


### PR DESCRIPTION
I was working on personal project that included DPP and Asio, and DPP was defining `poll` that was clashing with asio's `asio::details::scheduler::poll` method, so I decided to remove it, I'm not sure how compat layers usually done in such project, so this is just my vision

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
