### PR TITLE
fix: should invalidate previous session data when got session expired/invalid error

### DIFF
--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -228,7 +228,7 @@ public:
 	 */
 	bool is_active() const;
 
-	voiceconn& request(bool failed_resume = false);
+	voiceconn& request(bool session_invalid = true);
 
 	/**
 	 * @brief Create websocket object and connect it.

--- a/include/dpp/discordvoiceclient.h
+++ b/include/dpp/discordvoiceclient.h
@@ -233,7 +233,7 @@ using privacy_code_callback_t = std::function<void(const std::string&)>;
 /**
  * @brief A callback for a full reconnection after the voice client disconnects due to error.
  */
-using full_reconnection_callback_t = std::function<void()>;
+using full_reconnection_callback_t = std::function<void(bool)>;
 
 /** @brief Implements a discord voice connection.
  * Each discord_voice_client connects to one voice channel and derives from a websocket client.
@@ -440,6 +440,13 @@ class DPP_EXPORT discord_voice_client : public websocket_client
 	 * This is to avoid unintended Opus interpolation with subsequent transmissions.
 	 */
 	bool sent_stop_frames{};
+
+	/**
+	 * @brief Whether we got 4006 session invalid error code
+	 *
+	 * This is to tell reconnect callback to clear session data for the next reconnect attempt
+	 */
+	bool session_invalid{};
 
 	/**
 	 * @brief Number of times we have tried to reconnect in the last few seconds

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -607,11 +607,11 @@ voiceconn::~voiceconn() {
 	this->disconnect();
 }
 
-voiceconn& voiceconn::request(bool failed_resume) {
+voiceconn& voiceconn::request(bool session_invalid) {
 	/* Creating new connection from previously failed Opcode 7 Resume doesn't guarantee */
 	/* to receive voice_state_update AND voice_server_update event */
-	/* Keep previous session data so we can reconnect */
-	if (!failed_resume) {
+	/* Keep previous session data if still valid so we can reconnect */
+	if (session_invalid) {
 		this->token.clear();
 		this->session_id.clear();
 		this->websocket_hostname.clear();
@@ -626,9 +626,9 @@ voiceconn& voiceconn::connect() {
 	if (this->is_ready() && !this->is_active()) {
 		try {
 			this->creator->log(ll_debug, "Connecting voice for guild " + std::to_string(this->guild_id) + " channel " + std::to_string(this->channel_id));
-			full_reconnection_callback_t reconnection_callback = [weak_this=weak_from_this()] {
+			full_reconnection_callback_t reconnection_callback = [weak_this=weak_from_this()] (bool session_invalid) {
 			if (std::shared_ptr<voiceconn> strong_this = weak_this.lock()) {
-				strong_this->request(true);
+				strong_this->request(session_invalid);
 			}
 		};
 		this->voiceclient = std::make_unique<discord_voice_client>(creator->creator, std::move(reconnection_callback), this->channel_id, this->guild_id, this->token, this->session_id, this->websocket_hostname, this->dave);

--- a/src/dpp/discordvoiceclient.cpp
+++ b/src/dpp/discordvoiceclient.cpp
@@ -235,6 +235,7 @@ void discord_voice_client::error(uint32_t errorcode)
 		log(dpp::ll_error, "This is a non-recoverable error, giving up on voice connection");
 	}
 
+	this->session_invalid = errorcode == 4006;
 	this->close();
 }
 

--- a/src/dpp/voice/enabled/thread.cpp
+++ b/src/dpp/voice/enabled/thread.cpp
@@ -46,7 +46,9 @@ void discord_voice_client::on_disconnect() {
 	/* If we've looped 5 or more times, abort the loop. */
 	if (terminating || times_looped >= 5) {
 		log(dpp::ll_warning, "Reached max loops whilst attempting to read from the websocket. Starting a full reconnection.");
-		owner->queue_work(1, reconnection_callback);
+		bool si = this->session_invalid;
+		auto rc = reconnection_callback;
+		owner->queue_work(1, [rc, si]() { rc(si) ;});
 		return;
 	}
 	last_loop_time = current_time;


### PR DESCRIPTION
# Changes in this PR

Session expired/invalid was not handled in the previous PR (#1606)

- Fix #1613 (probably, unable to repro)
- Fix endless reconnect caused by invalid session

## Code change checklist 

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
