### PR TITLE
feat: Current Member Edit now supports banner, avatar and bio

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -3509,11 +3509,16 @@ public:
 	 * @note This method supports audit log reasons set by the cluster::set_audit_reason() method.
 	 * @see https://discord.com/developers/docs/resources/guild#modify-current-member
 	 * @param guild_id Guild ID to change on
-	 * @param nickname New nickname, or empty string to clear nickname
+	 * @param nickname New nickname, or empty string to clear nickname.
+	 * @param banner_blob New banner, or empty string to clear banner.
+	 * @param banner_type Type of image for new banner.
+	 * @param avatar_blob New avatar, or empty string to clear avatar.
+	 * @param avatar_type Type of image for new avatar.
+	 * @param bio New bio, or empty string to clear bio
 	 * @param callback Function to call when the API call completes.
 	 * On success the callback will contain a dpp::confirmation object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
 	 */
-	void guild_current_member_edit(snowflake guild_id, const std::string &nickname, command_completion_event_t callback = utility::log_error());
+	void guild_current_member_edit(snowflake guild_id, const std::string& nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio, command_completion_event_t callback = utility::log_error());
 
 	/**
 	 * @brief Get current user's connections (linked accounts, e.g. steam, xbox).

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -835,11 +835,16 @@
  * @see dpp::cluster::guild_current_member_edit
  * @see https://discord.com/developers/docs/resources/guild#modify-current-member
  * @param guild_id Guild ID to change on
- * @param nickname New nickname, or empty string to clear nickname
+ * @param nickname New nickname, or empty string to clear nickname.
+ * @param banner_blob New banner, or empty string to clear banner.
+ * @param banner_type Type of image for new banner.
+ * @param avatar_blob New avatar, or empty string to clear avatar.
+ * @param avatar_type Type of image for new avatar.
+ * @param bio New bio, or empty string to clear bio
  * @return confirmation returned object on completion
  * \memberof dpp::cluster
  */
-[[nodiscard]] async<confirmation_callback_t> co_guild_current_member_edit(snowflake guild_id, const std::string &nickname);
+[[nodiscard]] async<confirmation_callback_t> co_guild_current_member_edit(snowflake guild_id, const std::string& nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio);
 
 /**
  * @brief Get the audit log for a guild

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -43,7 +43,7 @@ void cluster::guild_current_member_edit(snowflake guild_id, const std::string &n
 	if (banner_blob.empty()) {
 		j["banner"] = json::value_t::null;
 	} else {
-		if(banner_blob.size() > MAX_AVATAR_SIZE) {
+		if (banner_blob.size() > MAX_AVATAR_SIZE) {
 			throw dpp::length_exception(err_icon_size, "Banner file exceeds discord limit of 10240 kilobytes");
 		}
 		j["banner"] = "data:" + mimetypes.find(banner_type)->second + ";base64," + base64_encode((unsigned char const*)banner_blob.data(), static_cast<unsigned int>(banner_blob.length()));
@@ -52,7 +52,7 @@ void cluster::guild_current_member_edit(snowflake guild_id, const std::string &n
 	if (avatar_blob.empty()) {
 		j["avatar"] = json::value_t::null;
 	} else {
-		if(avatar_blob.size() > MAX_AVATAR_SIZE) { // Avatar limit is 10240 kb.
+		if (avatar_blob.size() > MAX_AVATAR_SIZE) { // Avatar limit is 10240 kb.
 			throw dpp::length_exception(err_icon_size, "Avatar file exceeds discord limit of 10240 kilobytes");
 		}
 		j["avatar"] = "data:" + mimetypes.find(avatar_type)->second + ";base64," + base64_encode((unsigned char const*)avatar_blob.data(), static_cast<unsigned int>(avatar_blob.length()));
@@ -65,7 +65,7 @@ void cluster::guild_current_member_edit(snowflake guild_id, const std::string &n
 	}
 
 	const std::string post_data = j.dump(-1, ' ', false, json::error_handler_t::replace);
-	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, post_data, std::move(callback));
+	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, std::move(post_data), std::move(callback));
 }
 
 

--- a/src/dpp/cluster/guild.cpp
+++ b/src/dpp/cluster/guild.cpp
@@ -23,7 +23,7 @@
 
 namespace dpp {
 
-void cluster::guild_current_member_edit(snowflake guild_id, const std::string &nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio, command_completion_event_t callback) {
+void cluster::guild_current_member_edit(snowflake guild_id, const std::string& nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio, command_completion_event_t callback) {
 	json j = json::object();
 
 	// Cannot use ternary operator, json null isn't compatible with std::string.
@@ -64,7 +64,7 @@ void cluster::guild_current_member_edit(snowflake guild_id, const std::string &n
 		j["bio"] = bio;
 	}
 
-	const std::string post_data = j.dump(-1, ' ', false, json::error_handler_t::replace);
+	std::string post_data = j.dump(-1, ' ', false, json::error_handler_t::replace);
 	rest_request<confirmation>(this, API_PATH "/guilds", std::to_string(guild_id), "members/@me", m_patch, std::move(post_data), std::move(callback));
 }
 

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -303,8 +303,8 @@ async<confirmation_callback_t> cluster::co_get_gateway_bot() {
 	return async{ this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::get_gateway_bot) };
 }
 
-async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string &nickname) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname };
+async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string &nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string&, const image_type, const std::string&, const image_type, const std::string&, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname, banner_blob, banner_type, avatar_blob, avatar_type, bio };
 }
 
 async<confirmation_callback_t> cluster::co_guild_auditlog_get(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit) {

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -303,7 +303,7 @@ async<confirmation_callback_t> cluster::co_get_gateway_bot() {
 	return async{ this, static_cast<void (cluster::*)(command_completion_event_t)>(&cluster::get_gateway_bot) };
 }
 
-async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string &nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio) {
+async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string& nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string&, const image_type, const std::string&, const image_type, const std::string&, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname, banner_blob, banner_type, avatar_blob, avatar_type, bio };
 }
 


### PR DESCRIPTION
This PR allows bots to edit their banner, avatar and bio, per guild.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
