### PR TITLE
chore: Replace `for` loop with `while`

### DIFF
--- a/docpages/example_code/mp3.cpp
+++ b/docpages/example_code/mp3.cpp
@@ -41,13 +41,10 @@ int main() {
 	mpg123_open(mh, MUSIC_FILE);
 	mpg123_getformat(mh, &rate, &channels, &encoding);
 
-	unsigned int counter = 0;
-	for (int totalBytes = 0; mpg123_read(mh, buffer, buffer_size, &done) == MPG123_OK; ) {
+	while (mpg123_read(mh, buffer, buffer_size, &done) == MPG123_OK) {
 		for (size_t i = 0; i < buffer_size; i++) {
 			pcmdata.push_back(buffer[i]);
 		}
-		counter += buffer_size;
-		totalBytes += done;
 	}
 	delete[] buffer;
 	mpg123_close(mh);


### PR DESCRIPTION
This PR replaces a `for` loop with unused variables with a `while` loop, to remove the unused `counter` and `totalBytes` variables. This is needed to resolve the `-Werror` diagnostics (from `-Wunused-but-set-variable`). We could have marked it with `[[maybe_unused]]`, but that seems pointless if the code is genuinely unused.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
