### PR TITLE
feat: add guild messages search endpoint

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -1984,6 +1984,17 @@ public:
 	void messages_get(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit, command_completion_event_t callback);
 
 	/**
+	 * @brief Search for messages in a guild
+	 *
+	 * @see https://discord.com/developers/docs/resources/message#search-guild-messages
+	 * @param guild_id Guild ID to search in
+	 * @param params Search parameters
+	 * @param callback Function to call when the API call completes.
+	 * On success the callback will contain a dpp::message_search_result object in confirmation_callback_t::value. On failure, the value is undefined and confirmation_callback_t::is_error() method will return true. You can obtain full error details with confirmation_callback_t::get_error().
+	 */
+	void guild_messages_search(snowflake guild_id, const message_search_params& params, command_completion_event_t callback);
+
+	/**
 	 * @brief Send a message to a channel. The callback function is called when the message has been sent
 	 *
 	 * @see https://discord.com/developers/docs/resources/channel#create-message

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -1680,6 +1680,18 @@
 [[nodiscard]] async<confirmation_callback_t> co_messages_get(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit);
 
 /**
+ * @brief Search for messages in a guild
+ *
+ * @see dpp::cluster::guild_messages_search
+ * @see https://discord.com/developers/docs/resources/message#search-guild-messages
+ * @param guild_id Guild ID to search in
+ * @param params Search parameters
+ * @return message_search_result returned object on completion
+ * \memberof dpp::cluster
+ */
+[[nodiscard]] async<confirmation_callback_t> co_guild_messages_search(snowflake guild_id, const message_search_params& params);
+
+/**
  * @brief Unpin a message
  * @see dpp::cluster::message_unpin
  * @see https://discord.com/developers/docs/resources/channel#unpin-message

--- a/include/dpp/cluster_coro_calls.h
+++ b/include/dpp/cluster_coro_calls.h
@@ -1680,18 +1680,6 @@
 [[nodiscard]] async<confirmation_callback_t> co_messages_get(snowflake channel_id, snowflake around, snowflake before, snowflake after, uint64_t limit);
 
 /**
- * @brief Search for messages in a guild
- *
- * @see dpp::cluster::guild_messages_search
- * @see https://discord.com/developers/docs/resources/message#search-guild-messages
- * @param guild_id Guild ID to search in
- * @param params Search parameters
- * @return message_search_result returned object on completion
- * \memberof dpp::cluster
- */
-[[nodiscard]] async<confirmation_callback_t> co_guild_messages_search(snowflake guild_id, const message_search_params& params);
-
-/**
  * @brief Unpin a message
  * @see dpp::cluster::message_unpin
  * @see https://discord.com/developers/docs/resources/channel#unpin-message
@@ -1754,6 +1742,18 @@
  * \memberof dpp::cluster
  */
 [[nodiscard]] async<confirmation_callback_t> co_poll_end(snowflake message_id, snowflake channel_id);
