### PR TITLE
Replacing the const uint32_t color values with static constexpr uint3…

### DIFF
--- a/include/dpp/colors.h
+++ b/include/dpp/colors.h
@@ -31,7 +31,7 @@ namespace dpp {
  * @brief predefined color constants.
  */
 namespace colors {
-	const uint32_t
+	static constexpr uint32_t
 		white = 0xFFFFFF,
 		discord_white = 0xFFFFFE,
 		light_gray = 0xC0C0C0,


### PR DESCRIPTION
## Summary
Converts all color constants in the colors namespace to `constexpr`, enabling compile-time evaluation and optimization.

## Changes
- Added `constexpr` to all color constant declarations
- No functional changes - purely optimization

## Benefits
- **Compile-time evaluation**: Colors used in constant expressions can now be computed at compile time
- **Dead code elimination**: Unused color constants can be completely eliminated by the compiler
- **Better inlining**: `constexpr` enables more aggressive compiler optimizations
- **Zero runtime cost**: No performance impact, only improvements
## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
