### PR TITLE
fix: voice session reconnect

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/include/dpp/cluster.h
+++ b/include/dpp/cluster.h
@@ -576,9 +576,9 @@ public:
 	/**
 	 * @brief Get the list of shards
 	 *
-	 * @return shard_list map of shards for this cluster
+	 * @return const shard_list& map of shards for this cluster
 	 */
-	shard_list get_shards() const;
+	const shard_list& get_shards() const;
 
 	/**
 	 * @brief Sets the request timeout.

--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -228,7 +228,7 @@ public:
 	 */
 	bool is_active() const;
 
-	voiceconn& request();
+	voiceconn& request(bool failed_resume = false);
 
 	/**
 	 * @brief Create websocket object and connect it.

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -50,7 +50,7 @@ namespace dpp {
 /**
  * @brief A list of shards
  */
-typedef std::map<uint32_t, class discord_client*> shard_list;
+typedef std::map<uint32_t, std::unique_ptr<class discord_client>> shard_list;
 
 /**
  * @brief List of shards awaiting reconnection, by id with earliest possible reconnect time

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -143,6 +143,14 @@ protected:
 	openssl_connection* ssl;
 
 	/**
+	 * @brief Protects openssl opaque contexts when closing
+	 *
+	 * There's data races when reconnecting severed connection.
+	 * This makes sure we don't double free our contexts.
+	 */
+	std::mutex ssl_close_mutex;
+
+	/**
 	 * @brief SSL cipher in use
 	 */
 	std::string cipher;

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -150,14 +150,6 @@ protected:
 	openssl_connection* ssl;
 
 	/**
-	 * @brief Protects openssl opaque contexts when closing
-	 *
-	 * There's data races when reconnecting severed connection.
-	 * This makes sure we don't double free our contexts.
-	 */
-	std::mutex ssl_close_mutex;
-
-	/**
 	 * @brief SSL cipher in use
 	 */
 	std::string cipher;

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -97,13 +97,6 @@ private:
 	std::mutex out_mutex;
 
 	/**
-	 * @brief Event handlers mutex
-	 *
-	 * Only one thread can call event handlers at a time
-	 */
-	std::mutex event_mutex;
-
-	/**
 	 * @brief Start offset into internal ring buffer for client to server IO
 	 */
 	size_t client_to_server_length = 0;
@@ -148,6 +141,14 @@ protected:
 	 * @brief Openssl opaque contexts
 	 */
 	openssl_connection* ssl;
+
+	/**
+	 * @brief Protects openssl opaque contexts when closing
+	 *
+	 * There's data races when reconnecting severed connection.
+	 * This makes sure we don't double free our contexts.
+	 */
+	std::mutex ssl_close_mutex;
 
 	/**
 	 * @brief SSL cipher in use

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -97,6 +97,13 @@ private:
 	std::mutex out_mutex;
 
 	/**
+	 * @brief Event handlers mutex
+	 *
+	 * Only one thread can call event handlers at a time
+	 */
+	std::mutex event_mutex;
+
+	/**
 	 * @brief Start offset into internal ring buffer for client to server IO
 	 */
 	size_t client_to_server_length = 0;
@@ -141,14 +148,6 @@ protected:
 	 * @brief Openssl opaque contexts
 	 */
 	openssl_connection* ssl;
