### PR TITLE
fix: Remove unused captures in example code

### DIFF
--- a/docpages/example_code/attachments1.cpp
+++ b/docpages/example_code/attachments1.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "file") {
 			dpp::message msg(event.command.channel_id, "Hey there, I've got a new file!");

--- a/docpages/example_code/attachments2.cpp
+++ b/docpages/example_code/attachments2.cpp
@@ -11,7 +11,7 @@ int main() {
 		if (event.command.get_command_name() == "file") {
 
 			/* Request the image from the URL specified and capture the event in a lambda. */
-			bot.request("https://dpp.dev/DPP-Logo.png", dpp::m_get, [event](const dpp::http_request_completion_t & httpRequestCompletion) {
+			bot.request("https://dpp.dev/DPP-Logo.png", dpp::m_get, [event](const dpp::http_request_completion_t& httpRequestCompletion) {
 
 				/* Create a message */
 				dpp::message msg(event.command.channel_id, "This is my new attachment:");

--- a/docpages/example_code/attachments3.cpp
+++ b/docpages/example_code/attachments3.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "file") {
 			/* Create a message. */

--- a/docpages/example_code/autocomplete.cpp
+++ b/docpages/example_code/autocomplete.cpp
@@ -23,7 +23,7 @@ int main()
 	});
 
 	/* The interaction create event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {

--- a/docpages/example_code/autocomplete.cpp
+++ b/docpages/example_code/autocomplete.cpp
@@ -6,7 +6,7 @@ int main()
 
 	bot.on_log(dpp::utility::cout_logger());
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 
 			/* Create a new global command once on ready event */
@@ -23,7 +23,7 @@ int main()
 	});
 
 	/* The interaction create event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
@@ -39,7 +39,7 @@ int main()
 	/* The on_autocomplete event is fired whenever discord needs information to fill in a command options's choices.
 	 * You must reply with a REST event within 500ms, so make it snappy!
 	 */
-	bot.on_autocomplete([&bot](const dpp::autocomplete_t & event) {
+	bot.on_autocomplete([&bot](const dpp::autocomplete_t& event) {
 		for (auto & opt : event.options) {
 			/* The option which has focused set to true is the one the user is typing in */
 			if (opt.focused) {

--- a/docpages/example_code/cache_messages.cpp
+++ b/docpages/example_code/cache_messages.cpp
@@ -23,7 +23,7 @@ int main() {
 	});
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot, &message_cache](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([&message_cache](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "get") {
 

--- a/docpages/example_code/cache_messages.cpp
+++ b/docpages/example_code/cache_messages.cpp
@@ -11,7 +11,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* Message handler */
-	bot.on_message_create([&message_cache](const dpp::message_create_t &event) {
+	bot.on_message_create([&message_cache](const dpp::message_create_t& event) {
 		/* Make a permanent pointer using new, for each message to be cached */
 		dpp::message* m = new dpp::message();
 

--- a/docpages/example_code/clearing_slashcommands.cpp
+++ b/docpages/example_code/clearing_slashcommands.cpp
@@ -7,7 +7,7 @@ int main() {
 
 	/* We won't be performing any commands, so we don't need to add the event here! */
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct clear_bot_commands>()) {
 			/* Now, we're going to wipe our commands */
 			bot.global_bulk_command_delete();

--- a/docpages/example_code/commandhandler.cpp
+++ b/docpages/example_code/commandhandler.cpp
@@ -12,7 +12,7 @@ int main() {
 	command_handler.add_prefix(".")
 		.add_prefix("/");
 
-	bot.on_ready([&command_handler](const dpp::ready_t &event) {
+	bot.on_ready([&command_handler](const dpp::ready_t& event) {
 
 		command_handler.add_command(
 			/* Command name */

--- a/docpages/example_code/components.cpp
+++ b/docpages/example_code/components.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "button") {
 			/* Create a message */
@@ -33,7 +33,7 @@ int main() {
 	/* When a user clicks your button, the on_button_click event will fire,
 	 * containing the custom_id you defined in your button.
 	 */
-	bot.on_button_click([&bot](const dpp::button_click_t& event) {
+	bot.on_button_click([](const dpp::button_click_t& event) {
 		/* Button clicks are still interactions, and must be replied to in some form to
 		 * prevent the "this interaction has failed" message from Discord to the user.
  		 */

--- a/docpages/example_code/components2.cpp
+++ b/docpages/example_code/components2.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "math") {
 
@@ -40,7 +40,7 @@ int main() {
 		}
 	});
 
-	bot.on_button_click([&bot](const dpp::button_click_t & event) {
+	bot.on_button_click([](const dpp::button_click_t & event) {
 		if (event.custom_id == "10") {
 			event.reply(dpp::message("You got it right!").set_flags(dpp::m_ephemeral));
 		} else {

--- a/docpages/example_code/components2.cpp
+++ b/docpages/example_code/components2.cpp
@@ -40,7 +40,7 @@ int main() {
 		}
 	});
 
-	bot.on_button_click([](const dpp::button_click_t & event) {
+	bot.on_button_click([](const dpp::button_click_t& event) {
 		if (event.custom_id == "10") {
 			event.reply(dpp::message("You got it right!").set_flags(dpp::m_ephemeral));
 		} else {

--- a/docpages/example_code/components3.cpp
+++ b/docpages/example_code/components3.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "select") {
 			/* Create a message */
@@ -33,7 +33,7 @@ int main() {
 	/* When a user clicks your select menu , the on_select_click event will fire,
 	 * containing the custom_id you defined in your select menu.
 	 */
-	bot.on_select_click([&bot](const dpp::select_click_t & event) {
+	bot.on_select_click([](const dpp::select_click_t & event) {
 		/* Select clicks are still interactions, and must be replied to in some form to
 		 * prevent the "this interaction has failed" message from Discord to the user.
 		 */

--- a/docpages/example_code/components3.cpp
+++ b/docpages/example_code/components3.cpp
@@ -33,7 +33,7 @@ int main() {
 	/* When a user clicks your select menu , the on_select_click event will fire,
 	 * containing the custom_id you defined in your select menu.
 	 */
-	bot.on_select_click([](const dpp::select_click_t & event) {
+	bot.on_select_click([](const dpp::select_click_t& event) {
 		/* Select clicks are still interactions, and must be replied to in some form to
 		 * prevent the "this interaction has failed" message from Discord to the user.
 		 */

--- a/docpages/example_code/components3_rolemenu.cpp
+++ b/docpages/example_code/components3_rolemenu.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "select") {
 			/* Create a message */

--- a/docpages/example_code/context_menus.cpp
+++ b/docpages/example_code/context_menus.cpp
@@ -18,7 +18,7 @@ int main()
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t &event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create the command */
 			dpp::slashcommand command;

--- a/docpages/example_code/coro_expiring_buttons.cpp
+++ b/docpages/example_code/coro_expiring_buttons.cpp
@@ -21,7 +21,7 @@ int main() {
 			co_await event.co_reply(m);
 
 			auto result = co_await dpp::when_any{ // Whichever completes first...
-				event.owner->on_button_click.when([&id](const dpp::button_click_t &b) { // Button clicked
+				event.owner->on_button_click.when([&id](const dpp::button_click_t& b) { // Button clicked
 					return b.custom_id == id;
 				}),
 				event.owner->co_sleep(5) // Or sleep 5 seconds
@@ -29,7 +29,7 @@ int main() {
 			// Note!! Due to a bug in g++11 and g++12, id must be captured as a reference above or the compiler will destroy it twice. This is fixed in g++13
 			if (result.index() == 0) { // Awaitable #0 completed first, that is the button click event
 				// Acknowledge the click and edit the original response, removing the button
-				const dpp::button_click_t &click_event = result.get<0>();
+				const dpp::button_click_t& click_event = result.get<0>();
 				click_event.reply();
 				event.edit_original_response(dpp::message{"You clicked the button with the id " + click_event.custom_id});
 			} else { // Here index() is 1, the timer expired

--- a/docpages/example_code/coro_simple_commands2.cpp
+++ b/docpages/example_code/coro_simple_commands2.cpp
@@ -8,7 +8,7 @@ int main() {
 	bot.on_slashcommand([](const dpp::slashcommand_t& event) -> dpp::task<void> {
 		if (event.command.get_command_name() == "avatar") {
 			// Make a nested coroutine to fetch the guild member requested, that returns it as an optional
-			constexpr auto resolve_member = [](const dpp::slashcommand_t &event) -> dpp::task<std::optional<dpp::guild_member>> {
+			constexpr auto resolve_member = [](const dpp::slashcommand_t& event) -> dpp::task<std::optional<dpp::guild_member>> {
 				const dpp::command_value &user_param = event.get_parameter("user");
 				dpp::snowflake user_id;
 				if (std::holds_alternative<std::monostate>(user_param)) {

--- a/docpages/example_code/default_select_value.cpp
+++ b/docpages/example_code/default_select_value.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 	
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "select") {
 			/* Create a message */

--- a/docpages/example_code/detecting_messages.cpp
+++ b/docpages/example_code/detecting_messages.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when the bot detects a message in any server and any channel it has access to. */
-	bot.on_message_create([&bot](const dpp::message_create_t& event) {
+	bot.on_message_create([](const dpp::message_create_t& event) {
 		/* See if the message contains the phrase we want to check for.
 		 * If there's at least a single match, we reply and say it's not allowed.
 		 */

--- a/docpages/example_code/editing_message_after_click.cpp
+++ b/docpages/example_code/editing_message_after_click.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "button") {
 			/* Create a message */
@@ -33,7 +33,7 @@ int main() {
 	/* When a user clicks your button, the on_button_click event will fire,
 	 * containing the custom_id you defined in your button.
 	 */
-	bot.on_button_click([&bot](const dpp::button_click_t& event) {
+	bot.on_button_click([](const dpp::button_click_t& event) {
 		/* Instead of replying to the button click itself,
 		 * we want to update the message that had the buttons on it.
 		 */

--- a/docpages/example_code/editing_message_after_click2.cpp
+++ b/docpages/example_code/editing_message_after_click2.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "button") {
 			/* Create a message */
@@ -33,7 +33,7 @@ int main() {
 	/* When a user clicks your button, the on_button_click event will fire,
 	 * containing the custom_id you defined in your button.
 	 */
-	bot.on_button_click([&bot](const dpp::button_click_t& event) {
+	bot.on_button_click([](const dpp::button_click_t& event) {
 		/* Instead of replying to the button click itself,
 		 * we want to update the message that had the buttons on it.
 		 */

--- a/docpages/example_code/embeds.cpp
+++ b/docpages/example_code/embeds.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "embed") {
 			/* Create an embed */

--- a/docpages/example_code/ephemeral.cpp
+++ b/docpages/example_code/ephemeral.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "hello") {
 			/* Reply to the user, but only let them see the response. */

--- a/docpages/example_code/ephemeral.cpp
+++ b/docpages/example_code/ephemeral.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "hello") {
 			/* Reply to the user, but only let them see the response. */
@@ -15,7 +15,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create and Register the command */
 			bot.global_command_create(dpp::slashcommand("hello", "Hello there!", bot.me.id));

--- a/docpages/example_code/eval.cpp
+++ b/docpages/example_code/eval.cpp
@@ -75,7 +75,7 @@ int main() {
 			 * This code assumes the current directory is writeable. The file will have a
 			 * unique name made from the user's id and the message id.
 			 */
-        		std::string source_filename = std::to_string(event.msg.author.id) + "_" + std::to_string(event.msg.id) + ".cpp";
+			std::string source_filename = std::to_string(event.msg.author.id) + "_" + std::to_string(event.msg.id) + ".cpp";
 			std::fstream code_file(source_filename, std::fstream::binary | std::fstream::out);
 			if (!code_file.is_open()) {
 				bot.message_create(dpp::message(event.msg.channel_id, "Unable to create source file for `eval`"));
@@ -96,7 +96,7 @@ int main() {
 				std::to_string(event.msg.author.id) + "_" + std::to_string(event.msg.id) + ".cpp",
 				"-ldpp",
 				"-ldl"
-			}, [event, &bot, source_filename, compile_start](const std::string &output) {
+			}, [event, &bot, compile_start](const std::string &output) {
 
 				/* After g++ is ran we end up inside this lambda with the output as a string */
 				double compile_time = dpp::utility::time_f() - compile_start;

--- a/docpages/example_code/eval.h
+++ b/docpages/example_code/eval.h
@@ -3,7 +3,7 @@
 /* This is the snowflake ID of the bot's developer.
  * The eval command will be restricted to this user.
  */
-#define MY_DEVELOPER 189759562910400512ULL
+constexpr unsigned long long MY_DEVELOPER = 189759562910400512ULL;
 
 /* Any functions you want to be usable from within an eval,
  * that are not part of D++ itself or the message event, you

--- a/docpages/example_code/http_request.cpp
+++ b/docpages/example_code/http_request.cpp
@@ -11,7 +11,7 @@ int main() {
 		std::string mypostdata = "{\"value\": 42}";
 		// Make a HTTP POST request. HTTP and HTTPS are supported here.
 		bot.request(
-			"http://www.somebotlist.com/api/servers", dpp::m_post, [](const dpp::http_request_completion_t & cc) {
+			"http://www.somebotlist.com/api/servers", dpp::m_post, [](const dpp::http_request_completion_t& cc) {
 				// This callback is called when the HTTP request completes. See documentation of
 				// dpp::http_request_completion_t for information on the fields in the parameter.
 				std::cout << "I got reply: " << cc.body << " with HTTP status code: " << cc.status << "\n";

--- a/docpages/example_code/join_voice.cpp
+++ b/docpages/example_code/join_voice.cpp
@@ -9,7 +9,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {

--- a/docpages/example_code/join_voice.cpp
+++ b/docpages/example_code/join_voice.cpp
@@ -71,7 +71,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			bot.global_command_create(dpp::slashcommand("join", "Joins your voice channel.", bot.me.id));

--- a/docpages/example_code/making_threads2.cpp
+++ b/docpages/example_code/making_threads2.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when the bot detects a message in any server and any channel it has access to. */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "message-thread") {
 			/* Get all active threads in a guild. */

--- a/docpages/example_code/modal_dialog_interactions.cpp
+++ b/docpages/example_code/modal_dialog_interactions.cpp
@@ -6,7 +6,7 @@ int main() {
 
 	bot.on_log(dpp::utility::cout_logger());
 
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check for our /dialog command */
 		if (event.command.get_command_name() == "dialog") {
 			/* Instantiate an interaction_modal_response object */

--- a/docpages/example_code/modal_dialog_interactions.cpp
+++ b/docpages/example_code/modal_dialog_interactions.cpp
@@ -39,7 +39,7 @@ int main() {
 	});
 
 	/* This event handles form submission for the modal dialog we create above */
-	bot.on_form_submit([](const dpp::form_submit_t & event) {
+	bot.on_form_submit([](const dpp::form_submit_t& event) {
 		/* For this simple example, we know the elements value type is string.
 		 * We also know the indices of each element.
 		 * In the real world, it may not be safe to make such assumptions!
@@ -58,7 +58,7 @@ int main() {
 		event.reply(m);
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a slash command and register it as a global command */
 			bot.global_command_create(dpp::slashcommand("dialog", "Make a modal dialog box", bot.me.id));

--- a/docpages/example_code/mp3.cpp
+++ b/docpages/example_code/mp3.cpp
@@ -59,7 +59,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot, &pcmdata](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([&pcmdata](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {
 			/* Get the guild */

--- a/docpages/example_code/mp3.cpp
+++ b/docpages/example_code/mp3.cpp
@@ -90,7 +90,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);

--- a/docpages/example_code/oggopus.cpp
+++ b/docpages/example_code/oggopus.cpp
@@ -20,7 +20,7 @@ int main(int argc, char const *argv[]) {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {

--- a/docpages/example_code/oggopus.cpp
+++ b/docpages/example_code/oggopus.cpp
@@ -7,7 +7,7 @@
 #include <ogg/ogg.h>
 #include <opus/opusfile.h>
 
-int main(int argc, char const *argv[]) {
+int main() {
 	/* Load an ogg opus file into memory.
 	 * The bot expects opus packets to be 2 channel stereo, 48000Hz.
 	 * 
@@ -155,7 +155,7 @@ int main(int argc, char const *argv[]) {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);

--- a/docpages/example_code/oggopus2.cpp
+++ b/docpages/example_code/oggopus2.cpp
@@ -20,7 +20,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {

--- a/docpages/example_code/oggopus2.cpp
+++ b/docpages/example_code/oggopus2.cpp
@@ -97,7 +97,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);

--- a/docpages/example_code/private_messaging.cpp
+++ b/docpages/example_code/private_messaging.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "pm") {
 			dpp::snowflake user;

--- a/docpages/example_code/record_user.cpp
+++ b/docpages/example_code/record_user.cpp
@@ -21,7 +21,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot, &fd](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([&fd](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "record") {
 			/* Get the guild */
@@ -43,7 +43,7 @@ int main() {
 		}
 	});
 
-	bot.on_voice_receive([&bot, &fd, &user_id](const dpp::voice_receive_t &event) {
+	bot.on_voice_receive([&fd, &user_id](const dpp::voice_receive_t &event) {
 		if (event.user_id == user_id) {
 			fwrite((char *)event.audio, 1, event.audio_size, fd);
 		}

--- a/docpages/example_code/record_user.cpp
+++ b/docpages/example_code/record_user.cpp
@@ -43,13 +43,13 @@ int main() {
 		}
 	});
 
-	bot.on_voice_receive([&fd, &user_id](const dpp::voice_receive_t &event) {
+	bot.on_voice_receive([&fd, &user_id](const dpp::voice_receive_t& event) {
 		if (event.user_id == user_id) {
 			fwrite((char *)event.audio, 1, event.audio_size, fd);
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand recordcommand("record", "Joins your voice channel and records you.", bot.me.id);

--- a/docpages/example_code/slashcommands1.cpp
+++ b/docpages/example_code/slashcommands1.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
 			/* Fetch a parameter value from the command parameters */

--- a/docpages/example_code/slashcommands1.cpp
+++ b/docpages/example_code/slashcommands1.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
 			/* Fetch a parameter value from the command parameters */
@@ -19,7 +19,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new global command on ready event */
 			dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);

--- a/docpages/example_code/slashcommands2.cpp
+++ b/docpages/example_code/slashcommands2.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
 			/* Fetch a parameter value from the command parameters */

--- a/docpages/example_code/slashcommands2.cpp
+++ b/docpages/example_code/slashcommands2.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "blep") {
 			/* Fetch a parameter value from the command parameters */
@@ -19,7 +19,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new global command on ready event */
 			dpp::slashcommand newcommand("blep", "Send a random adorable animal photo", bot.me.id);

--- a/docpages/example_code/slashcommands3.cpp
+++ b/docpages/example_code/slashcommands3.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");

--- a/docpages/example_code/slashcommands3.cpp
+++ b/docpages/example_code/slashcommands3.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");
@@ -19,7 +19,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create some commands */
 			dpp::slashcommand pingcommand("ping", "Pong!", bot.me.id);

--- a/docpages/example_code/slashcommands4.cpp
+++ b/docpages/example_code/slashcommands4.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");

--- a/docpages/example_code/slashcommands4.cpp
+++ b/docpages/example_code/slashcommands4.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "ping") {
 			event.reply("Pong!");
@@ -19,7 +19,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create some commands */
 			dpp::slashcommand pingcommand("ping", "Pong!", bot.me.id);

--- a/docpages/example_code/soundboard.cpp
+++ b/docpages/example_code/soundboard.cpp
@@ -31,7 +31,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot, robot, robot_size](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([robot, robot_size](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "join") {
 			/* Get the guild */

--- a/docpages/example_code/soundboard.cpp
+++ b/docpages/example_code/soundboard.cpp
@@ -16,7 +16,7 @@ int main() {
 	 */
 	uint8_t* robot = nullptr;
 	size_t robot_size = 0;
-	std::ifstream input ("../testdata/Robot.pcm", std::ios::in|std::ios::binary|std::ios::ate);
+	std::ifstream input ("../testdata/Robot.pcm", std::ios::in | std::ios::binary | std::ios::ate);
 	if (input.is_open()) {
 		robot_size = input.tellg();
 		robot = new uint8_t[robot_size];
@@ -62,7 +62,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand joincommand("join", "Joins your voice channel.", bot.me.id);

--- a/docpages/example_code/subcommands.cpp
+++ b/docpages/example_code/subcommands.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* Use the on_slashcommand event to look for commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
 		dpp::command_interaction cmd_data = event.command.get_command_interaction();
 
 		/* Check if the command is the image command. */

--- a/docpages/example_code/subcommands.cpp
+++ b/docpages/example_code/subcommands.cpp
@@ -7,7 +7,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* Use the on_slashcommand event to look for commands */
-	bot.on_slashcommand([](const dpp::slashcommand_t & event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		dpp::command_interaction cmd_data = event.command.get_command_interaction();
 
 		/* Check if the command is the image command. */
@@ -40,7 +40,7 @@ int main() {
 	});
 
 	/* Executes on ready. */
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Define a slash command. */
 			dpp::slashcommand image("image", "Send a specific image.", bot.me.id);

--- a/docpages/example_code/thinking.cpp
+++ b/docpages/example_code/thinking.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "thinking") {
 			/*

--- a/docpages/example_code/upload_parameter.cpp
+++ b/docpages/example_code/upload_parameter.cpp
@@ -6,7 +6,7 @@ int main() {
 	bot.on_log(dpp::utility::cout_logger());
 
 	/* The event is fired when someone issues your commands */
-	bot.on_slashcommand([&bot](const dpp::slashcommand_t& event) {
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
 		/* Check which command they ran */
 		if (event.command.get_command_name() == "show") {
 			/* Get the file id from the parameter attachment. */

--- a/docpages/example_code/upload_parameter.cpp
+++ b/docpages/example_code/upload_parameter.cpp
@@ -20,7 +20,7 @@ int main() {
 		}
 	});
 
-	bot.on_ready([&bot](const dpp::ready_t & event) {
+	bot.on_ready([&bot](const dpp::ready_t& event) {
 		if (dpp::run_once<struct register_bot_commands>()) {
 			/* Create a new command. */
 			dpp::slashcommand newcommand("show", "Show an uploaded file", bot.me.id);


### PR DESCRIPTION
This PR removes unused captures from lambdas, which should resolve some previous warnings during example builds.

Additionally, I have changed the alignments of the ampersand to be on the left, to be consistent with most examples (which do this already; the code examples would sometimes use three different alignments in the same file).

This continues to decrease the surface area of #1530.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
