### PR TITLE
feat: Add missing BYPASS_SLOWMODE permission (bit 52)

### DIFF
--- a/include/dpp/permissions.h
+++ b/include/dpp/permissions.h
@@ -299,6 +299,11 @@ enum permissions : uint64_t {
 	 * @brief Allows pinning and unpinning messages
 	 */
 	p_pin_messages = 0x0008000000000000,
+
+	/**
+	 * @brief Allows members to bypass the slow mode rate limit for sending messages in a channel.
+	 */
+	p_bypass_slowmode = 0x0010000000000000,
 };
 
 /**

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -878,6 +878,15 @@ public:
 	bool has_pin_messages() const;
 
 	/**
+	 * @brief True if has the bypass slow mode permission.
+	 *
+	 * @note Having the administrator permission causes this method to always return true
+	 * Channel specific overrides may apply to permissions.
+	 * @return bool True if user has the bypass slow mode permission or is administrator.
+	 */
+	bool has_bypass_slowmode() const;
+
+	/**
 	 * @brief Get guild members who have this role.
 	 *
 	 * @note This method requires user/members cache to be active

--- a/src/dpp/role.cpp
+++ b/src/dpp/role.cpp
@@ -361,6 +361,10 @@ bool role::has_pin_messages() const {
 	return has_administrator() || permissions.has(p_pin_messages);
 }
 
+bool role::has_bypass_slowmode() const {
+	return has_administrator() || permissions.has(p_bypass_slowmode);
+}
+
 role& role::set_name(const std::string& n) {
 	name = utility::validate(n, 1, 100, "Role name too short");
 	return *this;


### PR DESCRIPTION
Discord added a `BYPASS_SLOWMODE` permission (bit 52, `0x0010000000000000`) but it wasn't in DPP yet.

Changes:
- Added `p_bypass_slowmode` to the `permissions` enum in `permissions.h`
- Added `has_bypass_slowmode()` helper to the `role` class
- Follows the same pattern as all the other permission entries

Ref: https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags