### PR TITLE
feat: add field attachment_size_limit to dpp::interaction

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -45,6 +45,14 @@ namespace dpp {
 #endif
 
 /**
+ * @brief Discords default attachment size limit is 10MiB, and will be used in case
+ * an interaction does not contain its attachment size limit.
+ */
+#ifndef DEFAULT_ATTACHMENT_SIZE_LIMIT
+	#define DEFAULT_ATTACHMENT_SIZE_LIMIT 10 * 1024 * 1024
+#endif
+
+/**
  * @brief Represents command option types.
  * These are the possible parameter value types.
  */
@@ -1092,6 +1100,11 @@ public:
 	 * @brief Guild's locale (language) - for guild interactions only.
 	 */
 	std::string guild_locale;
+
+	/**
+	 * @brief Attachment size limit in bytes for this interaction. Will be the discord default if not provided by the interaction.
+	 */
+	uint32_t attachment_size_limit;
 
 	/**
 	 * @brief Cache policy from cluster.

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -465,7 +465,7 @@ slashcommand& slashcommand::add_option(const command_option &o)
 	return *this;
 }
 
-interaction::interaction() : application_id(0), type(0), guild_id(0), channel_id(0), message_id(0), version(0), cache_policy(cache_policy::cpol_default) {
+interaction::interaction() : application_id(0), type(0), guild_id(0), channel_id(0), message_id(0), version(0), cache_policy(cache_policy::cpol_default), attachment_size_limit(DEFAULT_ATTACHMENT_SIZE_LIMIT) {
 }
 
 command_interaction interaction::get_command_interaction() const {
@@ -625,6 +625,11 @@ void from_json(const nlohmann::json& j, interaction& i) {
 	i.channel_id = snowflake_not_null(&j, "channel_id");
 	i.guild_id = snowflake_not_null(&j, "guild_id");
 	i.app_permissions = snowflake_not_null(&j, "app_permissions");
+	i.attachment_size_limit = int32_not_null(&j, "attachment_size_limit");
+
+	if (i.attachment_size_limit == 0) {
+		i.attachment_size_limit = DEFAULT_ATTACHMENT_SIZE_LIMIT;
+	}
 
 	if (j.contains("channel") && !j.at("channel").is_null()) {
 		const json& c = j["channel"];


### PR DESCRIPTION
Add the field attachment_size_limit to dpp::interaction, allowing all interactions to have the current response attachment size limit in bytes

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