-
-	/**
-	 * @brief Protects openssl opaque contexts when closing
-	 *
-	 * There's data races when reconnecting severed connection.
-	 * This makes sure we don't double free our contexts.
-	 */
-	std::mutex ssl_close_mutex;
 
 	/**
 	 * @brief SSL cipher in use

--- a/include/dpp/sslconnection.h
+++ b/include/dpp/sslconnection.h
@@ -150,6 +150,14 @@ protected:
 	openssl_connection* ssl;
 
 	/**
+	 * @brief Protects openssl opaque contexts when closing
+	 *
+	 * There's data races when reconnecting severed connection.
+	 * This makes sure we don't double free our contexts.
+	 */
+	std::mutex ssl_close_mutex;
+
+	/**
 	 * @brief SSL cipher in use
 	 */
 	std::string cipher;

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -249,12 +249,12 @@ void cluster::start(start_type return_after) {
 							auto session_id = old->sessionid;
 
 							log(ll_trace, "Attempting resume...");
-							shards.erase(shard_id);
+							shards[shard_id] = nullptr;
 							shards[shard_id] = new discord_client(*old, seq_no, session_id);
 							resume = true;
 						} else {
 							log(ll_trace, "Attempting full reconnection...");
-							shards.erase(shard_id);
+							shards[shard_id] = nullptr;
 							shards[shard_id] = new discord_client(this, shard_id, numshards, token, intents, compressed, ws_mode);
 						}
 						/* Delete the old one */
@@ -279,7 +279,7 @@ void cluster::start(start_type return_after) {
 						delete shards[shard_id];
 						delete old;
 						old = nullptr;
-						shards.erase(shard_id);
+						shards[shard_id] = nullptr;
 						add_reconnect(shard_id);
 					}
 					/* It is not possible to reconnect another shard within the same 5-second window,

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -231,17 +231,17 @@ void cluster::start(start_type return_after) {
 				if (now >= shard_reconnect_time) {
 					/* This shard needs to be reconnected */
 					reconnections.erase(reconnect);
