### PR TITLE
refactor: corrected ColourReset to be the correct Ansi sequence, added colour.cmake to the documentation tests

### DIFF
--- a/cmake/colour.cmake
+++ b/cmake/colour.cmake
@@ -1,6 +1,6 @@
 if(NOT WIN32)
   string(ASCII 27 Esc)
-  set(ColourReset "${Esc}[m")
+  set(ColourReset "${Esc}[0m")
   set(ColourBold  "${Esc}[1m")
   set(Red         "${Esc}[31m")
   set(Green       "${Esc}[32m")

--- a/docpages/example_code/CMakeLists.txt
+++ b/docpages/example_code/CMakeLists.txt
@@ -31,7 +31,7 @@
 cmake_minimum_required (VERSION 3.16)
 project(documentation_tests)
 
-string(ASCII 27 Esc)
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/colour.cmake")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDPP_CORO -std=c++20 -pthread -O0 -fPIC -rdynamic -DFMT_HEADER_ONLY -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -Wno-deprecated-declarations")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
@@ -39,7 +39,7 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
 file(GLOB example_list ./*.cpp)
 foreach (example ${example_list})
 	get_filename_component(examplename ${example} NAME)
-	message(STATUS "Found example '${Esc}[1;34m${examplename}${Esc}[m'")
+	message(STATUS "Found example '${BoldBlue}${examplename}${ColourReset}'")
 	add_executable(${examplename}_out ${example})
 	target_link_libraries(${examplename}_out dl dpp mpg123 oggz ogg opusfile opus)
 	include_directories(/usr/include/opus)


### PR DESCRIPTION
Noticed that ColourReset wasn't working on TeamCity and found we weren't doing it properly (see https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode), it would work on most terminals but stuff like TeamCity wouldn't understand and would look like this:
<img width="214" height="20" alt="image" src="https://github.com/user-attachments/assets/b2df823d-d1fe-42ba-8eae-b41e693ef1aa" />


Checklist does not apply here.