### PR TITLE
Added DPP_EXPORT to bignum.h bn_deleter struct

### DIFF
--- a/include/dpp/bignum.h
+++ b/include/dpp/bignum.h
@@ -48,7 +48,7 @@ class DPP_EXPORT bignumber {
 	 * @brief Forward declaration of structure which implements proper destructor for unique_ptr<openssl_bignum> as type is incomplete in header
 	 * custom deleter defined where openssl_bignum is complete
 	 */
-	struct bn_deleter {
+	struct DPP_EXPORT bn_deleter {
 
 		/**
 		 * @brief Deletes an `openssl_bignum` instance.


### PR DESCRIPTION
Added a missing DPP_EXPORT on bn_deleter struct since not exporting this symbol causes Windows (msvc) build to fail since it does not export symbols by default.

Without the change during linking on Windows you get:
<img width="2052" height="82" alt="image" src="https://github.com/user-attachments/assets/ae2b644c-c1b0-4cfe-8c3c-7be3ea6ca9a7" />

With the small change it works as expected (resolves #1527)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.


