### PR TITLE
fix: poll vote events and add missing poll intents

### DIFF
--- a/include/dpp/intents.h
+++ b/include/dpp/intents.h
@@ -127,6 +127,16 @@ enum intents {
 	i_auto_moderation_execution	= (1 << 21),
 
 	/**
+	 * @brief Intent for receipt of guild message poll votes.
+	 */
+	i_guild_message_polls		= (1 << 24),
+
+	/**
+	 * @brief Intent for receipt of direct message poll votes.
+	 */
+	i_direct_message_polls		= (1 << 25),
+
+	/**
 	 * @brief Default D++ intents (all non-privileged intents).
 	 */
 	i_default_intents		= dpp::i_guilds | dpp::i_guild_bans | dpp::i_guild_emojis | dpp::i_guild_integrations |
@@ -134,7 +144,7 @@ enum intents {
 					dpp::i_guild_messages | dpp::i_guild_message_reactions | dpp::i_guild_message_typing |
 					dpp::i_direct_messages | dpp::i_direct_message_typing | dpp::i_direct_message_reactions |
 					dpp::i_guild_scheduled_events | dpp::i_auto_moderation_configuration |
-					dpp::i_auto_moderation_execution,
+					dpp::i_auto_moderation_execution | dpp::i_guild_message_polls | dpp::i_direct_message_polls,
 
 	/**
 	 * @brief Privileged intents requiring ID.

--- a/src/dpp/events/message_poll_vote_add.cpp
+++ b/src/dpp/events/message_poll_vote_add.cpp
@@ -39,13 +39,13 @@ namespace dpp::events {
 void message_poll_vote_add::handle(discord_client* client, json &j, const std::string &raw) {
 
 	if (!client->creator->on_message_poll_vote_add.empty()) {
-		json d = j["d"];
+		json& d = j["d"];
 		dpp::message_poll_vote_add_t vote(client->owner, client->shard_id, raw);
-		vote.user_id = snowflake_not_null(&j, "user_id");
-		vote.message_id = snowflake_not_null(&j, "message_id");
-		vote.channel_id = snowflake_not_null(&j, "channel_id");
-		vote.guild_id = snowflake_not_null(&j, "guild_id");
-		vote.answer_id = int32_not_null(&j, "answer_id");
+		vote.user_id = snowflake_not_null(&d, "user_id");
+		vote.message_id = snowflake_not_null(&d, "message_id");
+		vote.channel_id = snowflake_not_null(&d, "channel_id");
+		vote.guild_id = snowflake_not_null(&d, "guild_id");
+		vote.answer_id = int32_not_null(&d, "answer_id");
 		client->creator->queue_work(1, [c = client->creator, vote]() {
 			c->on_message_poll_vote_add.call(vote);
 		});

--- a/src/dpp/events/message_poll_vote_remove.cpp
+++ b/src/dpp/events/message_poll_vote_remove.cpp
@@ -38,14 +38,14 @@ namespace dpp::events {
  */
 void message_poll_vote_remove::handle(discord_client* client, json &j, const std::string &raw) {
 
-	if (!client->creator->on_message_poll_vote_add.empty()) {
-		json d = j["d"];
+	if (!client->creator->on_message_poll_vote_remove.empty()) {
+		json& d = j["d"];
 		dpp::message_poll_vote_remove_t vote(client->owner, client->shard_id, raw);
-		vote.user_id = snowflake_not_null(&j, "user_id");
-		vote.message_id = snowflake_not_null(&j, "message_id");
-		vote.channel_id = snowflake_not_null(&j, "channel_id");
-		vote.guild_id = snowflake_not_null(&j, "guild_id");
-		vote.answer_id = int32_not_null(&j, "answer_id");
+		vote.user_id = snowflake_not_null(&d, "user_id");
+		vote.message_id = snowflake_not_null(&d, "message_id");
+		vote.channel_id = snowflake_not_null(&d, "channel_id");
+		vote.guild_id = snowflake_not_null(&d, "guild_id");
+		vote.answer_id = int32_not_null(&d, "answer_id");
 		client->creator->queue_work(1, [c = client->creator, vote]() {
 			c->on_message_poll_vote_remove.call(vote);
 		});


### PR DESCRIPTION

- Fix message_poll_vote_add/message_poll_vote_remove reading from root JSON instead of "d" object
- Fix message_poll_vote_remove checking wrong event handler (was checking on_message_poll_vote_add)
- Add i_guild_message_polls (1 << 24) intent for guild poll vote events
- Add i_direct_message_polls (1 << 25) intent for DM poll vote events
- Include poll intents in i_default_intents