### PR TITLE
fix: 100% busy main thread while bot is not playing audio in vc

### DIFF
--- a/src/dpp/voice/enabled/read_write.cpp
+++ b/src/dpp/voice/enabled/read_write.cpp
@@ -34,8 +34,17 @@ void discord_voice_client::send(const char* packet, size_t len, uint64_t duratio
 		frame.packet.assign(packet, packet + len);
 		frame.duration = duration;
 
-		std::lock_guard<std::mutex> lock(this->stream_mutex);
-		outbuf.emplace_back(frame);
+		bool was_empty = false;
+		{
+			std::lock_guard<std::mutex> lock(this->stream_mutex);
+			was_empty = outbuf.empty();
+			outbuf.emplace_back(frame);
+		}
+
+		if (was_empty) {
+			udp_events.flags = WANT_READ | WANT_WRITE | WANT_ERROR;
+			owner->socketengine->update_socket(udp_events);
+		}
 	} else [[unlikely]] {
 		this->udp_send(packet, len);
 	}

--- a/src/dpp/voice/enabled/write_ready.cpp
+++ b/src/dpp/voice/enabled/write_ready.cpp
@@ -31,12 +31,18 @@
 namespace dpp {
 
 void discord_voice_client::write_ready() {
-	/* 
-	 * WANT_WRITE has been reset everytime this method is being called,
-	 * ALWAYS set it again no matter what we're gonna do.
-	 */
-	udp_events.flags = WANT_READ | WANT_WRITE | WANT_ERROR;
-	owner->socketengine->update_socket(udp_events);
+	bool needs_write = false;
+	{
+		std::lock_guard<std::mutex> lock(this->stream_mutex);
+		const bool needs_stop_frames = this->paused && !this->sent_stop_frames;
+		const bool has_audio = !outbuf.empty();
+		needs_write = needs_stop_frames || has_audio;
+	}
+
+	if (needs_write) {
+		udp_events.flags = WANT_READ | WANT_WRITE | WANT_ERROR;
+		owner->socketengine->update_socket(udp_events);
+	}
 
 	uint64_t duration = 0;
 	bool track_marker_found = false;


### PR DESCRIPTION
I am unsure whether the fix is valid, considering it goes against the comment to always set WANT_WRITE.
I have tested with epoll in wsl, poll under windows and whatever my raspberry pi 3b+ on debian 12 uses and it seems to work
However my testing has not been extensive, and therefore I would like for some more confirmation as to whether this is valid.

I'm also unsure on the needs stop frames part, then again, the voice stuff is too much for me to all look at
And im unsure on whether the send_now branch should also need the same treatment with the socket update
I also want to look into whether update socket can be made more efficient by preventing the copy of the entire object each time

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR.
- [ ] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
