### PR TITLE
Fix: channel_invites_get incorrect endpoint

### DIFF
--- a/src/dpp/cluster/channel.cpp
+++ b/src/dpp/cluster/channel.cpp
@@ -80,7 +80,7 @@ void cluster::channel_invite_create(const class channel &c, const class invite &
 }
 
 void cluster::channel_invites_get(const class channel &c, command_completion_event_t callback) {
-	rest_request_list<invite>(this, API_PATH "/channels", std::to_string(c.id), "", m_get, "", callback);
+	rest_request_list<invite>(this, API_PATH "/channels", std::to_string(c.id), "invites", m_get, "", callback);
 }
 
 void cluster::channel_typing(const class channel &c, command_completion_event_t callback) {


### PR DESCRIPTION
Sorry, I just pushed to the wrong branch.

fix ```cluster::channel_invites_get``` incorrect endpoint.

The third parameter (`minor`) is an empty str `""`, resulting in the incorrect API endpoint:
- **Actual:** `GET /api/v10/channels/{channel_id}`
- **Expected:** `GET /api/v10/channels/{channel_id}/invites`

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.