### PR TITLE
fix: addition of a few protections to prevent data races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ config.json
 compile_commands.json
 src/dpp/dpp.rc
 .DS_STORE
+.env

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -471,6 +471,11 @@ public:
 	std::mutex	rem_mutex;
 
 	/**
+	 * @brief Rate-limit bucket mutex thread safety.
+	 */
+	std::mutex	buck_mutex;
+
+	/**
 	 * @brief Inbound queue timer. The timer is called every second,
 	 * and when it wakes up it checks for requests pending to be sent in the queue.
 	 * If there are any requests and we are not waiting on rate limit, it will send them,
@@ -599,7 +604,7 @@ public:
 	 * When globally rate limited the concurrency queues associated with this request queue
 	 * will not process any requests in their timers until the global rate limit expires.
 	 */
-	bool globally_ratelimited;
+	std::atomic<bool> globally_ratelimited;
 
 	/**
 	 * @brief When we are globally rate limited until (unix epoch)

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -229,12 +229,17 @@ class DPP_EXPORT http_request {
 	/**
 	 * @brief True if request has been made.
 	 */
-	bool completed;
+	std::atomic<bool> completed;
 
 	/**
 	 * @brief True for requests that are not going to discord (rate limits code skipped).
 	 */
 	bool non_discord;
+
+	/**
+	 * @brief Client mutex
+	 */
+	std::mutex cli_mutex;
 
 	/**
 	 * @brief HTTPS client

--- a/include/dpp/queues.h
+++ b/include/dpp/queues.h
@@ -466,6 +466,11 @@ public:
 	std::shared_mutex in_mutex;
 
 	/**
+	 * @brief Removals queue mutex thread safety.
+	 */
+	std::mutex	rem_mutex;
+
+	/**
 	 * @brief Inbound queue timer. The timer is called every second,
 	 * and when it wakes up it checks for requests pending to be sent in the queue.
 	 * If there are any requests and we are not waiting on rate limit, it will send them,

--- a/src/dpp/cluster/timer.cpp
+++ b/src/dpp/cluster/timer.cpp
@@ -57,8 +57,11 @@ bool cluster::stop_timer(timer t) {
 void cluster::tick_timers() {
 	time_t now = time(nullptr);
 
-	if (next_timer.empty()) {
-		return;
+	{
+		std::lock_guard<std::mutex> l(timer_guard);
+		if (next_timer.empty()) {
+			return;
+		}
 	}
 	do {
 		timer_t cur_timer;

--- a/src/dpp/discordevents.cpp
+++ b/src/dpp/discordevents.cpp
@@ -272,6 +272,8 @@ time_t ts_not_null(const json* j, const char* keyname)
 	 * Note that discord timestamps contain a decimal seconds part, which time_t and struct tm
 	 * can't handle. We strip these out.
 	 */
+	static	std::mutex	ts_time;
+	std::lock_guard<std::mutex>	lg_time(ts_time);
 	time_t retval = 0;
 	if (j->contains(keyname) && !(*j)[keyname].is_null() && (*j)[keyname].is_string()) {
 		tm timestamp = {};

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -153,6 +153,8 @@ void populate_result(const std::string &url, cluster* owner, http_request_comple
 /* Returns true if the request has been made */
 bool http_request::is_completed()
 {
+	// For some odd reason, BSD requires this to have a lock to prevent data races even though `completed` is std::atomic.
+	std::unique_lock<std::mutex> lock(this_captured_mutex);
 	return completed;
 }
 
@@ -281,8 +283,8 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 					{
 						std::lock_guard<std::mutex> lock(this_captured_mutex);
 						this_captured = false;
+						this_captured_signal.notify_all();
 					}
-					this_captured_signal.notify_all();
 				});
 			}
 		);
