### PR TITLE
Fix hang when sending HTTP request with empty token and non-empty logger

### DIFF
--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -195,10 +195,12 @@ void cluster::log(dpp::loglevel severity, const std::string &msg) const {
 		dpp::log_t logmsg(nullptr, 0, msg);
 		logmsg.severity = severity;
 		logmsg.message = msg;
-		size_t pos{0};
-		while ((pos = logmsg.message.find(token, pos)) != std::string::npos) {
-			logmsg.message.replace(pos, token.length(), "*****");
-			pos += 5;
+		if (!token.empty()) {
+			size_t pos{0};
+			while ((pos = logmsg.message.find(token, pos)) != std::string::npos) {
+				logmsg.message.replace(pos, token.length(), "*****");
+				pos += 5;
+			}
 		}
 		on_log.call(logmsg);
 	}


### PR DESCRIPTION
Fix infinite loop when sending HTTP request with empty token and non-empty logger
A simple bot to reproduce the issue: [hang_test.txt](https://github.com/user-attachments/files/24424056/hang_test.txt)

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
