### PR TITLE
breaking: rewrote channel_get_pins, added Pin Message permission, updated pin endpoints.

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2380,6 +2380,17 @@ public:
 	void channel_pins_get(snowflake channel_id, command_completion_event_t callback);
 
 	/**
+	 * @brief Get a channel's pins
+	 * @see https://discord.com/developers/docs/resources/channel#get-pinned-messages
+	 * @param channel_id Channel ID to get pins for
+	 * @param before Get messages pinned before this timestamp.
+	 * @param limit Max number of pins to return (1-50). Defaults to 50 if not set.
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void channel_pins_get(snowflake channel_id, std::optional<time_t> before, std::optional<uint64_t> limit, command_completion_event_t callback);
+
+	/**
 	 * @brief Adds a recipient to a Group DM using their access token
 	 * @see https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
 	 * @param channel_id Channel id to add group DM recipients to

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -2375,7 +2375,7 @@ public:
 	 * @see https://discord.com/developers/docs/resources/channel#get-pinned-messages
 	 * @param channel_id Channel ID to get pins for
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::message_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::message_pin_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void channel_pins_get(snowflake channel_id, command_completion_event_t callback);
 
@@ -2386,7 +2386,7 @@ public:
 	 * @param before Get messages pinned before this timestamp.
 	 * @param limit Max number of pins to return (1-50). Defaults to 50 if not set.
 	 * @param callback Function to call when the API call completes.
-	 * On success the callback will contain a dpp::message_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 * On success the callback will contain a dpp::message_pin_map object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
 	void channel_pins_get(snowflake channel_id, std::optional<time_t> before, std::optional<uint64_t> limit, command_completion_event_t callback);
 

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2334,7 +2334,7 @@ template <typename T> struct message_snapshot {
 	std::vector<T> messages;
 };
 
-	/**
+/**
  * @brief Represents messages sent and received on Discord
  */
 struct DPP_EXPORT message : public managed, json_interface<message> {
@@ -2999,9 +2999,86 @@ public:
 };
 
 /**
+ * @brief Represents a discord webhook
+ */
+class DPP_EXPORT message_pin : public json_interface<message_pin> {
+protected:
+	friend struct json_interface<message_pin>;
+
+	/**
+	 * @brief Fill in object from json data
+	 *
+	 * @param j JSON data
+	 * @return message_pin& Reference to self
+	 */
+	message_pin& fill_from_json_impl(nlohmann::json* j);
+
+	/** Build JSON from this object.
+	 * @return The JSON text of the message
+	 */
+	virtual json to_json() const;
+
+public:
+
+	message_pin();
+
+	message_pin(time_t _pinned_at, const message& _pinned_message);
+
+	/*
+	 * @brief Construct a new message_pin object
+	 * @param msg_pin message_pin to copy
+	 */
+	message_pin(const message_pin& msg_pin) = default;
+
+	/*
+	 * @brief Construct a new message_pin object
+	 * @param msg_pin message_pin to move
+	 */
+	message_pin(message_pin&& msg_pin) = default;
+
+	/**
+	 * @brief Destroy the message_pin object
+	 */
+	~message_pin() = default;
+
+	/**
+	 * @brief Copy a message_pin object
+	 *
+	 * @param msg_pin message_pin to copy
+	 * @return message_pin& Reference to self
+	 */
+	message_pin &operator=(const message_pin& msg_pin) = default;
+
+	/**
+	 * @brief Move a message_pin object
+	 *
+	 * @param msg_pin message_pin to move
+	 * @return message_pin& Reference to self
+	 */
+	message_pin &operator=(message_pin&& msg_pin) = default;
+
+public:
+
+	/**
+	 * @brief The time the message was pinned.
+	 */
+	time_t pinned_at;
+
+	/**
+	 * @brief The pinned message.
+	 */
+	message pinned_message;
+};
+
+/**
  * @brief A group of messages
  */
 typedef std::unordered_map<snowflake, message> message_map;
