### PR TITLE
ci: Added offline Unit Tests to Windows, CI now depends on a pre-build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,13 +246,9 @@ jobs:
 
       - name: Run offline unit tests
         if: ${{ matrix.cfg.unittest }}
-        run: cd main\build\library\${{matrix.cfg.config}} && .\unittest.exe | cat output.txt
+        run: main\build\library\${{matrix.cfg.config}}\unittest.exe
         env:
           TEST_DATA_DIR: '${{github.workspace}}\testdata\'
-
-      - name: Print Unit Test logs
-        if: ${{ matrix.cfg.unittest && (success() || failure()) }}
-        run: cd main\build\library\${{matrix.cfg.config}} && tee output.txt
 
       - name: Move debug files for packaging
         if: ${{ matrix.cfg.config == 'Debug' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           DONT_RUN_VCPKG: true
 
       - name: Run offline unit tests
-        run: cd build/library && ./unittest
+        run: cd main\build\library\${{matrix.cfg.config}} && ./unittest
 
       - name: Move debug files for packaging
         if: ${{ matrix.cfg.config == 'Debug' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:
         cfg:
-        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '', unittest: true }
-        - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
+        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: ''}
+        - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '', unittest: true }
         - { name: 'x86',            arch: x86, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
         - { name: 'x86',            arch: x86, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
         - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: false, options: '-T ClangCL', unittest: true }
@@ -246,7 +246,11 @@ jobs:
 
       - name: Run offline unit tests
         if: ${{ matrix.cfg.unittest }}
-        run: cd main\build\library\${{matrix.cfg.config}} && .\unittest.exe
+        run: cd main\build\library\${{matrix.cfg.config}} && .\unittest.exe | cat output.txt
+
+      - name: Print Unit Test logs
+        if: ${{ matrix.cfg.unittest && (success() || failure()) }}
+        run: cd main\build\library\${{matrix.cfg.config}} && tee output.txt
 
       - name: Move debug files for packaging
         if: ${{ matrix.cfg.config == 'Debug' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,11 +195,11 @@ jobs:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:
         cfg:
-        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
+        - { name: 'x64',            arch: x64, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '', unittest: true }
         - { name: 'x64',            arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '' }
         - { name: 'x86',            arch: x86, config: Release, vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
         - { name: 'x86',            arch: x86, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: true,  options: '-T host=x86' }
-        - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: false, options: '-T ClangCL' }
+        - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: false, options: '-T ClangCL', unittest: true }
 
     name: "Windows ${{matrix.cfg.name}}-${{matrix.cfg.config}}-vs${{matrix.cfg.vs}}"
     needs: linux-prebuild
@@ -238,8 +238,15 @@ jobs:
         env:
           DONT_RUN_VCPKG: true
 
+      - name: Build Unit Test
+        if: ${{ matrix.cfg.unittest }}
+        run: cmake --build main/build --target unittest --config ${{matrix.cfg.config}} --parallel 2
+        env:
+          DONT_RUN_VCPKG: true
+
       - name: Run offline unit tests
-        run: cd main\build\library\${{matrix.cfg.config}} && ./unittest
+        if: ${{ matrix.cfg.unittest }}
+        run: cd main\build\library\${{matrix.cfg.config}} && .\unittest.exe
 
       - name: Move debug files for packaging
         if: ${{ matrix.cfg.config == 'Debug' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
       matrix:
         cfg:
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-18, cpp: clang++, version: 18, cmake-flags: '-DDPP_CORO=ON' }
+          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-18, cpp: clang++, version: 18, cmake-flags: '' }
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -74,14 +74,8 @@ jobs:
         cfg:
           # clang++
           - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: clang-11, cpp: clang++, version: 11, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: clang-12, cpp: clang++, version: 12, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: clang-13, cpp: clang++, version: 13, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: clang-14, cpp: clang++, version: 14, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-22.04, package: clang-15, cpp: clang++, version: 15, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-16, cpp: clang++, version: 16, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-17, cpp: clang++, version: 17, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-18, cpp: clang++, version: 18, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
-          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-19, cpp: clang++, version: 19, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-20, cpp: clang++, version: 20, cmake-flags: '', cpack: 'no', ctest: 'no', mold: 'yes' }
           - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: 'clang-21 libc++-21-dev libc++abi-21-dev', cpp: clang++, version: 21, cmake-flags: '-DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"', cpack: 'no', ctest: 'no', mold: 'yes', name-extra: ' libc++', llvm-apt: 'yes' }
           # g++
@@ -182,7 +176,7 @@ jobs:
         run: brew install make opus openssl
 
       - name: Generate CMake
-        run: cmake -B build -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Release -DDPP_CORO=ON -DAVX_TYPE=AVX0
+        run: cmake -B build -DDPP_NO_VCPKG=ON -DCMAKE_BUILD_TYPE=Release -DAVX_TYPE=AVX0
         env:
           DONT_RUN_VCPKG: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ permissions:
   contents: read
 
 jobs:
+  linux-prebuild:
+    permissions:
+      contents: write
+    name: Linux Pre-Build Check ${{ matrix.cfg.arch }} (${{ matrix.cfg.cpp }}-${{ matrix.cfg.version }}${{ matrix.cfg.name-extra }})
+    runs-on: ${{ matrix.cfg.os }}
+    strategy:
+      fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
+      matrix:
+        cfg:
+          - { arch: 'amd64', concurrency: 4, os: ubuntu-24.04, package: clang-18, cpp: clang++, version: 18, cmake-flags: '-DDPP_CORO=ON' }
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout D++
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup mold
+        uses: rui314/setup-mold@b015f7e3f2938ad3a5ed6e5111a8c6c7c1d6db6e # v1
+
+      - name: Install apt packages
+        run: sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt update && sudo apt-get install -y ${{ matrix.cfg.package }} pkg-config libopus-dev zlib1g-dev rpm
+
+      - name: Generate CMake
+        run: cmake -B build -DDPP_NO_VCPKG=ON -DAVX_TYPE=AVX0 -DCMAKE_BUILD_TYPE=Release ${{matrix.cfg.cmake-flags}}
+        env:
+          CXX: ${{ matrix.cfg.cpp }}-${{ matrix.cfg.version }}
+
   linux:
     permissions:
       contents: write
@@ -34,6 +64,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.cfg.arch }}-(${{ matrix.cfg.cpp }}-${{ matrix.cfg.version }})
       cancel-in-progress: true
     name: Linux ${{ matrix.cfg.arch }} (${{ matrix.cfg.cpp }}-${{ matrix.cfg.version }}${{ matrix.cfg.name-extra }})
