### PR TITLE
Added DPP_EXPORT to bignum.h bn_deleter::operator()

### DIFF
--- a/include/dpp/bignum.h
+++ b/include/dpp/bignum.h
@@ -58,7 +58,7 @@ class DPP_EXPORT bignumber {
 		 *
 		 * @param p Pointer to the `openssl_bignum` instance to delete.
 		 */
-		void operator()(openssl_bignum* p) const noexcept;
+		DPP_EXPORT void operator()(openssl_bignum* p) const noexcept;
 	};
 
 	/**


### PR DESCRIPTION
Added a missing DPP_EXPORT on bn_deleter::operator() since not exporting this symbol causes Windows build to fail since it does not export symbols by default.

Without the change during linking on Windows you get:
<img width="2052" height="82" alt="image" src="https://github.com/user-attachments/assets/ae2b644c-c1b0-4cfe-8c3c-7be3ea6ca9a7" />

With the small change it works as expected.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.


