### PR TITLE
fix: fix segfault in dpp::task on g++ starting with 15.2 (gcc-mirror/gcc@a169a4718b5b621f1770789e55eb8c441f7d0fcd specifically)

### DIFF
--- a/include/dpp/coro/task.h
+++ b/include/dpp/coro/task.h
@@ -282,8 +282,8 @@ struct promise_base : basic_promise<R> {
 
 		/** @brief Wrapper for the awaitable's await_suspend */
 		template <typename T>
-		[[nodiscard]] decltype(auto) await_suspend(T&& handle) noexcept(noexcept(awaitable.await_suspend(std::forward<T>(handle)))) {
-			return awaitable.await_suspend(std::forward<T>(handle));
+		[[nodiscard]] decltype(auto) await_suspend(T handle) noexcept(noexcept(awaitable.await_suspend(std::move(handle)))) {
+			return awaitable.await_suspend(std::move(handle));
 		}
 
 		/**


### PR DESCRIPTION
yee

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
