### PR TITLE
fix: coro autogen now works again

### DIFF
--- a/buildtools/make_struct.php
+++ b/buildtools/make_struct.php
@@ -44,8 +44,8 @@ $forcedReturn = [
     'threads_get_public_archived' => 'thread_map',
     'threads_get_active' => 'active_threads',
     'user_get_cached' => 'user_identified',
-    'application_role_connection_get' => 'application_role_connection',
-    'application_role_connection_update' => 'application_role_connection'
+    'channel_pins_get' => 'message_pin_map',
+    'application_role_connection_get' => 'application_role_connection'
 ];
 
 /* Get the contents of cluster.h into an array */
@@ -90,6 +90,9 @@ foreach ($clustercpp as $cpp) {
         } elseif (preg_match('/rest_request_list<([^>]+)>/', $cpp, $matches)) {
             /* rest_request_list<T> */
             $returnType = $matches[1] . '_map';
+        } elseif (preg_match('/rest_request_vector<([^>]+)>/', $cpp, $matches)) {
+            /* rest_request_vector<T> */
+            $returnType = $matches[1] . '_list';
         } elseif (preg_match('/callback\(confirmation_callback_t\(\w+, ([^(]+)\(.*, \w+\)\)/', $cpp, $matches)) {
             /* confirmation_callback_t */
             $returnType = $matches[1];

--- a/buildtools/make_struct.php
+++ b/buildtools/make_struct.php
@@ -44,8 +44,7 @@ $forcedReturn = [
     'threads_get_public_archived' => 'thread_map',
     'threads_get_active' => 'active_threads',
     'user_get_cached' => 'user_identified',
-    'channel_pins_get' => 'message_pin_map',
-    'application_role_connection_get' => 'application_role_connection'
+    'channel_pins_get' => 'message_pin_map'
 ];
 
 /* Get the contents of cluster.h into an array */

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -280,7 +280,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_interaction_response_get_original(const std::string &token);
 
 /**
- * @brief Create a followup message to a slash command
+ * @brief Create a followup message for an interaction
  *
  * @see dpp::cluster::interaction_followup_create
  * @see https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response
@@ -292,7 +292,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_interaction_followup_create(const std::string &token, const message &m);
 
 /**
- * @brief Edit original followup message to a slash command
+ * @brief Edit original followup message for an interaction
  * This is an alias for cluster::interaction_response_edit
  * @see dpp::cluster::interaction_followup_edit_original
  * @see cluster::interaction_response_edit
@@ -316,7 +316,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_interaction_followup_delete(const std::string &token);
 
 /**
- * @brief Edit followup message to a slash command
+ * @brief Edit followup message for an interaction
  * The message ID in the message you pass should be correctly set to that of a followup message you previously sent
  *
  * @see dpp::cluster::interaction_followup_edit
@@ -329,7 +329,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_interaction_followup_edit(const std::string &token, const message &m);
 
 /**
- * @brief Get the followup message to a slash command
+ * @brief Get the followup message for an interaction
  *
  * @see dpp::cluster::interaction_followup_get
  * @see https://discord.com/developers/docs/interactions/receiving-and-responding#get-followup-message
@@ -341,7 +341,7 @@
 [[nodiscard]] async<confirmation_callback_t> co_interaction_followup_get(const std::string &token, snowflake message_id);
 
 /**
- * @brief Get the original followup message to a slash command
+ * @brief Get the original followup message for an interaction
  * This is an alias for cluster::interaction_response_get_original
  * @see dpp::cluster::interaction_followup_get_original
  * @see cluster::interaction_response_get_original
@@ -1743,10 +1743,22 @@
  * @see dpp::cluster::channel_pins_get
  * @see https://discord.com/developers/docs/resources/channel#get-pinned-messages
  * @param channel_id Channel ID to get pins for
- * @return message_map returned object on completion
+ * @return message_pin_map returned object on completion
  * \memberof dpp::cluster
  */
 [[nodiscard]] async<confirmation_callback_t> co_channel_pins_get(snowflake channel_id);
+
+/**
+ * @brief Get a channel's pins
+ * @see dpp::cluster::channel_pins_get
+ * @see https://discord.com/developers/docs/resources/channel#get-pinned-messages
+ * @param channel_id Channel ID to get pins for
+ * @param before Get messages pinned before this timestamp.
+ * @param limit Max number of pins to return (1-50). Defaults to 50 if not set.
+ * @return message_pin_map returned object on completion
+ * \memberof dpp::cluster
+ */
+[[nodiscard]] async<confirmation_callback_t> co_channel_pins_get(snowflake channel_id, std::optional<time_t> before, std::optional<uint64_t> limit);
 
 /**
  * @brief Create a role on a guild
@@ -1825,7 +1837,7 @@
  * @see dpp::cluster::application_role_connection_get
  * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records
  * @param application_id The application ID
- * @return application_role_connection returned object on completion
+ * @return application_role_connection_metadata_list returned object on completion
  * \memberof dpp::cluster
  */
 [[nodiscard]] async<confirmation_callback_t> co_application_role_connection_get(snowflake application_id);
@@ -1837,7 +1849,7 @@
  * @see https://discord.com/developers/docs/resources/application-role-connection-metadata#update-application-role-connection-metadata-records
  * @param application_id The application ID
  * @param connection_metadata The application role connection metadata to update
- * @return application_role_connection returned object on completion
+ * @return application_role_connection_metadata_list returned object on completion
  * @note An application can have a maximum of 5 metadata records.
  * \memberof dpp::cluster
  */

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -575,6 +575,10 @@ async<confirmation_callback_t> cluster::co_channel_pins_get(snowflake channel_id
 	return async{ this, static_cast<void (cluster::*)(snowflake, command_completion_event_t)>(&cluster::channel_pins_get), channel_id };
 }
 
+async<confirmation_callback_t> cluster::co_channel_pins_get(snowflake channel_id, std::optional<time_t> before, std::optional<uint64_t> limit) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, std::optional<time_t>, std::optional<uint64_t>, command_completion_event_t)>(&cluster::channel_pins_get), channel_id, before, limit };
+}
+
 async<confirmation_callback_t> cluster::co_role_create(const class role &r) {
 	return async{ this, static_cast<void (cluster::*)(const class role &, command_completion_event_t)>(&cluster::role_create), r };
 }


### PR DESCRIPTION
This PR fixes the coro autogen breaking since the change to `cluster_pins_get`. It also removes the bypass for `application_role_connection_get` and `application_role_connection_update` so it correctly passes through the list param, along with now automatically parsing `rest_request_vector`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
