### PR TITLE
Wait for http request completion with condition variable

### DIFF
--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <functional>
 #include <atomic>
+#include <condition_variable>		
 #include <dpp/httpsclient.h>
 
 namespace dpp {
@@ -239,6 +240,22 @@ class DPP_EXPORT http_request {
 	 * @brief HTTPS client
 	 */
 	std::unique_ptr<https_client> cli;
+
+	/**
+	 * @brief Mutex for this_captured_signal and this_captured
+	 */
+	std::mutex this_captured_mutex;
+
+	/**
+	 * @brief Condition variable to signal this is no longer captured by an ongoing lambda
+	 */
+	std::condition_variable this_captured_signal;
+
+
+	/**
+	 * @brief True if this is currently captured in a lambda and cannot be deleted
+	 */
+	bool this_captured{false};
 
 public:
 	/**

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -107,7 +107,10 @@ http_request::http_request(const std::string &_url, http_completion_event comple
 {
 }
 
-http_request::~http_request()  = default;
+http_request::~http_request() {
+	std::unique_lock<std::mutex> lock(this_captured_mutex);
+	this_captured_signal.wait(lock, [this] { return !this_captured; });
+}
 
 void http_request::complete(const http_request_completion_t &c) {
 	if (complete_handler) {
@@ -260,6 +263,10 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 				processor->buckets[this->endpoint] = newbucket;
 
 				/* Transfer it to completed requests */
+				{
+					std::lock_guard<std::mutex> lock(this_captured_mutex);
+					this_captured = true;
+				}
 				owner->queue_work(0, [owner, this, result, hci, _url]() {
 					try {
 						complete(result);
@@ -270,7 +277,11 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 					catch (...) {
 						owner->log(ll_error, "Uncaught exception thrown in HTTPS callback for " + std::string(request_verb[method]) + " "  + hci.hostname + ":" + std::to_string(hci.port) + _url + ": <non exception value>");
 					}
-					completed = true;
+					{
+						std::lock_guard<std::mutex> lock(this_captured_mutex);
+						this_captured = false;
+					}
+					this_captured_signal.notify_all();
 				});
 			}
 		);

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -277,6 +277,7 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 					catch (...) {
 						owner->log(ll_error, "Uncaught exception thrown in HTTPS callback for " + std::string(request_verb[method]) + " "  + hci.hostname + ":" + std::to_string(hci.port) + _url + ": <non exception value>");
 					}
+					completed = true;
 					{
 						std::lock_guard<std::mutex> lock(this_captured_mutex);
 						this_captured = false;


### PR DESCRIPTION
Hello !

It's related to the memory issue I reported on discord. The root cause is that a http_request ptr is stored in a lambda but the lifecycle of the lambda is bigger than the life of http_request

`owner->queue_work(0, [owner, this, result, hci, _url]() {`

Depending on when you shutdown dpp (if you do it very early, before shards are started), you will delete this http_request before the lambda end and then it's undefined behaviour as you kept a this ptr. I tried to make a shared_ptr implementation to fix that but it's leaking memory like crazy (like before the fix that created this crash https://github.com/brainboxdotcc/DPP/commit/0d5e9325a06a14ef8cde5b1e7440e2eeb46aab18). I then tested this wait for completion and it works. I added custom logs to confirm that the wait saved me from crashing

> http_request::outer lambda start :dpp::http_request@0x19770c20af0: completed=false
> http_request::outer lambda stop :dpp::http_request@0x19770c20af0: completed=false
> http_request::inner lambda start :dpp::http_request@0x19770c20af0: completed=false
> http_request::inner lambda stop :dpp::http_request@0x19770c20af0: completed=true
> http_request::outer lambda start :dpp::http_request@0x19770bde310: completed=false
> http_request::outer lambda stop :dpp::http_request@0x19770bde310: completed=false`
> http_request::inner lambda start :dpp::http_request@0x19770bde310: completed=false
> [Sun Dec 14 16:04:05 2025] DEBUG: Cluster: 998 of 1000 session starts remaining
> [Sun Dec 14 16:04:05 2025] INFO: Auto Shard: Bot requires 1 shard
> [Sun Dec 14 16:04:05 2025] DEBUG: Starting with 1 shards...
> [Sun Dec 14 16:04:05 2025] DEBUG: Connecting new session...
> [Sun Dec 14 16:04:05 2025] INFO: Shard id 0 (1/1) ready!
> [Sun Dec 14 16:04:05 2025] DEBUG: Resume URL for session cccfaf4f25ad5336dfdbbc1c9c8ad29d is wss://gateway-us-east1-d.discord.gg (host: gateway-us-east1-d.discord.gg)
> http_request::~http_request begin this:dpp::http_request@0x19770c20af0: completed=true
> http_request::~http_request end this:dpp::http_request@0x19770c20af0: completed=true
> http_request::~http_request begin this:dpp::http_request@0x19770bde310: completed=false
> [Sun Dec 14 16:04:10 2025] DEBUG: Shards started.
> http_request::inner lambda stop :dpp::http_request@0x19770bde310: completed=true
> http_request::~http_request end this:dpp::http_request@0x19770bde310: completed=true

I fixed the CI but 2 jobs are still timeouting on my side due to no available runner it seems

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