+    needs: linux-prebuild
     runs-on: ${{ matrix.cfg.os }}
     strategy:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
@@ -126,6 +157,7 @@ jobs:
     permissions:
       contents: write
     name: macOS ${{ matrix.cfg.arch }} (${{ matrix.cfg.cpp }}-${{ matrix.cfg.version }})
+    needs: linux-prebuild
     runs-on: ${{ matrix.cfg.os }}
     strategy:
       fail-fast: false # Don't fail everything if one fails. We want to test each OS/Compiler individually
@@ -176,6 +208,7 @@ jobs:
         - { name: 'x64-Clang',      arch: x64, config: Debug,   vs: '2022', os: 'windows-2025', vsv: '17', upload: false, options: '-T ClangCL' }
 
     name: "Windows ${{matrix.cfg.name}}-${{matrix.cfg.config}}-vs${{matrix.cfg.vs}}"
+    needs: linux-prebuild
     runs-on: ${{matrix.cfg.os}}
     steps:
       - name: Harden Runner
@@ -211,6 +244,9 @@ jobs:
         env:
           DONT_RUN_VCPKG: true
 
+      - name: Run offline unit tests
+        run: cd build/library && ./unittest
+
       - name: Move debug files for packaging
         if: ${{ matrix.cfg.config == 'Debug' }}
         run: xcopy main\build\library\Debug\* main\build\library\Release\ /s /q
@@ -239,6 +275,7 @@ jobs:
           - {name: "ARMv6", os: ubuntu-24.04, cmake-options: -DDPP_NO_CORO=ON -DCMAKE_TOOLCHAIN_FILE=cmake/ARMv6ToolChain.cmake}
 
     name: ${{matrix.cfg.name}}
+    needs: linux-prebuild
     runs-on: ${{matrix.cfg.os}}
     steps:
       - name: Harden Runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,8 @@ jobs:
       - name: Run offline unit tests
         if: ${{ matrix.cfg.unittest }}
         run: cd main\build\library\${{matrix.cfg.config}} && .\unittest.exe | cat output.txt
+        env:
+          TEST_DATA_DIR: '${{github.workspace}}\testdata\'
 
       - name: Print Unit Test logs
         if: ${{ matrix.cfg.unittest && (success() || failure()) }}


### PR DESCRIPTION
This PR now lets Windows build Unit Tests. CI now also has a pre-build which will just generate CMake. In the event that there is any issue in that step, CI will prevent any other runners, meaning we don't throw too many resources.

This PR also reduces the amount of clang runners for linux. We now only do the lowest and highest version for an ubuntu LTS version.

No Checklist applies for this PR.