### PR TITLE
fix: dpp::cluster::register_command with coroutine handler on windows

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -638,12 +638,6 @@ cluster& cluster::set_request_timeout(uint16_t timeout) {
 	return *this;
 }
 
-bool cluster::register_command(const std::string &name, const slashcommand_handler_t handler) {
-	std::unique_lock lk(named_commands_mutex);
-	auto [_, inserted] = named_commands.try_emplace(name, handler);
-	return inserted;
-}
-
 bool cluster::unregister_command(const std::string &name) {
 	std::unique_lock lk(named_commands_mutex);
 	return named_commands.erase(name) == 1;


### PR DESCRIPTION
register_command with dpp::task was not working for me on windows with msvc, this fixes that, and it makes sure to keep register_command working for non coroutines.

I have not tested the changes on anything other than windows, therefore I'm unsure if im sacraficing other platforms.

~~Also I'm not sure if this is the ideal fix, however it does also let clangd correctly determine the function in use when ctrl+click'ing the register_command, as previously it would just use the non-coro one for all usages of register_command for me. (It is inspired by how dpp::cluster::start_timer works, which works correctly for me)~~

As of the latest commit it now only allows void or dpp::task<void> function return signatures as well.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