@@ -317,7 +319,7 @@ request_concurrency_queue::request_concurrency_queue(class cluster* owner, class
 		tick_and_deliver_requests(in_index);
 		/* Clear pending removals in the removals queue */
 		if (time(nullptr) % 90 == 0) {
-			std::scoped_lock lock1{in_mutex};
+			std::scoped_lock lock1{rem_mutex};
 			for (auto it = removals.cbegin(); it != removals.cend();) {
 				if ((*it)->is_completed()) {
 					it = removals.erase(it);
@@ -409,6 +411,7 @@ void request_concurrency_queue::tick_and_deliver_requests(uint32_t index)
 			{
 				/* Find the owned pointer in requests_in */
 				std::scoped_lock lock1{in_mutex};
+				std::scoped_lock lock2{rem_mutex};
 
 				const std::string &key = request_view->endpoint;
 				auto [begin, end] = std::equal_range(requests_in.begin(), requests_in.end(), key, compare_request{});

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -262,7 +262,9 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 					/* We are globally rate limited - user up to shenanigans */
 					processor->requests->globally_limited_until = (newbucket.retry_after ? newbucket.retry_after : newbucket.reset_after) + newbucket.timestamp;
 				}
+				processor->buck_mutex.lock();
 				processor->buckets[this->endpoint] = newbucket;
+				processor->buck_mutex.unlock();
 
 				/* Transfer it to completed requests */
 				{
@@ -333,6 +335,8 @@ request_concurrency_queue::request_concurrency_queue(class cluster* owner, class
 
 request_concurrency_queue::~request_concurrency_queue()
 {
+	std::scoped_lock lock1{in_mutex};
+	std::lock_guard lock2{rem_mutex};
 	terminate();
 	creator->stop_timer(in_timer);
 }
@@ -379,31 +383,38 @@ void request_concurrency_queue::tick_and_deliver_requests(uint32_t index)
 		for (auto& request_view : requests_view) {
 			const std::string &key = request_view->endpoint;
 			http_request_completion_t rv;
-			auto currbucket = buckets.find(key);
 
-			if (currbucket != buckets.end()) {
-				/* There's a bucket for this request. Check its status. If the bucket says to wait,
-				 * skip all requests until the timer value indicates the rate limit won't be hit
-				 */
-				if (currbucket->second.remaining < 1) {
-					uint64_t wait = (currbucket->second.retry_after ? currbucket->second.retry_after : currbucket->second.reset_after);
-					if ((uint64_t)time(nullptr) > currbucket->second.timestamp + wait) {
-						/* Time has passed, we can process this bucket again. send its request. */
-						request_view->run(this, creator);
-					} else {
-						if (!request_view->waiting) {
-							request_view->waiting = true;
+			{
+				std::unique_lock<std::mutex>	unilock{buck_mutex};
+				auto currbucket = buckets.find(key);
+
+				if (currbucket != buckets.end()) {
+					/* There's a bucket for this request. Check its status. If the bucket says to wait,
+					 * skip all requests until the timer value indicates the rate limit won't be hit
+					 */
+					if (currbucket->second.remaining < 1) {
+						uint64_t wait = (currbucket->second.retry_after ? currbucket->second.retry_after : currbucket->second.reset_after);
+						if ((uint64_t)time(nullptr) > currbucket->second.timestamp + wait) {
+							/* Time has passed, we can process this bucket again. send its request. */
+							unilock.unlock();
+							request_view->run(this, creator);
+						} else {
+							if (!request_view->waiting) {
+								request_view->waiting = true;
+							}
+							/* Time not up yet, wait more */
+							break;
 						}
-						/* Time not up yet, wait more */
-						break;
+					} else {
+						/* We aren't at the limit, so we can just run the request */
+						unilock.unlock();
+						request_view->run(this, creator);
 					}
 				} else {
-					/* We aren't at the limit, so we can just run the request */
+					/* No bucket for this endpoint yet. Just send it, and make one from its reply */
+					unilock.unlock();
 					request_view->run(this, creator);
 				}
-			} else {
-				/* No bucket for this endpoint yet. Just send it, and make one from its reply */
-				request_view->run(this, creator);
 			}
 
 			/* Remove from inbound requests */
@@ -411,7 +422,7 @@ void request_concurrency_queue::tick_and_deliver_requests(uint32_t index)
 			{
 				/* Find the owned pointer in requests_in */
 				std::scoped_lock lock1{in_mutex};
-				std::scoped_lock lock2{rem_mutex};
+				std::lock_guard lock2{rem_mutex};
 
 				const std::string &key = request_view->endpoint;
 				auto [begin, end] = std::equal_range(requests_in.begin(), requests_in.end(), key, compare_request{});

--- a/src/dpp/queues.cpp
+++ b/src/dpp/queues.cpp
@@ -225,7 +225,7 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 	}
 	http_connect_info hci = https_client::get_host_info(_host);
 	try {
-		cli = std::make_unique<https_client>(
+		std::unique_ptr<https_client> tmp = std::make_unique<https_client>(
 			owner,
 			hci.hostname,
 			hci.port,
@@ -286,6 +286,10 @@ http_request_completion_t http_request::run(request_concurrency_queue* processor
 				});
 			}
 		);
+		{
+			std::lock_guard<std::mutex>	client(this->cli_mutex);
+			cli = std::move(tmp);
+		}
 	}
 	catch (const std::exception& e) {
 		owner->log(ll_error, "HTTP(S) error on " + hci.scheme + " connection to " + hci.hostname + ":" + std::to_string(hci.port) + ": " + std::string(e.what()));

--- a/src/dpp/socketengines/epoll.cpp
+++ b/src/dpp/socketengines/epoll.cpp
@@ -135,6 +135,7 @@ struct DPP_EXPORT socket_engine_epoll : public socket_engine_base {
 
 			if ((eh->flags & WANT_DELETION) != 0L) {
 				remove_socket(fd);
+				std::lock_guard<std::shared_mutex>	lg(this->fds_mutex);
 				fds.erase(fd);
 			}
 		}

--- a/src/dpp/socketengines/epoll.cpp
+++ b/src/dpp/socketengines/epoll.cpp
@@ -56,6 +56,7 @@ struct DPP_EXPORT socket_engine_epoll : public socket_engine_base {
 	static constexpr size_t MAX_EVENTS = 65536;
 	std::array<struct epoll_event, MAX_EVENTS> events{};
 	int sockets{0};
+	std::mutex	sockets_mutex;
 
 	socket_engine_epoll(const socket_engine_epoll&) = delete;
 	socket_engine_epoll(socket_engine_epoll&&) = delete;
@@ -144,7 +145,10 @@ struct DPP_EXPORT socket_engine_epoll : public socket_engine_base {
 
 	bool register_socket(const socket_events& e) final {
 		bool r = socket_engine_base::register_socket(e);
-		sockets++;
+		{
+			std::lock_guard	lg(sockets_mutex);
+			sockets++;
+		}
 		if (r) {
 			struct epoll_event ev{};
 			ev.events = EPOLLET;
@@ -187,7 +191,10 @@ protected:
 
 	bool remove_socket(dpp::socket fd) final {
 		struct epoll_event ev{};
-		sockets--;
+		{
+			std::lock_guard	lg(sockets_mutex);
+			sockets--;
+		}
 		epoll_ctl(epoll_handle, EPOLL_CTL_DEL, fd, &ev);
 		if (!owner->on_socket_close.empty()) {
 			socket_close_t event(owner, 0, "");

--- a/src/dpp/socketengines/kqueue.cpp
+++ b/src/dpp/socketengines/kqueue.cpp
@@ -108,6 +108,7 @@ struct DPP_EXPORT socket_engine_kqueue : public socket_engine_base {
 
 			if ((eh->flags & WANT_DELETION) != 0L) {
 				remove_socket(kev.ident);
+				std::lock_guard<std::shared_mutex>	lg(this->fds_mutex);
 				fds.erase(kev.ident);
 			}
 		}

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -61,7 +61,7 @@ namespace dpp {
 /**
  * @brief Unique ID of next socket (for end-user use)
  */
-uint64_t last_unique_id{1};
+std::atomic<uint64_t> last_unique_id{1};
 
 /**
  * @brief This is an opaque class containing openssl library specific structures.

--- a/src/dpp/thread_pool.cpp
+++ b/src/dpp/thread_pool.cpp
@@ -66,19 +66,17 @@ thread_pool::~thread_pool() {
 	{
 		std::unique_lock<std::mutex> lock(queue_mutex);
 		stop = true;
+		cv.notify_all();
 	}
 
-	cv.notify_all();
 	for (auto &thread: threads) {
 		thread.join();
 	}
 }
 
 void thread_pool::enqueue(thread_pool_task task) {
-	{
-		std::unique_lock<std::mutex> lock(queue_mutex);
-		tasks.emplace(std::move(task));
-	}
+	std::unique_lock<std::mutex> lock(queue_mutex);
+	tasks.emplace(std::move(task));
 	cv.notify_one();
 }
 


### PR DESCRIPTION
This pull request aims to fix a few recurring data races that keep happening, which I mentionned in #1476 . I have run the unit tests and they pass with 100% completion.

However, I have found a few issues with that:
- `guild_get_ban()` fails if there has not been anyone who has been banned. This does not seem to be affected by the changes in this PR directly since it fails on a clean build too.
- `channel_pins_get()` also fails if there are no pinned messages at all. Same as above.

There still is a data race happening whith a write in `dpp::request_concurrency_queue::~request_concurrency_queue()` while `dpp::thread_pool::thread_pool` is active (offending line seems to be the `task.function()` in the `try` block) which I would still like to fix, but have no clue how just yet.

I was only able to test `epoll()` and there are no more races when `fds.erase(fd)` gets called. the kqueue call does not have any thread protection, but I assume the fix is the same as `epoll()`. Since I cannot test it myself, i have left it out of this PR.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