+
+/**
+ * @brief A group of pinned messages
+ */
+typedef std::unordered_map<snowflake, message_pin> message_pin_map;
 
 /**
  * @brief A group of stickers

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -2999,7 +2999,7 @@ public:
 };
 
 /**
- * @brief Represents a discord webhook
+ * @brief Represents a pinned message.
  */
 class DPP_EXPORT message_pin : public json_interface<message_pin> {
 protected:
@@ -3014,7 +3014,7 @@ protected:
 	message_pin& fill_from_json_impl(nlohmann::json* j);
 
 	/** Build JSON from this object.
-	 * @return The JSON text of the message
+	 * @return The JSON text of the message_pin
 	 */
 	virtual json to_json() const;
 

--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -265,6 +265,11 @@ enum permissions : uint64_t {
 	 * @brief Allows use of Clyde AI.
 	 */
 	p_use_clyde_ai = 0x0000800000000000,
+
+	/**
+	 * @brief Allows pinning and unpinning messages
+	 */
+	p_pin_messages = 0x0008000000000000,
 };
 
 /**

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -135,6 +135,7 @@ typedef std::variant<
 		confirmation,
 		message,
 		message_map,
+		message_pin_map,
 		user,
 		user_identified,
 		user_map,

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -829,6 +829,15 @@ public:
 	bool has_use_clyde_ai() const;
 
 	/**
+	 * @brief True if has permission to use pin messages.
+	 *
+	 * @note Having the administrator permission causes this method to always return true
+	 * Channel specific overrides may apply to permissions.
+	 * @return bool True if user has the Pin Messages permission or is administrator.
+	 */
+	bool has_pin_messages() const;
+
+	/**
 	 * @brief Get guild members who have this role.
 	 *
 	 * @note This method requires user/members cache to be active

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -153,7 +153,7 @@ void cluster::message_get_reactions(snowflake message_id, snowflake channel_id, 
 
 
 void cluster::message_pin(snowflake channel_id, snowflake message_id, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "pins/" + std::to_string(message_id), m_put, "", callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "/messages/pins/" + std::to_string(message_id), m_put, "", std::move(callback));
 }
 
 void cluster::messages_get(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit, command_completion_event_t callback) {
@@ -168,7 +168,7 @@ void cluster::messages_get(snowflake channel_id, snowflake around, snowflake bef
 
 
 void cluster::message_unpin(snowflake channel_id, snowflake message_id, command_completion_event_t callback) {
-	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "pins/" + std::to_string(message_id), m_delete, "", callback);
+	rest_request<confirmation>(this, API_PATH "/channels", std::to_string(channel_id), "/messages/pins/" + std::to_string(message_id), m_delete, "", std::move(callback));
 }
 
 
@@ -205,7 +205,7 @@ void cluster::poll_end(snowflake message_id, snowflake channel_id, command_compl
 
 
 void cluster::channel_pins_get(snowflake channel_id, command_completion_event_t callback) {
-	rest_request_list<message>(this, API_PATH "/channels", std::to_string(channel_id), "pins", m_get, "", callback);
+	rest_request_list<message>(this, API_PATH "/channels", std::to_string(channel_id), "/messages/pins", m_get, "", std::move(callback));
 }
 
 }

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -211,8 +211,7 @@ void cluster::channel_pins_get(snowflake channel_id, command_completion_event_t 
 }
 
 void cluster::channel_pins_get(snowflake channel_id, std::optional<time_t> before, std::optional<uint64_t> limit, command_completion_event_t callback) {
-	if (!limit.has_value())
-	{
+	if (!limit.has_value()) {
 		limit = GET_CHANNEL_PINS_MAX;
 	}
 
@@ -238,6 +237,7 @@ void cluster::channel_pins_get(snowflake channel_id, std::optional<time_t> befor
 				list[pinned_msg.pinned_message.id] = pinned_msg;
 			}
 		}
+
 		if (callback) {
 			callback(confirmation_callback_t(this, list, http));
 		}

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1789,7 +1789,6 @@ message_pin::message_pin() : pinned_at(-1), pinned_message() {
 message_pin::message_pin(time_t _pinned_at, const message& _pinned_message) : pinned_at(_pinned_at), pinned_message(_pinned_message) {
 }
 
-
 message_pin& message_pin::fill_from_json_impl(nlohmann::json *j) {
 	this->pinned_at = ts_not_null(j, "pinned_at");
 	json& j_message = (*j)["message"];
@@ -1804,6 +1803,5 @@ json message_pin::to_json() const {
 	j["message"] = pinned_message.to_json();
 	return j;
 }
-
 
 }// namespace dpp

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1783,5 +1783,27 @@ sticker& sticker::set_file_content(std::string_view fc) {
 	return *this;
 }
 
-
+message_pin::message_pin() : pinned_at(-1), pinned_message() {
 }
+
+message_pin::message_pin(time_t _pinned_at, const message& _pinned_message) : pinned_at(_pinned_at), pinned_message(_pinned_message) {
+}
+
+
+message_pin& message_pin::fill_from_json_impl(nlohmann::json *j) {
+	this->pinned_at = ts_not_null(j, "pinned_at");
+	json& j_message = (*j)["message"];
+	this->pinned_message = message().fill_from_json(&j_message);
+
+	return *this;
+}
+
+json message_pin::to_json() const {
+	json j;
+	j["pinned_at"] = pinned_at;
+	j["message"] = pinned_message.to_json();
+	return j;
+}
+
+
+}// namespace dpp

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -341,6 +341,10 @@ bool role::has_use_clyde_ai() const {
 	return has_administrator() || permissions.has(p_use_clyde_ai);
 }
 
+bool role::has_pin_messages() const {
+	return has_administrator() || permissions.has(p_pin_messages);
+}
+
 role& role::set_name(const std::string& n) {
 	name = utility::validate(n, 1, 100, "Role name too short");
 	return *this;

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -2424,7 +2424,7 @@ Markdown lol \\|\\|spoiler\\|\\| \\~\\~strikethrough\\~\\~ \\`small \\*code\\* b
 			singleparam_api_test_list(channels_get, TEST_GUILD_ID, dpp::channel_map, GETCHANS);
 			singleparam_api_test_list(guild_get_invites, TEST_GUILD_ID, dpp::invite_map, GETINVS);
 			multiparam_api_test_list(guild_get_bans, TEST_GUILD_ID, dpp::ban_map, GETBANS);
-			singleparam_api_test_list(channel_pins_get, TEST_TEXT_CHANNEL_ID, dpp::message_map, GETPINS);
+			singleparam_api_test_list(channel_pins_get, TEST_TEXT_CHANNEL_ID, dpp::message_pin_map, GETPINS);
 			singleparam_api_test_list(guild_events_get, TEST_GUILD_ID, dpp::scheduled_event_map, GETEVENTS);
 			twoparam_api_test(guild_event_get, TEST_GUILD_ID, TEST_EVENT_ID, dpp::scheduled_event, GETEVENT);
 			twoparam_api_test_list(guild_event_users_get, TEST_GUILD_ID, TEST_EVENT_ID, dpp::event_member_map, GETEVENTUSERS);


### PR DESCRIPTION
This PR adds the new `PIN_MESSAGES` permission, and changes the get/set/unset pinned message endpoints to the new endpoints.

Because of the new endpoints, the `channel_get_pins` endpoint no longer returns the same data, meaning we now had to change this, causing a **breaking change** to make it conform to the new standard that Discord has set.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
