### PR TITLE
fix(coro): fix an issue with coroutine lambdas with captures with cluster::start_timer

### DIFF
--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -476,16 +476,29 @@ public:
 	 * @return timer A handle to the timer, used to remove that timer later
 	 */
 	template <std::invocable<timer> T, std::invocable<timer> U = std::function<void(timer)>>
-	requires (dpp::awaitable_type<typename std::invoke_result<T, timer>::type>)
+	requires (
+		dpp::awaitable_type<typename std::invoke_result<T, timer>::type> &&
+		std::copy_constructible<std::decay_t<T>> && // N4988 [func.wrap.func.con]/10.1 - std::function requires a copy constructible argument
+		std::copy_constructible<std::decay_t<U>>
+	)
 	timer start_timer(T&& on_tick, uint64_t frequency, U&& on_stop = {}) {
-		std::function<void(timer)> ticker = [fun = std::forward<T>(on_tick)](timer t) mutable -> dpp::job {
+		using tick_fun = std::decay_t<T>;
+		using stop_fun = std::decay_t<U>;
+
+		// We want to ship the function object on the coroutine frame to allow for lambda captures
+		// See https://discord.com/channels/825407338755653642/825411707521728512/1495801839827030067
+		// and https://discord.com/channels/825407338755653642/825411707521728512/1492502683444052109
+		// Now we can only realistically do that by copying the lambda on each invocation, I think...
+		// People should be avoiding lambda captures to begin with (see https://dpp.dev/coro-introduction.html),
+		// so while this isn't super efficient, it's practically zero-cost with no capture anyways
+		std::function<void(timer)> ticker = std::bind_front([](tick_fun fun, timer t) -> dpp::job {
 			co_await std::invoke(fun, t);
-		};
+		}, static_cast<tick_fun>(std::forward<T>(on_tick)));
 		std::function<void(timer)> stopper;
 		if constexpr (dpp::awaitable_type<typename std::invoke_result<U, timer>::type>) {
-			stopper = [fun = std::forward<U>(on_stop)](timer t) mutable -> dpp::job {
+			stopper = std::bind_front([](stop_fun fun, timer t) -> dpp::job {
 				co_await std::invoke(fun, t);
-			};
+			}, static_cast<stop_fun>(std::forward<U>(on_stop)));
 		} else {
 			stopper = std::forward<U>(on_stop);
 		}


### PR DESCRIPTION
This is technically less of a bug fix, more so making things easier for the user, adding a workaround on our end

See https://discord.com/channels/825407338755653642/825411707521728512/1495800924923498566:
> because in coroutines the lambda is only alive for the invocation of the function creating the coroutine
and the capture is within the lambda
so if you co_await - control gets sent back to the caller
the lambda gets destroyed if it's not saved by something else
and then all your captures are gone once you come back from the co_await
but the parameters to the function are different, they live on the coroutine frame itself

So now - we do save the lambda on the coroutine frame by making a lambda that has it as a parameter, and we [std::bind_front](https://en.cppreference.com/cpp/utility/functional/bind_front) it

[Code like this](https://discord.com/channels/825407338755653642/825411707521728512/1495729341512941568) should now work:
```c++
bot.start_timer([&bot](const dpp::timer& timer)-> dpp::task <void> {
	co_await bot.co_message_create(dpp::message{825411707521728512, "foo"});
	co_await bot.co_message_create(dpp::message{825411707521728512, "bar"});
}, 5);
```
Which would segfault before due to the deletion of the lambda & its captures in-between `co_await` expressions

See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95111

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
