### PR TITLE
Wait for http request completion

### DIFF
--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -107,7 +107,11 @@ http_request::http_request(const std::string &_url, http_completion_event comple
 {
 }
 
-http_request::~http_request()  = default;
+http_request::~http_request() {
+	while (!completed) {
+		std::this_thread::sleep_for(10ms);
+	}
+}
 
 void http_request::complete(const http_request_completion_t &c) {
 	if (complete_handler) {


### PR DESCRIPTION
Hello !

It's related to the memory issue I reported on discord. The root cause is that a http_request ptr is stored in several lambda but the lifecycle of the lambda is bigger than the life of http_request

This one is fine `[processor, rv, hci, this, owner, start, _url](https_client* client) {`
This one isn't `owner->queue_work(0, [owner, this, result, hci, _url]() {`

In the second lambda and depending on when you shutdown dpp (if you do it very early, before shards are started), you will delete this http_request before the lambda finish and then it's undefined behaviour as you kept a this ptr. I tried to make a shared_ptr implementation to fix that but it's leaking memory like crazy (like before the fix that created this crash https://github.com/brainboxdotcc/DPP/commit/0d5e9325a06a14ef8cde5b1e7440e2eeb46aab18). I then tested this wait for completion and it works. I added custom logs to confirm that the wait saved me from crashing

> http_request::outer lambda start :dpp::http_request@0x19770c20af0: completed=false
> http_request::outer lambda stop :dpp::http_request@0x19770c20af0: completed=false
> http_request::inner lambda start :dpp::http_request@0x19770c20af0: completed=false
> http_request::inner lambda stop :dpp::http_request@0x19770c20af0: completed=true
> http_request::outer lambda start :dpp::http_request@0x19770bde310: completed=false
> http_request::outer lambda stop :dpp::http_request@0x19770bde310: completed=false`
> http_request::inner lambda start :dpp::http_request@0x19770bde310: completed=false
> [Sun Dec 14 16:04:05 2025] DEBUG: Cluster: 998 of 1000 session starts remaining
> [Sun Dec 14 16:04:05 2025] INFO: Auto Shard: Bot requires 1 shard
> [Sun Dec 14 16:04:05 2025] DEBUG: Starting with 1 shards...
> [Sun Dec 14 16:04:05 2025] DEBUG: Connecting new session...
> [Sun Dec 14 16:04:05 2025] INFO: Shard id 0 (1/1) ready!
> [Sun Dec 14 16:04:05 2025] DEBUG: Resume URL for session cccfaf4f25ad5336dfdbbc1c9c8ad29d is wss://gateway-us-east1-d.discord.gg (host: gateway-us-east1-d.discord.gg)
> http_request::~http_request begin this:dpp::http_request@0x19770c20af0: completed=true
> http_request::~http_request end this:dpp::http_request@0x19770c20af0: completed=true
> http_request::~http_request begin this:dpp::http_request@0x19770bde310: completed=false
> [Sun Dec 14 16:04:10 2025] DEBUG: Shards started.
> http_request::inner lambda stop :dpp::http_request@0x19770bde310: completed=true
> http_request::~http_request end this:dpp::http_request@0x19770bde310: completed=true



## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
