### PR TITLE
refactor: Fix typos and suppress unhandled VOICE_CHANNEL_START_TIME_UPDATE event

### DIFF
--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -263,7 +263,7 @@ public:
 	void enable_raw_tracing();
 
 	/**
-	 * @brief Get the bytes out objectGet total bytes sent
+	 * @brief Get total bytes sent
 	 * @return uint64_t bytes sent
 	 */
 	uint64_t get_bytes_out();

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -405,6 +405,7 @@ static const std::map<std::string, dpp::events::event*> event_map = {
 	{ "GUILD_SOUNDBOARD_SOUNDS_UPDATE", nullptr },
 	{ "GUILD_SOUNDBOARD_SOUND_UPDATE", nullptr },
 	{ "VOICE_CHANNEL_STATUS_UPDATE", nullptr },
+	{ "VOICE_CHANNEL_START_TIME_UPDATE", nullptr },
 	{ "GUILD_SCHEDULED_EVENT_CREATE", make_static_event<dpp::events::guild_scheduled_event_create>() },
 	{ "GUILD_SCHEDULED_EVENT_UPDATE", make_static_event<dpp::events::guild_scheduled_event_update>() },
 	{ "GUILD_SCHEDULED_EVENT_DELETE", make_static_event<dpp::events::guild_scheduled_event_delete>() },

--- a/src/dpp/voice/enabled/handle_frame.cpp
+++ b/src/dpp/voice/enabled/handle_frame.cpp
@@ -226,7 +226,7 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 					dave_mls_pending_remove_list.erase(dpp::snowflake(user));
 				}
 
-				log(ll_debug, "New of clients in voice channel: " + std::to_string(joining_dave_users.size()) + " total is " + std::to_string(dave_mls_user_list.size()));
+				log(ll_debug, "New number of clients in voice channel: " + std::to_string(joining_dave_users.size()) + " total is " + std::to_string(dave_mls_user_list.size()));
 			}
 			break;
 			case voice_client_dave_mls_invalid_commit_welcome: {


### PR DESCRIPTION
A few small fixes I noticed while looking through the codebase:

- **sslconnection.h**: The doxygen comment for `get_bytes_out()` had a garbled string (`Get the bytes out objectGet total bytes sent`). Cleaned it up to match the style of `get_bytes_in()` right below it.
- **handle_frame.cpp**: The DAVE voice debug log said `"New of clients in voice channel"` which is missing a word — changed to `"New number of clients in voice channel"`.
- **discordevents.cpp**: `VOICE_CHANNEL_START_TIME_UPDATE` is a gateway event that Discord sends (e.g. when bots are moved between voice channels), but it wasn't in the event map. This caused noisy `Unhandled event` debug log lines. Added it as a silently-ignored entry, same as the other events we don't need to handle like `VOICE_CHANNEL_STATUS_UPDATE`.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.