### PR TITLE
ci: sitemap now uses a pinned version

### DIFF
--- a/.github/workflows/sitemap.yml
+++ b/.github/workflows/sitemap.yml
@@ -30,7 +30,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Install sitemap-generator
-        run: npm install -g sitemap-generator-cli
+        run: npm install sitemap-generator-cli@7.5.0 --save-exact
 
       - name: Run sitemap-generator
         run: cd /home/runner/dpp-web && npx sitemap-generator --no-respect-robots-txt --verbose https://dpp.dev/


### PR DESCRIPTION
This PR changes the sitemap.yml to be a pinned version for security reasons (see the OpenSSF Scorecard)

Templates are not applicable for this PR.