+
+/**
+ * @brief Search for messages in a guild
+ *
+ * @see dpp::cluster::guild_messages_search
+ * @see https://discord.com/developers/docs/resources/message#search-guild-messages
+ * @param guild_id Guild ID to search in
+ * @param params Search parameters
+ * @return message_search_result returned object on completion
+ * \memberof dpp::cluster
+ */
+[[nodiscard]] async<confirmation_callback_t> co_guild_messages_search(snowflake guild_id, const message_search_params& params);
 
 /**
  * @brief Get a channel's pins

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -3091,6 +3091,209 @@ typedef std::unordered_map<snowflake, message> message_map;
 typedef std::unordered_map<snowflake, message_pin> message_pin_map;
 
 /**
+ * @brief Possible values for the "has" filter in message search
+ */
+enum message_search_has : uint8_t {
+	has_image,
+	has_sound,
+	has_video,
+	has_file,
+	has_sticker,
+	has_embed,
+	has_link,
+	has_poll,
+	has_snapshot,
+};
+
+/**
+ * @brief Sort mode for message search results
+ */
+enum message_search_sort : uint8_t {
+	sort_timestamp,
+	sort_relevance,
+};
+
+/**
+ * @brief Sort order for message search results
+ */
+enum message_search_order : uint8_t {
+	sort_desc,
+	sort_asc,
+};
+
+/**
+ * @brief Parameters for searching messages within a guild
+ * @see https://discord.com/developers/docs/resources/message#search-guild-messages
+ */
+struct DPP_EXPORT message_search_params {
+	/**
+	 * @brief Filter messages by content (max 1024 characters)
+	 */
+	std::string content;
+
+	/**
+	 * @brief Filter by author IDs (max 100)
+	 */
+	std::vector<snowflake> author_id;
+
+	/**
+	 * @brief Filter messages that mention these users (max 100)
+	 */
+	std::vector<snowflake> mentions;
+
+	/**
+	 * @brief Filter by channel IDs (max 500)
+	 */
+	std::vector<snowflake> channel_id;
+
+	/**
+	 * @brief Filter messages that mention these roles (max 100)
+	 */
+	std::vector<snowflake> mentions_role_id;
+
+	/**
+	 * @brief Filter messages that reply to these users (max 100)
+	 */
+	std::vector<snowflake> replied_to_user_id;
+
+	/**
+	 * @brief Filter messages that reply to these messages (max 100)
+	 */
+	std::vector<snowflake> replied_to_message_id;
+
+	/**
+	 * @brief Filter by author type (user, bot, webhook; prefix with - to negate)
+	 */
+	std::vector<std::string> author_type;
+
+	/**
+	 * @brief Filter by presence of element types
+	 */
+	std::vector<message_search_has> has;
+
+	/**
+	 * @brief Filter messages by embed type
+	 */
+	std::vector<std::string> embed_type;
+
+	/**
+	 * @brief Filter messages by embed provider (case-sensitive, max 100)
+	 */
+	std::vector<std::string> embed_provider;
+
+	/**
+	 * @brief Filter messages by link hostname (max 100)
+	 */
+	std::vector<std::string> link_hostname;
+
+	/**
+	 * @brief Filter messages by attachment filename (max 100)
+	 */
+	std::vector<std::string> attachment_filename;
+
+	/**
+	 * @brief Filter messages by attachment extension (max 100)
+	 */
+	std::vector<std::string> attachment_extension;
+
+	/**
+	 * @brief Get messages before this message ID
+	 */
+	snowflake max_id;
+
+	/**
+	 * @brief Get messages after this message ID
+	 */
+	snowflake min_id;
+
+	/**
+	 * @brief Filter messages by whether they are pinned
+	 */
+	std::optional<bool> pinned;
+
+	/**
+	 * @brief Filter by @everyone mention presence
+	 */
+	std::optional<bool> mention_everyone;
+
+	/**
+	 * @brief Whether to include results from age-restricted channels (default false)
+	 */
+	std::optional<bool> include_nsfw;
+
+	/**
+	 * @brief Max number of messages to return (1-25, default 25)
+	 */
+	std::optional<uint32_t> limit;
+
+	/**
+	 * @brief Pagination offset (max 9975)
+	 */
+	std::optional<uint32_t> offset;
+
+	/**
+	 * @brief Max number of words to skip between matching tokens (max 100, default 2)
+	 */
+	std::optional<uint32_t> slop;
+
+	/**
+	 * @brief Sorting algorithm to use (default: sort_timestamp)
+	 */
+	std::optional<message_search_sort> sort_by;
+
+	/**
+	 * @brief Direction to sort (default: sort_desc)
+	 */
+	std::optional<message_search_order> sort_order;
+
+	/**
+	 * @brief Build the query string for the REST request
+	 * @return URL query string starting with '?'
+	 */
+	std::string build_url_params() const;
+};
+
+/**
+ * @brief Represents the result of a guild message search
+ * @see https://discord.com/developers/docs/resources/message#search-guild-messages
+ */
+struct DPP_EXPORT message_search_result : public json_interface<message_search_result> {
+protected:
+	friend struct json_interface<message_search_result>;
+
+	/**
+	 * @brief Fill from JSON
+	 * @param j JSON data
+	 * @return Reference to self
+	 */
+	message_search_result& fill_from_json_impl(nlohmann::json* j);
+
+public:
+	message_search_result() = default;
+
+	/**
+	 * @brief Total number of results matching the query
+	 */
+	uint32_t total_results{0};
+
+	/**
+	 * @brief Whether a deep historical index is being performed
+	 */
+	bool doing_deep_historical_index{false};
+
+	/**
+	 * @brief Number of documents indexed so far (only present during deep indexing)
+	 */
+	std::optional<uint32_t> documents_indexed;
+
+	/**
+	 * @brief Matched messages grouped by context.
+	 * Each inner vector contains the matched message followed by context messages.
+	 */
+	std::vector<std::vector<message>> messages;
+};
+
+/**
  * @brief A group of stickers
  */
 typedef std::unordered_map<snowflake, sticker> sticker_map;

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -196,7 +196,8 @@ typedef std::variant<
 		entitlement,
 		entitlement_map,
 		sku,
