### PR TITLE
refactor: simplify run_once usage via default template parameter

### DIFF
--- a/include/dpp/once.h
+++ b/include/dpp/once.h
@@ -2,7 +2,7 @@
  *
  * D++, A Lightweight C++ library for Discord
  *
- * Copyright 2022 Craig Edwards and D++ contributors 
+ * Copyright 2022 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ namespace dpp {
  * Use this template like this:
  *
  * ```
- * if (dpp::run_once<struct any_unique_name_you_like_here>()) {
+ * if (dpp::run_once()) {
  *     // Your code here
  * }
  * ```
@@ -38,7 +38,7 @@ namespace dpp {
  * @tparam T any unique 'tag' identifier name
  * @return auto a true/false return to say if we should execute or not
  */
-template <typename T> auto run_once() {
+template <typename T = decltype([]{})> auto run_once() {
 	static auto called = false;
 	return !std::exchange(called, true);
 };


### PR DESCRIPTION
Defaulting `run_once`'s template parameter to `decltype([]{})` removes the need for its users to provide a unique type, since lambdas are guaranteed to have a unique type:

> [C++11: 5.1.2/3]: The type of the lambda-expression (which is also the type of the closure object) is a unique, unnamed non-union class type — called the closure type — whose properties are described below. This class type is not an aggregate (8.5.1). The closure type is declared in the smallest block scope, class scope, or namespace scope that contains the corresponding lambda-expression.

Example code:

```
#include "dpp/once.h"

#include <iostream>

int main() {
    for (int i = 0; i < 10; ++i) {
        if (dpp::run_once()) {
            std::cout << "This will print once\n";
        }
        if (dpp::run_once()) {
            std::cout << "This, too, will print once\n";
        }
    }
    return 0;
}
```

## Code change checklist

- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [X] I tested that my change works before raising the PR.
- [X] I have ensured that I did not break any existing API calls.
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
