### PR TITLE
fix: resolve warnings during build

### DIFF
--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -277,7 +277,6 @@ void ssl_connection::on_buffer_drained() {
 /* SSL Client constructor throws std::runtime_error if it can't allocate a socket or call connect() */
 void ssl_connection::connect() {
 	/* Resolve hostname to IP */
-	int err = 0;
 	const dns_cache_entry* addr = resolve_hostname(hostname, port);
 	sfd = addr->make_connecting_socket();
 	address_t destination = addr->get_connecting_address(from_string<uint16_t>(this->port, std::dec));

--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -465,7 +465,7 @@ void exec(const std::string& cmd, std::vector<std::string> parameters, cmd_resul
 			}
 			/* Capture stderr */
 			cmd_and_parameters << " 2>&1";
-			std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd_and_parameters.str().c_str(), "r"), pclose);
+			std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd_and_parameters.str().c_str(), "r"), pclose);
 			if (!pipe) {
 				return;
 			}


### PR DESCRIPTION
This PR resolves some warnings that are raised during compilation:
- `warning: unused variable ‘err’ [-Wunused-variable]` in `src/dpp/sslconnection.h`
- `warning: ignoring attributes on template argument ‘int (*)(FILE*)’ [-Wignored-attributes]` in `src/dpp/utility.cpp`

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.