-		sku_map
+		sku_map,
+		message_search_result
 	> confirmable_t;
 
 /**

--- a/src/dpp/cluster/message.cpp
+++ b/src/dpp/cluster/message.cpp
@@ -206,6 +206,15 @@ void cluster::poll_end(snowflake message_id, snowflake channel_id, command_compl
 }
 
 
+void cluster::guild_messages_search(snowflake guild_id, const message_search_params& params, command_completion_event_t callback) {
+	this->post_rest(API_PATH "/guilds", std::to_string(guild_id), "messages/search" + params.build_url_params(), m_get, "", [this, callback](json &j, const http_request_completion_t& http) {
+		if (callback) {
+			callback(confirmation_callback_t(this, message_search_result().fill_from_json(&j), http));
+		}
+	});
+}
+
+
 void cluster::channel_pins_get(snowflake channel_id, command_completion_event_t callback) {
 	channel_pins_get(channel_id, {}, {}, callback);
 }

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -551,6 +551,10 @@ async<confirmation_callback_t> cluster::co_messages_get(snowflake channel_id, sn
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, snowflake, uint64_t, command_completion_event_t)>(&cluster::messages_get), channel_id, around, before, after, limit };
 }
 
+async<confirmation_callback_t> cluster::co_guild_messages_search(snowflake guild_id, const message_search_params& params) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, const message_search_params&, command_completion_event_t)>(&cluster::guild_messages_search), guild_id, params };
+}
+
 async<confirmation_callback_t> cluster::co_message_unpin(snowflake channel_id, snowflake message_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_unpin), channel_id, message_id };
 }

--- a/src/dpp/cluster_coro_calls.cpp
+++ b/src/dpp/cluster_coro_calls.cpp
@@ -304,7 +304,7 @@ async<confirmation_callback_t> cluster::co_get_gateway_bot() {
 }
 
 async<confirmation_callback_t> cluster::co_guild_current_member_edit(snowflake guild_id, const std::string& nickname, const std::string& banner_blob, const image_type banner_type, const std::string& avatar_blob, const image_type avatar_type, const std::string& bio) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string &, const std::string&, const image_type, const std::string&, const image_type, const std::string&, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname, banner_blob, banner_type, avatar_blob, avatar_type, bio };
+	return async{ this, static_cast<void (cluster::*)(snowflake, const std::string&, const std::string&, const image_type, const std::string&, const image_type, const std::string&, command_completion_event_t)>(&cluster::guild_current_member_edit), guild_id, nickname, banner_blob, banner_type, avatar_blob, avatar_type, bio };
 }
 
 async<confirmation_callback_t> cluster::co_guild_auditlog_get(snowflake guild_id, snowflake user_id, uint32_t action_type, snowflake before, snowflake after, uint32_t limit) {
@@ -551,10 +551,6 @@ async<confirmation_callback_t> cluster::co_messages_get(snowflake channel_id, sn
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, snowflake, snowflake, uint64_t, command_completion_event_t)>(&cluster::messages_get), channel_id, around, before, after, limit };
 }
 
-async<confirmation_callback_t> cluster::co_guild_messages_search(snowflake guild_id, const message_search_params& params) {
-	return async{ this, static_cast<void (cluster::*)(snowflake, const message_search_params&, command_completion_event_t)>(&cluster::guild_messages_search), guild_id, params };
-}
-
 async<confirmation_callback_t> cluster::co_message_unpin(snowflake channel_id, snowflake message_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::message_unpin), channel_id, message_id };
 }
@@ -573,6 +569,10 @@ async<confirmation_callback_t> cluster::co_poll_end(const message &m) {
 
 async<confirmation_callback_t> cluster::co_poll_end(snowflake message_id, snowflake channel_id) {
 	return async{ this, static_cast<void (cluster::*)(snowflake, snowflake, command_completion_event_t)>(&cluster::poll_end), message_id, channel_id };
+}
+
+async<confirmation_callback_t> cluster::co_guild_messages_search(snowflake guild_id, const message_search_params& params) {
+	return async{ this, static_cast<void (cluster::*)(snowflake, const message_search_params&, command_completion_event_t)>(&cluster::guild_messages_search), guild_id, params };
 }
 
 async<confirmation_callback_t> cluster::co_channel_pins_get(snowflake channel_id) {

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -1817,4 +1817,137 @@ json message_pin::to_json() const {
 	return j;
 }
 
+std::string message_search_params::build_url_params() const {
+	std::string params = "?";
+	bool first = true;
+
+	auto append = [&](const std::string& key, const std::string& value) {
+		if (!first) {
+			params += '&';
+		}
+		params += utility::url_encode(key) + "=" + utility::url_encode(value);
+		first = false;
+	};
+
+	if (!content.empty()) {
+		append("content", content);
+	}
+	for (const auto& id : author_id) {
+		if (id) {
+			append("author_id", std::to_string(id));
+		}
+	}
+	for (const auto& id : mentions) {
+		if (id) {
+			append("mentions", std::to_string(id));
+		}
+	}
+	for (const auto& id : channel_id) {
+		if (id) {
+			append("channel_id", std::to_string(id));
+		}
+	}
+	for (const auto& id : mentions_role_id) {
+		if (id) {
+			append("mentions_role_id", std::to_string(id));
+		}
+	}
+	for (const auto& id : replied_to_user_id) {
+		if (id) {
+			append("replied_to_user_id", std::to_string(id));
+		}
+	}
+	for (const auto& id : replied_to_message_id) {
+		if (id) {
+			append("replied_to_message_id", std::to_string(id));
+		}
+	}
+	for (const auto& t : author_type) {
+		if (!t.empty()) {
+			append("author_type", t);
+		}
+	}
+	for (const auto& h : has) {
+		static constexpr const char* has_names[] = {
+			"image", "sound", "video", "file", "sticker", "embed", "link", "poll", "snapshot"
+		};
+		append("has", has_names[static_cast<uint8_t>(h)]);
+	}
+	for (const auto& t : embed_type) {
+		if (!t.empty()) {
+			append("embed_type", t);
+		}
+	}
+	for (const auto& p : embed_provider) {
+		if (!p.empty()) {
+			append("embed_provider", p);
+		}
+	}
+	for (const auto& h : link_hostname) {
+		if (!h.empty()) {
+			append("link_hostname", h);
+		}
+	}
+	for (const auto& f : attachment_filename) {
+		if (!f.empty()) {
+			append("attachment_filename", f);
+		}
+	}
+	for (const auto& e : attachment_extension) {
+		if (!e.empty()) {
+			append("attachment_extension", e);
+		}
+	}
+	if (max_id) {
+		append("max_id", std::to_string(max_id));
+	}
+	if (min_id) {
+		append("min_id", std::to_string(min_id));
+	}
+	if (pinned.has_value()) {
+		append("pinned", pinned.value() ? "true" : "false");
+	}
+	if (mention_everyone.has_value()) {
+		append("mention_everyone", mention_everyone.value() ? "true" : "false");
+	}
+	if (include_nsfw.has_value()) {
+		append("include_nsfw", include_nsfw.value() ? "true" : "false");
+	}
+	if (limit.has_value()) {
+		append("limit", std::to_string(limit.value()));
+	}
+	if (offset.has_value()) {
+		append("offset", std::to_string(offset.value()));
+	}
+	if (slop.has_value()) {
+		append("slop", std::to_string(slop.value()));
+	}
+	if (sort_by.has_value()) {
+		append("sort_by", sort_by.value() == sort_relevance ? "relevance" : "timestamp");
+	}
+	if (sort_order.has_value()) {
+		append("sort_order", sort_order.value() == sort_asc ? "asc" : "desc");
+	}
+
+	return first ? "" : params;
+}
+
+message_search_result& message_search_result::fill_from_json_impl(nlohmann::json* j) {
+	total_results = int32_not_null(j, "total_results");
+	doing_deep_historical_index = bool_not_null(j, "doing_deep_historical_index");
+	if (j->contains("documents_indexed") && !(*j)["documents_indexed"].is_null()) {
+		documents_indexed = int32_not_null(j, "documents_indexed");
+	}
+	if (j->contains("messages")) {
+		for (auto& group : (*j)["messages"]) {
+			std::vector<message> msg_group;
+			for (auto& m : group) {
+				msg_group.emplace_back(message().fill_from_json(&m));
+			}
+			messages.push_back(std::move(msg_group));
+		}
+	}
+	return *this;
+}
+
 }// namespace dpp


### PR DESCRIPTION
## Summary

Implements the [Search Guild Messages](https://discord.com/developers/docs/resources/message#search-guild-messages) endpoint (`GET /guilds/{guild.id}/messages/search`).

- Adds `message_search_params` struct with all query parameters from the API spec
- Adds `message_search_result` struct for the response (including nested message arrays)
- Adds `guild_messages_search()` and coroutine wrapper `co_guild_messages_search()`
- Enums for `has`, `sort_by`, and `sort_order` filter values

Closes #1563