### PR TITLE
feat: DAVE is now default enabled.

### DIFF
--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -205,7 +205,6 @@ public:
 	 * @param guild_id Guild to connect to the voice channel on
 	 * @param channel_id voice channel id
 	 * @param enable_dave True to enable DAVE E2EE
-	 * @warn DAVE is an EXPERIMENTAL feature!
 	 */
 	voiceconn(class discord_client* o, voice_connection_gateway_request_callback_t request_callback, snowflake guild_id, snowflake channel_id, bool enable_dave);
 
@@ -608,13 +607,13 @@ public:
 	 * @param channel_id Channel ID of the voice channel
 	 * @param self_mute True if the bot should mute itself
 	 * @param self_deaf True if the bot should deafen itself
-	 * @param enable_dave True to enable DAVE E2EE - EXPERIMENTAL
+	 * @param enable_dave True to enable DAVE E2EE
 	 * @return reference to self
 	 * @note This is NOT a synchronous blocking call! The bot isn't instantly ready to send or listen for audio,
 	 * as we have to wait for the connection to the voice server to be established!
 	 * e.g. wait for dpp::cluster::on_voice_ready event, and then send the audio within that event.
 	 */
-	discord_client& connect_voice(snowflake guild_id, snowflake channel_id, bool self_mute = false, bool self_deaf = false, bool enable_dave = false);
+	discord_client& connect_voice(snowflake guild_id, snowflake channel_id, bool self_mute = false, bool self_deaf = false, bool enable_dave = true);
 
 	/**
 	 * @brief Disconnect from the connected voice channel on a guild

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -597,7 +597,6 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * @brief DAVE - Discord Audio Visual Encryption
 	 * Used for E2EE encryption. dave_protocol_none is
 	 * the default right now.
-	 * @warning DAVE E2EE is an EXPERIMENTAL feature!
 	 */
 	dave_version_t dave_version;
 
@@ -887,9 +886,8 @@ public:
 	 * @param _host The voice server hostname to connect to (hostname:port format)
 	 * @param enable_dave Enable DAVE E2EE
 	 * @throw dpp::voice_exception Opus failed to initialise, or D++ is not compiled with voice support
-	 * @warning DAVE E2EE is an EXPERIMENTAL feature!
 	 */
-	discord_voice_client(dpp::cluster* _cluster, full_reconnection_callback_t _reconnection_callback, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave = false);
+	discord_voice_client(dpp::cluster* _cluster, full_reconnection_callback_t _reconnection_callback, snowflake _channel_id, snowflake _server_id, const std::string &_token, const std::string &_session_id, const std::string &_host, bool enable_dave = true);
 
 	/**
 	 * @brief Destroy the discord voice client object

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -1291,13 +1291,12 @@ public:
 	 * @param self_mute True if the bot should mute itself
 	 * @param self_deaf True if the bot should deafen itself
 	 * @param dave True to enable DAVE E2EE
-	 * @warning DAVE is EXPERIMENTAL and subject to change.
 	 * @return True if the user specified is in a vc, false if they aren't
 	 * @note This is NOT a synchronous blocking call! The bot isn't instantly ready to send or listen for audio,
 	 * as we have to wait for the connection to the voice server to be established!
 	 * e.g. wait for dpp::cluster::on_voice_ready event, and then send the audio within that event.
 	 */
-	bool connect_member_voice(const cluster& owner, snowflake user_id, bool self_mute = false, bool self_deaf = false, bool dave = false);
+	bool connect_member_voice(const cluster& owner, snowflake user_id, bool self_mute = false, bool self_deaf = false, bool dave = true);
 
 	/**
 	 * @brief Get the banner url of the guild if it have one, otherwise returns an empty string

--- a/src/davetest/dave.cpp
+++ b/src/davetest/dave.cpp
@@ -80,8 +80,8 @@ int main() {
 	dave_test.on_guild_create([&](const dpp::guild_create_t & event) {
 		if (event.created.id == TEST_GUILD_ID) {
 			dpp::discord_client* s = event.from();
-			bool muted = false, deaf = false, enable_dave = true;
-			s->connect_voice(TEST_GUILD_ID, TEST_VC_ID, muted, deaf, enable_dave);
+			bool muted = false, deaf = false;
+			s->connect_voice(TEST_GUILD_ID, TEST_VC_ID, muted, deaf);
 		}
 	});
 	dave_test.start(dpp::st_wait);


### PR DESCRIPTION
This PR makes Dave now enabled by default as Discord now starts to remove old deprecated voice/video encryption modes.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