-					discord_client* old = nullptr;
+					std::unique_ptr<discord_client> old = nullptr;
 					{
 						std::shared_lock lk(shards_mutex);
-						old = shards[shard_id];
+						old = std::move(shards[shard_id]);
 					}
 					log(ll_info, "Reconnecting shard " + std::to_string(shard_id));
 					/* Make a new resumed connection based off the old one */
 					try {
 						bool resume = false;
 						std::unique_lock lk(shards_mutex);
-						if (shards[shard_id] != nullptr) {
+						if (old != nullptr) {
 							/* These values must be copied to the new connection
 							 * to attempt to resume it
 							 */
@@ -250,16 +250,16 @@ void cluster::start(start_type return_after) {
 
 							log(ll_trace, "Attempting resume...");
 							shards[shard_id] = nullptr;
-							shards[shard_id] = new discord_client(*old, seq_no, session_id);
+							shards[shard_id] = std::make_unique<class discord_client>(*old, seq_no, session_id);
 							resume = true;
 						} else {
 							log(ll_trace, "Attempting full reconnection...");
 							shards[shard_id] = nullptr;
-							shards[shard_id] = new discord_client(this, shard_id, numshards, token, intents, compressed, ws_mode);
+							shards[shard_id] = std::make_unique<class discord_client>(this, shard_id, numshards, token, intents, compressed, ws_mode);
 						}
 						/* Delete the old one */
 						log(ll_trace, "Attempting to delete old connection...");
-						delete old;
+						old.reset();
 						old = nullptr;
 						/* Set up the new shard's IO events */
 						log(ll_trace, "Running new connection...");
@@ -276,8 +276,8 @@ void cluster::start(start_type return_after) {
 					catch (const std::exception& e) {
 						std::unique_lock lk(shards_mutex);
 						log(ll_info, "Exception when reconnecting shard " + std::to_string(shard_id) + ": " + std::string(e.what()));
-						delete shards[shard_id];
-						delete old;
+						shards[shard_id].reset();
+						old.reset();
 						old = nullptr;
 						shards[shard_id] = nullptr;
 						add_reconnect(shard_id);
@@ -361,7 +361,7 @@ void cluster::start(start_type return_after) {
 					/* Each discord_client is inserted into the socket engine when we call run() */
 					try {
 						std::unique_lock lk(shards_mutex);
-						this->shards[s] = new discord_client(this, s, numshards, token, intents, compressed, ws_mode);
+						this->shards[s] = std::make_unique<class discord_client>(this, s, numshards, token, intents, compressed, ws_mode);
 						this->shards[s]->run();
 					}
 					catch (const std::exception &e) {
@@ -478,8 +478,8 @@ void cluster::shutdown() {
 
 	std::unique_lock lk(shards_mutex);
 	/* Terminate shards */
-	for (const auto& sh : shards) {
-		delete sh.second;
+	for (auto& sh : shards) {
+		sh.second.reset();
 	}
 	shards.clear();
 }
@@ -636,12 +636,13 @@ discord_client* cluster::get_shard(uint32_t id) const {
 	std::shared_lock lk(shards_mutex);
 	auto i = shards.find(id);
 	if (i != shards.end()) {
-		return i->second;
+		/* How do we tell user when the shard is going to be deleted? */
+		return i->second.get();
 	}
 	return nullptr;
 }
 
-shard_list cluster::get_shards() const {
+const shard_list& cluster::get_shards() const {
 	std::shared_lock lk(shards_mutex);
 	return shards;
 }

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -236,19 +236,22 @@ void cluster::start(start_type return_after) {
 						std::shared_lock lk(shards_mutex);
 						old = shards[shard_id];
 					}
-					/* These values must be copied to the new connection
-					 * to attempt to resume it
-					 */
-					auto seq_no = old->last_seq;
-					auto session_id = old->sessionid;
 					log(ll_info, "Reconnecting shard " + std::to_string(shard_id));
 					/* Make a new resumed connection based off the old one */
 					try {
+						bool resume = false;
 						std::unique_lock lk(shards_mutex);
 						if (shards[shard_id] != nullptr) {
+							/* These values must be copied to the new connection
+							 * to attempt to resume it
+							 */
+							auto seq_no = old->last_seq;
+							auto session_id = old->sessionid;
+
 							log(ll_trace, "Attempting resume...");
 							shards[shard_id] = nullptr;
 							shards[shard_id] = new discord_client(*old, seq_no, session_id);
+							resume = true;
 						} else {
 							log(ll_trace, "Attempting full reconnection...");
 							shards[shard_id] = nullptr;
@@ -260,6 +263,14 @@ void cluster::start(start_type return_after) {
 						old = nullptr;
 						/* Set up the new shard's IO events */
 						log(ll_trace, "Running new connection...");
+						if (resume) {
+							/* Start connecting only after the old client is destroyed */
+							shards[shard_id]->start_connecting();
+							std::unique_lock lock(shards[shard_id]->voice_mutex);
+							for (auto &c : shards[shard_id]->connecting_voice_channels) {
+								c.second->connect();
+							}
+						}
 						shards[shard_id]->run();
 					}
 					catch (const std::exception& e) {

--- a/src/dpp/cluster.cpp
+++ b/src/dpp/cluster.cpp
@@ -249,12 +249,12 @@ void cluster::start(start_type return_after) {
 							auto session_id = old->sessionid;
 
 							log(ll_trace, "Attempting resume...");
-							shards[shard_id] = nullptr;
+							shards.erase(shard_id);
 							shards[shard_id] = new discord_client(*old, seq_no, session_id);
 							resume = true;
 						} else {
 							log(ll_trace, "Attempting full reconnection...");
-							shards[shard_id] = nullptr;
+							shards.erase(shard_id);
 							shards[shard_id] = new discord_client(this, shard_id, numshards, token, intents, compressed, ws_mode);
 						}
 						/* Delete the old one */
@@ -279,7 +279,7 @@ void cluster::start(start_type return_after) {
 						delete shards[shard_id];
 						delete old;
 						old = nullptr;
-						shards[shard_id] = nullptr;
+						shards.erase(shard_id);
 						add_reconnect(shard_id);
 					}
 					/* It is not possible to reconnect another shard within the same 5-second window,

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -3,7 +3,7 @@
  * D++, A Lightweight C++ library for Discord
  *
  * SPDX-License-Identifier: Apache-2.0
-#include <dpp/zlibcontext.h> * Copyright 2021 Craig Edwards and D++ contributors
+ * Copyright 2021 Craig Edwards and D++ contributors
  * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@
 #include <dpp/json.h>
 #include <dpp/etf.h>
 #include <utility>
+#include <dpp/zlibcontext.h>
 
 #define PATH_UNCOMPRESSED_JSON "/?v=" DISCORD_API_VERSION "&encoding=json"
 #define PATH_COMPRESSED_JSON "/?v=" DISCORD_API_VERSION "&encoding=json&compress=zlib-stream"

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -126,8 +126,10 @@ void discord_client::on_disconnect()
 	set_resume_hostname();
 	if (sfd != INVALID_SOCKET) {
 		log(dpp::ll_debug, "Lost connection to websocket on shard " + std::to_string(shard_id) + ", reconnecting...");
+		sfd = INVALID_SOCKET;
 	}
 	ssl_connection::close();
+	owner->stop_timer(timer_handle);
 	owner->add_reconnect(this->shard_id);
 }
 

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -127,6 +127,7 @@ void discord_client::on_disconnect()
 		log(dpp::ll_debug, "Lost connection to websocket on shard " + std::to_string(shard_id) + ", reconnecting...");
 	}
 	ssl_connection::close();
+	owner->stop_timer(timer_handle);
 	owner->add_reconnect(this->shard_id);
 }
 

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -79,7 +79,6 @@ discord_client::discord_client(discord_client &old, uint64_t sequence, const std
 	for (auto& [shard_id, vconn] : connecting_voice_channels) {
 		vconn->reassign_owner(this);
 	}
-	start_connecting();
 }
 
 discord_client::discord_client(dpp::cluster* _cluster, uint32_t _shard_id, uint32_t _max_shards, const std::string &_token, uint32_t _intents, bool comp, websocket_protocol_t ws_proto)
@@ -607,10 +606,15 @@ voiceconn::~voiceconn() {
 	this->disconnect();
 }
 
-voiceconn& voiceconn::request() {
-	this->token.clear();
-	this->session_id.clear();
-	this->websocket_hostname.clear();
+voiceconn& voiceconn::request(bool failed_resume) {
+	/* Creating new connection from previously failed Opcode 7 Resume doesn't guarantee */
+	/* to receive voice_state_update AND voice_server_update event */
+	/* Keep previous session data so we can reconnect */
+	if (!failed_resume) {
+		this->token.clear();
+		this->session_id.clear();
+		this->websocket_hostname.clear();
+	}
 	this->voiceclient.reset();
 
 	this->request_callback(this->creator);
@@ -623,7 +627,7 @@ voiceconn& voiceconn::connect() {
 			this->creator->log(ll_debug, "Connecting voice for guild " + std::to_string(this->guild_id) + " channel " + std::to_string(this->channel_id));
 			full_reconnection_callback_t reconnection_callback = [weak_this=weak_from_this()] {
 			if (std::shared_ptr<voiceconn> strong_this = weak_this.lock()) {
-				strong_this->request();
+				strong_this->request(true);
 			}
 		};
 		this->voiceclient = std::make_unique<discord_voice_client>(creator->creator, std::move(reconnection_callback), this->channel_id, this->guild_id, this->token, this->session_id, this->websocket_hostname, this->dave);

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -126,7 +126,7 @@ void discord_client::on_disconnect()
 	set_resume_hostname();
 	if (sfd != INVALID_SOCKET) {
 		log(dpp::ll_debug, "Lost connection to websocket on shard " + std::to_string(shard_id) + ", reconnecting...");
-		owner->socketengine->delete_socket(sfd);
+		sfd = INVALID_SOCKET;
 	}
 	ssl_connection::close();
 	owner->stop_timer(timer_handle);

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -125,6 +125,7 @@ void discord_client::on_disconnect()
 	set_resume_hostname();
 	if (sfd != INVALID_SOCKET) {
 		log(dpp::ll_debug, "Lost connection to websocket on shard " + std::to_string(shard_id) + ", reconnecting...");
+		owner->socketengine->delete_socket(sfd);
 	}
 	ssl_connection::close();
 	owner->stop_timer(timer_handle);

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -126,10 +126,8 @@ void discord_client::on_disconnect()
 	set_resume_hostname();
 	if (sfd != INVALID_SOCKET) {
 		log(dpp::ll_debug, "Lost connection to websocket on shard " + std::to_string(shard_id) + ", reconnecting...");
-		sfd = INVALID_SOCKET;
 	}
 	ssl_connection::close();
-	owner->stop_timer(timer_handle);
 	owner->add_reconnect(this->shard_id);
 }
 

--- a/src/dpp/events/voice_state_update.cpp
+++ b/src/dpp/events/voice_state_update.cpp
@@ -83,6 +83,8 @@ void voice_state_update::handle(discord_client* client, json &j, const std::stri
 					[](discord_client* client) {
 						/* do nothing, discord will handle reconnection*/
 					}, vsu.state.guild_id, vsu.state.channel_id, enable_dave);
+				/* Should set the session_id here, did this ever work before without setting session_id?? */
+				client->connecting_voice_channels[vsu.state.guild_id]->session_id = vsu.state.session_id;
 			}
 		} else {
 			std::shared_lock lock(client->voice_mutex);

--- a/src/dpp/socketengine.cpp
+++ b/src/dpp/socketengine.cpp
@@ -136,6 +136,8 @@ bool socket_engine_base::delete_socket(dpp::socket fd) {
 	if (iter == fds.end() || ((iter->second->flags & WANT_DELETION) != 0L)) {
 		return false;
 	}
+	/* Remove any other flag to let the engine delete it immediately */
+	iter->second->flags &= ~(WANT_WRITE | WANT_READ | WANT_ERROR);
 	iter->second->flags |= WANT_DELETION;
 	stats.deletions++;
 	stats.active_fds--;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -680,6 +680,7 @@ void ssl_connection::close() {
 	 * that is done often.
 	 */
 	if (!plaintext) {
+		std::unique_lock lock(ssl_close_mutex);
 		if (ssl != nullptr && ssl->ssl != nullptr) {
 			SSL_free(ssl->ssl);
 			ssl->ssl = nullptr;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -684,6 +684,7 @@ void ssl_connection::close() {
 	 * that is done often.
 	 */
 	if (!plaintext) {
+		std::unique_lock lock(ssl_close_mutex);
 		if (ssl != nullptr && ssl->ssl != nullptr) {
 			SSL_free(ssl->ssl);
 			ssl->ssl = nullptr;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -21,7 +21,6 @@
  ************************************************************************************/
 #include <dpp/export.h>
 #include <cerrno>
-#include <mutex>
 #ifdef _WIN32
 	/* Windows-specific sockets includes */
 	#include <WinSock2.h>
@@ -611,7 +610,6 @@ void ssl_connection::read_loop() {
 			sfd,
 			WANT_READ | WANT_WRITE | WANT_ERROR,
 			[this](socket fd, const struct socket_events &e) {
-				std::unique_lock lock(event_mutex);
 				if (this->sfd == INVALID_SOCKET) {
 					close_socket(fd);
 					owner->socketengine->delete_socket(fd);
@@ -620,7 +618,6 @@ void ssl_connection::read_loop() {
 				on_read(fd, e);
 			},
 			[this](socket fd, const struct socket_events &e) {
-				std::unique_lock lock(event_mutex);
 				if (this->sfd == INVALID_SOCKET) {
 					close_socket(fd);
 					owner->socketengine->delete_socket(fd);
@@ -629,7 +626,6 @@ void ssl_connection::read_loop() {
 				on_write(fd, e);
 			},
 			[this](socket fd, const struct socket_events &e, int error_code) {
-				std::unique_lock lock(event_mutex);
 				do_raw_trace("on_error");
 				on_error(fd, e, error_code);
 			}
@@ -684,6 +680,7 @@ void ssl_connection::close() {
 	 * that is done often.
 	 */
 	if (!plaintext) {
+		std::unique_lock lock(ssl_close_mutex);
 		if (ssl != nullptr && ssl->ssl != nullptr) {
 			SSL_free(ssl->ssl);
 			ssl->ssl = nullptr;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -21,6 +21,7 @@
  ************************************************************************************/
 #include <dpp/export.h>
 #include <cerrno>
+#include <mutex>
 #ifdef _WIN32
 	/* Windows-specific sockets includes */
 	#include <WinSock2.h>
@@ -610,6 +611,7 @@ void ssl_connection::read_loop() {
 			sfd,
 			WANT_READ | WANT_WRITE | WANT_ERROR,
 			[this](socket fd, const struct socket_events &e) {
+				std::unique_lock lock(event_mutex);
 				if (this->sfd == INVALID_SOCKET) {
 					close_socket(fd);
 					owner->socketengine->delete_socket(fd);
@@ -618,6 +620,7 @@ void ssl_connection::read_loop() {
 				on_read(fd, e);
 			},
 			[this](socket fd, const struct socket_events &e) {
+				std::unique_lock lock(event_mutex);
 				if (this->sfd == INVALID_SOCKET) {
 					close_socket(fd);
 					owner->socketengine->delete_socket(fd);
@@ -626,6 +629,7 @@ void ssl_connection::read_loop() {
 				on_write(fd, e);
 			},
 			[this](socket fd, const struct socket_events &e, int error_code) {
+				std::unique_lock lock(event_mutex);
 				do_raw_trace("on_error");
 				on_error(fd, e, error_code);
 			}
@@ -680,7 +684,6 @@ void ssl_connection::close() {
 	 * that is done often.
 	 */
 	if (!plaintext) {
-		std::unique_lock lock(ssl_close_mutex);
 		if (ssl != nullptr && ssl->ssl != nullptr) {
 			SSL_free(ssl->ssl);
 			ssl->ssl = nullptr;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -684,7 +684,6 @@ void ssl_connection::close() {
 	 * that is done often.
 	 */
 	if (!plaintext) {
-		std::unique_lock lock(ssl_close_mutex);
 		if (ssl != nullptr && ssl->ssl != nullptr) {
 			SSL_free(ssl->ssl);
 			ssl->ssl = nullptr;

--- a/src/dpp/sslconnection.cpp
+++ b/src/dpp/sslconnection.cpp
@@ -674,6 +674,14 @@ bool ssl_connection::handle_buffer(std::string &buffer) {
 }
 
 void ssl_connection::close() {
+	/* Notify socketengine first before deleting ssl contexts */
+	if (sfd != INVALID_SOCKET) {
+		log(ll_trace, "ssl_connection::close() with sfd");
+		owner->socketengine->delete_socket(sfd);
+		close_socket(sfd);
+		sfd = INVALID_SOCKET;
+	}
+
 	/**
 	 * Many of the values here are reset to initial values in the case
 	 * we want to reconnect the socket after closing it. This is not something
@@ -690,12 +698,6 @@ void ssl_connection::close() {
 	client_to_server_length = client_to_server_offset = 0;
 	last_tick = time(nullptr);
 	bytes_in = bytes_out = 0;
-	if (sfd != INVALID_SOCKET) {
-		log(ll_trace, "ssl_connection::close() with sfd");
-		owner->socketengine->delete_socket(sfd);
-		close_socket(sfd);
-		sfd = INVALID_SOCKET;
-	}
 	obuffer.clear();
 	buffer.clear();
 }

--- a/src/dpp/voice/enabled/handle_frame.cpp
+++ b/src/dpp/voice/enabled/handle_frame.cpp
@@ -441,6 +441,7 @@ bool discord_voice_client::handle_frame(const std::string &data, ws_opcode opcod
 				destination = address_t(this->ip, this->port);
 
 				// Modes
+				modes.clear();
 				for (auto & m : d["modes"]) {
 					this->modes.push_back(m.get<std::string>());
 				}


### PR DESCRIPTION
# Changes in this PR

- Fix #1605
- Fix reconnect when bot is moved to another VC by user
- Fix reconnect caused by severed connection
- Fix crash when reconnecting while having active voice session

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
