### PR TITLE
move confirmation_callback_t constructors out of line and fix move semantics

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -1156,16 +1156,16 @@ public:
 	interaction();
 
 	/** Copy constructor */
-	interaction(const interaction&) = default;
+	interaction(const interaction&);
 
 	/** Move constructor */
-	interaction(interaction&&) = default;
+	interaction(interaction&&) noexcept(std::is_nothrow_move_constructible_v<command_resolved> && std::is_nothrow_move_constructible_v<message> && std::is_nothrow_move_constructible_v<std::map<application_integration_types, snowflake>>);
 
 	/** Copy assignment operator */
-	interaction& operator=(const interaction&) = default;
+	interaction& operator=(const interaction&);
 
 	/** Move assignment operator */
-	interaction& operator=(interaction&&) = default;
+	interaction& operator=(interaction&&) noexcept(std::is_nothrow_move_assignable_v<command_resolved> && std::is_nothrow_move_assignable_v<message> && std::is_nothrow_move_assignable_v<std::map<application_integration_types, snowflake>>);
 
 	/**
 	 * @brief Destroy the interaction object

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -30,6 +30,7 @@
 #include <dpp/entitlement.h>
 #include <variant>
 #include <map>
+#include <type_traits>
 #include <dpp/json_fwd.h>
 #include <dpp/json_interface.h>
 
@@ -525,9 +526,9 @@ public:
 	 */
 	interaction_response() = default;
 	interaction_response(const interaction_response&);
-	interaction_response(interaction_response&&) noexcept;
+	interaction_response(interaction_response&&) noexcept(std::is_nothrow_move_constructible_v<message>);
 	interaction_response& operator=(const interaction_response&);
-	interaction_response& operator=(interaction_response&&) noexcept;
+	interaction_response& operator=(interaction_response&&) noexcept(std::is_nothrow_move_assignable_v<message>);
 
 	/**
 	 * @brief Construct a new interaction response object

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -1442,6 +1442,11 @@ public:
 	 */
 	guild_command_permissions();
 
+	guild_command_permissions(const guild_command_permissions&) = default;
+	guild_command_permissions(guild_command_permissions&&) = default;
+	guild_command_permissions& operator=(const guild_command_permissions&) = default;
+	guild_command_permissions& operator=(guild_command_permissions&&) = default;
+
 	virtual ~guild_command_permissions() = default;
 
 };

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -302,10 +302,15 @@ public:
 	 */
 	command_option() = default;
 
+	command_option(const command_option&);
+	command_option(command_option&&) noexcept;
+	command_option& operator=(const command_option&);
+	command_option& operator=(command_option&&) noexcept;
+
 	/**
 	 * @brief Destroy the command option object
 	 */
-	virtual ~command_option() = default;
+	virtual ~command_option();
 
 	/**
 	 * @brief Add a file type (dpp::co_attachment) to filter for.
@@ -519,6 +524,10 @@ public:
 	 * @brief Construct a new interaction response object
 	 */
 	interaction_response() = default;
+	interaction_response(const interaction_response&);
+	interaction_response(interaction_response&&) noexcept;
+	interaction_response& operator=(const interaction_response&);
+	interaction_response& operator=(interaction_response&&) noexcept;
 
 	/**
 	 * @brief Construct a new interaction response object
@@ -554,7 +563,7 @@ public:
 	/**
 	 * @brief Destroy the interaction response object
 	 */
-	virtual ~interaction_response() = default;
+	virtual ~interaction_response();
 
 };
 
@@ -577,7 +586,7 @@ protected:
 	 * @param j JSON to fill from
 	 * @return interaction_response& Reference to self
 	 */
-	virtual interaction_modal_response& fill_from_json_impl(nlohmann::json* j);
+	interaction_modal_response& fill_from_json_impl(nlohmann::json* j) override;
 
 	/**
 	 * @brief Build a json for this object
@@ -585,7 +594,7 @@ protected:
 	 *
 	 * @return json JSON object
 	 */
-	virtual json to_json_impl(bool with_id = false) const;
+	json to_json_impl(bool with_id = false) const override;
 
 public:
 	using json_interface<interaction_modal_response>::fill_from_json;
@@ -687,7 +696,7 @@ public:
 	/**
 	 * @brief Destroy the interaction modal response object
 	 */
-	virtual ~interaction_modal_response() = default;
+	~interaction_modal_response() override = default;
 };
 
 /**
@@ -1130,10 +1139,15 @@ public:
 	 */
 	interaction();
 
+	interaction(const interaction&);
+	interaction(interaction&&) noexcept;
+	interaction& operator=(const interaction&);
+	interaction& operator=(interaction&&) noexcept;
+
 	/**
 	 * @brief Destroy the interaction object
 	 */
-	virtual ~interaction() = default;
+	~interaction() override;
 
 	/**
 	 * @brief Get a user associated with the slash command from the resolved list.
@@ -1574,10 +1588,15 @@ public:
 	 */
 	slashcommand(const std::string &_name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id);
 
+	slashcommand(const slashcommand&);
+	slashcommand(slashcommand&&) noexcept;
+	slashcommand& operator=(const slashcommand&);
+	slashcommand& operator=(slashcommand&&) noexcept;
+
 	/**
 	 * @brief Destroy the slashcommand object
 	 */
-	virtual ~slashcommand() = default;
+	~slashcommand() override;
 
 	/**
 	 * @brief Add a localisation for this slash command

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -303,9 +303,16 @@ public:
 	 */
 	command_option() = default;
 
+	/** Copy constructor */
 	command_option(const command_option&) = default;
+
+	/** Move constructor */
 	command_option(command_option&&) = default;
+
+	/** Copy assignment operator */
 	command_option& operator=(const command_option&) = default;
+
+	/** Move assignment operator */
 	command_option& operator=(command_option&&) = default;
 
 	/**
@@ -525,9 +532,17 @@ public:
 	 * @brief Construct a new interaction response object
 	 */
 	interaction_response() = default;
+
+	/** Copy constructor */
 	interaction_response(const interaction_response&);
+
+	/** Move constructor, noexcept mirrors dpp::message's move */
 	interaction_response(interaction_response&&) noexcept(std::is_nothrow_move_constructible_v<message>);
+
+	/** Copy assignment operator */
 	interaction_response& operator=(const interaction_response&);
+
+	/** Move assignment operator */
 	interaction_response& operator=(interaction_response&&) noexcept(std::is_nothrow_move_assignable_v<message>);
 
 	/**
@@ -1140,9 +1155,16 @@ public:
 	 */
 	interaction();
 
+	/** Copy constructor */
 	interaction(const interaction&) = default;
+
+	/** Move constructor */
 	interaction(interaction&&) = default;
+
+	/** Copy assignment operator */
 	interaction& operator=(const interaction&) = default;
+
+	/** Move assignment operator */
 	interaction& operator=(interaction&&) = default;
 
 	/**
@@ -1443,9 +1465,16 @@ public:
 	 */
 	guild_command_permissions();
 
+	/** Copy constructor */
 	guild_command_permissions(const guild_command_permissions&) = default;
+
+	/** Move constructor */
 	guild_command_permissions(guild_command_permissions&&) = default;
+
+	/** Copy assignment operator */
 	guild_command_permissions& operator=(const guild_command_permissions&) = default;
+
+	/** Move assignment operator */
 	guild_command_permissions& operator=(guild_command_permissions&&) = default;
 
 	virtual ~guild_command_permissions() = default;
@@ -1594,9 +1623,16 @@ public:
 	 */
 	slashcommand(const std::string &_name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id);
 
+	/** Copy constructor */
 	slashcommand(const slashcommand&) = default;
+
+	/** Move constructor */
 	slashcommand(slashcommand&&) = default;
+
+	/** Copy assignment operator */
 	slashcommand& operator=(const slashcommand&) = default;
+
+	/** Move assignment operator */
 	slashcommand& operator=(slashcommand&&) = default;
 
 	/**

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -302,10 +302,10 @@ public:
 	 */
 	command_option() = default;
 
-	command_option(const command_option&);
-	command_option(command_option&&) noexcept;
-	command_option& operator=(const command_option&);
-	command_option& operator=(command_option&&) noexcept;
+	command_option(const command_option&) = default;
+	command_option(command_option&&) = default;
+	command_option& operator=(const command_option&) = default;
+	command_option& operator=(command_option&&) = default;
 
 	/**
 	 * @brief Destroy the command option object
@@ -1139,10 +1139,10 @@ public:
 	 */
 	interaction();
 
-	interaction(const interaction&);
-	interaction(interaction&&) noexcept;
-	interaction& operator=(const interaction&);
-	interaction& operator=(interaction&&) noexcept;
+	interaction(const interaction&) = default;
+	interaction(interaction&&) = default;
+	interaction& operator=(const interaction&) = default;
+	interaction& operator=(interaction&&) = default;
 
 	/**
 	 * @brief Destroy the interaction object
@@ -1593,10 +1593,10 @@ public:
 	 */
 	slashcommand(const std::string &_name, const slashcommand_contextmenu_type _type, const dpp::snowflake _application_id);
 
-	slashcommand(const slashcommand&);
-	slashcommand(slashcommand&&) noexcept;
-	slashcommand& operator=(const slashcommand&);
-	slashcommand& operator=(slashcommand&&) noexcept;
+	slashcommand(const slashcommand&) = default;
+	slashcommand(slashcommand&&) = default;
+	slashcommand& operator=(const slashcommand&) = default;
+	slashcommand& operator=(slashcommand&&) = default;
 
 	/**
 	 * @brief Destroy the slashcommand object

--- a/include/dpp/application.h
+++ b/include/dpp/application.h
@@ -487,9 +487,6 @@ public:
 	/** Constructor */
 	application();
 
-	/** Destructor */
-	~application();
-
 	/**
 	 * @brief Get the application's cover image url if they have one, otherwise returns an empty string
 	 *

--- a/include/dpp/auditlog.h
+++ b/include/dpp/auditlog.h
@@ -474,9 +474,16 @@ public:
 	/** Constructor */
 	auditlog() = default;
 
+	/** Copy constructor */
 	auditlog(const auditlog&) = default;
+
+	/** Move constructor */
 	auditlog(auditlog&&) = default;
+
+	/** Copy assignment operator */
 	auditlog& operator=(const auditlog&) = default;
+
+	/** Move assignment operator */
 	auditlog& operator=(auditlog&&) = default;
 
 	/** Destructor */

--- a/include/dpp/auditlog.h
+++ b/include/dpp/auditlog.h
@@ -474,6 +474,11 @@ public:
 	/** Constructor */
 	auditlog() = default;
 
+	auditlog(const auditlog&) = default;
+	auditlog(auditlog&&) = default;
+	auditlog& operator=(const auditlog&) = default;
+	auditlog& operator=(auditlog&&) = default;
+
 	/** Destructor */
 	virtual ~auditlog() = default;
 };

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -247,6 +247,11 @@ public:
 	 */
 	automod_metadata();
 
+	automod_metadata(const automod_metadata&) = default;
+	automod_metadata(automod_metadata&&) = default;
+	automod_metadata& operator=(const automod_metadata&) = default;
+	automod_metadata& operator=(automod_metadata&&) = default;
+
 	/**
 	 * @brief Destroy the automod metadata object
 	 */
@@ -389,11 +394,6 @@ public:
 	 * @brief Construct a new automod rule object
 	 */
 	automod_rule();
-
-	/**
-	 * @brief Destroy the automod rule object
-	 */
-	virtual ~automod_rule();
 };
 
 /** A group of automod rules.

--- a/include/dpp/automod.h
+++ b/include/dpp/automod.h
@@ -247,9 +247,16 @@ public:
 	 */
 	automod_metadata();
 
+	/** Copy constructor */
 	automod_metadata(const automod_metadata&) = default;
+
+	/** Move constructor */
 	automod_metadata(automod_metadata&&) = default;
+
+	/** Copy assignment operator */
 	automod_metadata& operator=(const automod_metadata&) = default;
+
+	/** Move assignment operator */
 	automod_metadata& operator=(automod_metadata&&) = default;
 
 	/**

--- a/include/dpp/ban.h
+++ b/include/dpp/ban.h
@@ -57,9 +57,16 @@ public:
 	/** Constructor */
 	ban();
 
+	/** Copy constructor */
 	ban(const ban&) = default;
+
+	/** Move constructor */
 	ban(ban&&) = default;
+
+	/** Copy assignment operator */
 	ban& operator=(const ban&) = default;
+
+	/** Move assignment operator */
 	ban& operator=(ban&&) = default;
 
 	/** Destructor */

--- a/include/dpp/ban.h
+++ b/include/dpp/ban.h
@@ -57,6 +57,11 @@ public:
 	/** Constructor */
 	ban();
 
+	ban(const ban&) = default;
+	ban(ban&&) = default;
+	ban& operator=(const ban&) = default;
+	ban& operator=(ban&&) = default;
+
 	/** Destructor */
 	virtual ~ban() = default;
 };

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -480,10 +480,10 @@ public:
 	/** Constructor */
 	channel();
 
-	channel(const channel&);
-	channel(channel&&) noexcept;
-	channel& operator=(const channel&);
-	channel& operator=(channel&&) noexcept;
+	channel(const channel&) = default;
+	channel(channel&&) = default;
+	channel& operator=(const channel&) = default;
+	channel& operator=(channel&&) = default;
 
 	/** Destructor */
 	~channel() override;

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -480,8 +480,13 @@ public:
 	/** Constructor */
 	channel();
 
+	channel(const channel&);
+	channel(channel&&) noexcept;
+	channel& operator=(const channel&);
+	channel& operator=(channel&&) noexcept;
+
 	/** Destructor */
-	virtual ~channel();
+	~channel() override;
 
 	/**
 	* @brief Create a mentionable channel.
@@ -893,4 +898,3 @@ void to_json(nlohmann::json& j, const permission_overwrite& po);
 typedef std::unordered_map<snowflake, channel> channel_map;
 
 }
-

--- a/include/dpp/channel.h
+++ b/include/dpp/channel.h
@@ -480,9 +480,16 @@ public:
 	/** Constructor */
 	channel();
 
+	/** Copy constructor */
 	channel(const channel&) = default;
+
+	/** Move constructor */
 	channel(channel&&) = default;
+
+	/** Copy assignment operator */
 	channel& operator=(const channel&) = default;
+
+	/** Move assignment operator */
 	channel& operator=(channel&&) = default;
 
 	/** Destructor */

--- a/include/dpp/dtemplate.h
+++ b/include/dpp/dtemplate.h
@@ -101,9 +101,16 @@ public:
 	 */
 	dtemplate();
 
+	/** Copy constructor */
 	dtemplate(const dtemplate&) = default;
+
+	/** Move constructor */
 	dtemplate(dtemplate&&) = default;
+
+	/** Copy assignment operator */
 	dtemplate& operator=(const dtemplate&) = default;
+
+	/** Move assignment operator */
 	dtemplate& operator=(dtemplate&&) = default;
 
 	/**

--- a/include/dpp/dtemplate.h
+++ b/include/dpp/dtemplate.h
@@ -101,6 +101,11 @@ public:
 	 */
 	dtemplate();
 
+	dtemplate(const dtemplate&) = default;
+	dtemplate(dtemplate&&) = default;
+	dtemplate& operator=(const dtemplate&) = default;
+	dtemplate& operator=(dtemplate&&) = default;
+
 	/**
 	 * @brief Destroy the dtemplate object
 	 */

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -805,16 +805,16 @@ public:
 	welcome_screen() = default;
 
 	/** Copy constructor */
-	welcome_screen(const welcome_screen&);
+	welcome_screen(const welcome_screen&) = default;
 
 	/** Move constructor */
-	welcome_screen(welcome_screen&&) noexcept;
+	welcome_screen(welcome_screen&&) = default;
 
 	/** Copy assignment operator */
-	welcome_screen& operator=(const welcome_screen&);
+	welcome_screen& operator=(const welcome_screen&) = default;
 
 	/** Move assignment operator */
-	welcome_screen& operator=(welcome_screen&&) noexcept;
+	welcome_screen& operator=(welcome_screen&&) = default;
 
 	/**
 	 * @brief Destroy the welcome screen object
@@ -1225,16 +1225,16 @@ public:
 	guild();
 
 	/** Copy constructor */
-	guild(const guild&) = default;
+	guild(const guild&);
 
 	/** Move constructor */
-	guild(guild&&) = default;
+	guild(guild&&) noexcept(std::is_nothrow_move_constructible_v<std::map<snowflake, voicestate>>);
 
 	/** Copy assignment operator */
-	guild& operator=(const guild&) = default;
+	guild& operator=(const guild&);
 
 	/** Move assignment operator */
-	guild& operator=(guild&&) = default;
+	guild& operator=(guild&&) noexcept(std::is_nothrow_move_assignable_v<std::map<snowflake, voicestate>>);
 
 	/**
 	 * @brief Destroy the guild object

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -2002,6 +2002,11 @@ public:
 	 */
 	onboarding();
 
+	onboarding(const onboarding&) = default;
+	onboarding(onboarding&&) = default;
+	onboarding& operator=(const onboarding&) = default;
+	onboarding& operator=(onboarding&&) = default;
+
 	/**
 	 * @brief Destroy the onboarding object
 	 */

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -1216,10 +1216,10 @@ public:
 	/** Default constructor, zeroes all values */
 	guild();
 
-	guild(const guild&);
-	guild(guild&&) noexcept;
-	guild& operator=(const guild&);
-	guild& operator=(guild&&) noexcept;
+	guild(const guild&) = default;
+	guild(guild&&) = default;
+	guild& operator=(const guild&) = default;
+	guild& operator=(guild&&) = default;
 
 	/**
 	 * @brief Destroy the guild object

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -803,11 +803,15 @@ public:
 	 * @brief Construct a new welcome screen object
 	 */
 	welcome_screen() = default;
+	welcome_screen(const welcome_screen&);
+	welcome_screen(welcome_screen&&) noexcept;
+	welcome_screen& operator=(const welcome_screen&);
+	welcome_screen& operator=(welcome_screen&&) noexcept;
 
 	/**
 	 * @brief Destroy the welcome screen object
 	 */
-	virtual ~welcome_screen() = default;
+	virtual ~welcome_screen();
 
 	/**
 	 * @brief Set the server description for this welcome screen object shown in the welcome screen
@@ -1212,10 +1216,15 @@ public:
 	/** Default constructor, zeroes all values */
 	guild();
 
+	guild(const guild&);
+	guild(guild&&) noexcept;
+	guild& operator=(const guild&);
+	guild& operator=(guild&&) noexcept;
+
 	/**
 	 * @brief Destroy the guild object
 	 */
-	virtual ~guild() = default;
+	~guild() override;
 
 	/** Read class values from json object
 	 * @param shard originating shard

--- a/include/dpp/guild.h
+++ b/include/dpp/guild.h
@@ -803,9 +803,17 @@ public:
 	 * @brief Construct a new welcome screen object
 	 */
 	welcome_screen() = default;
+
+	/** Copy constructor */
 	welcome_screen(const welcome_screen&);
+
+	/** Move constructor */
 	welcome_screen(welcome_screen&&) noexcept;
+
+	/** Copy assignment operator */
 	welcome_screen& operator=(const welcome_screen&);
+
+	/** Move assignment operator */
 	welcome_screen& operator=(welcome_screen&&) noexcept;
 
 	/**
@@ -1216,9 +1224,16 @@ public:
 	/** Default constructor, zeroes all values */
 	guild();
 
+	/** Copy constructor */
 	guild(const guild&) = default;
+
+	/** Move constructor */
 	guild(guild&&) = default;
+
+	/** Copy assignment operator */
 	guild& operator=(const guild&) = default;
+
+	/** Move assignment operator */
 	guild& operator=(guild&&) = default;
 
 	/**
@@ -2002,9 +2017,16 @@ public:
 	 */
 	onboarding();
 
+	/** Copy constructor */
 	onboarding(const onboarding&) = default;
+
+	/** Move constructor */
 	onboarding(onboarding&&) = default;
+
+	/** Copy assignment operator */
 	onboarding& operator=(const onboarding&) = default;
+
+	/** Move assignment operator */
 	onboarding& operator=(onboarding&&) = default;
 
 	/**

--- a/include/dpp/integration.h
+++ b/include/dpp/integration.h
@@ -234,9 +234,6 @@ public:
 	/** Default constructor */
 	integration();
 
-	/** Default destructor */
-	~integration() = default;
-
 	/**
 	 * Are emoticons enabled for this integration?
 	 * @warning This is not provided for discord bot integrations.

--- a/include/dpp/invite.h
+++ b/include/dpp/invite.h
@@ -183,9 +183,16 @@ public:
 	 */
 	invite();
 
+	/** Copy constructor */
 	invite(const invite&) = default;
+
+	/** Move constructor */
 	invite(invite&&) = default;
+
+	/** Copy assignment operator */
 	invite& operator=(const invite&) = default;
+
+	/** Move assignment operator */
 	invite& operator=(invite&&) = default;
 
 	/**

--- a/include/dpp/invite.h
+++ b/include/dpp/invite.h
@@ -183,6 +183,11 @@ public:
 	 */
 	invite();
 
+	invite(const invite&) = default;
+	invite(invite&&) = default;
+	invite& operator=(const invite&) = default;
+	invite& operator=(invite&&) = default;
+
 	/**
 	 * @brief Destructor.
 	 */

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -682,10 +682,15 @@ public:
 	 */
 	component();
 
+	component(const component&);
+	component(component&&) noexcept;
+	component& operator=(const component&);
+	component& operator=(component&&) noexcept;
+
 	/**
 	 * @brief Destructor
 	 */
-	virtual ~component() = default;
+	virtual ~component();
 
 	/**
 	 * @brief Add a channel type to include in the channel select component (dpp::cot_channel_selectmenu)
@@ -1182,6 +1187,11 @@ struct DPP_EXPORT embed {
 	 * @param j JSON to read content from
 	 */
 	embed(nlohmann::json* j);
+
+	embed(const embed&);
+	embed(embed&&) noexcept;
+	embed& operator=(const embed&);
+	embed& operator=(embed&&) noexcept;
 
 	/**
 	 * @brief Destructor
@@ -2633,13 +2643,13 @@ public:
 	 * @brief Construct a new message object
 	 * @param m Message to copy
 	 */
-	message(const message& m) = default;
+	message(const message& m);
 
 	/*
 	 * @brief Construct a new message object
 	 * @param m Message to move
 	 */
-	message(message&& m) = default;
+	message(message&& m) noexcept;
 
 	/**
 	 * @brief Construct a new message object
@@ -2684,7 +2694,7 @@ public:
 	/**
 	 * @brief Destroy the message object
 	 */
-	~message() override = default;
+	~message() override;
 
 	/**
 	 * @brief Copy a message object
@@ -2692,7 +2702,7 @@ public:
 	 * @param m Message to copy
 	 * @return message& Reference to self
 	 */
-	message &operator=(const message& m) = default;
+	message &operator=(const message& m);
 
 	/**
 	 * @brief Move a message object
@@ -2700,7 +2710,7 @@ public:
 	 * @param m Message to move
 	 * @return message& Reference to self
 	 */
-	message &operator=(message&& m) = default;
+	message &operator=(message&& m) noexcept;
 
 	/**
 	 * @brief Set the original message reference for replies/crossposts

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -1640,8 +1640,6 @@ public:
 	 */
 	sticker();
 
-	virtual ~sticker() = default;
-
 	/**
 	 * @brief Get the sticker url.
 	 *

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -28,6 +28,7 @@
 #include <dpp/guild.h>
 #include <optional>
 #include <variant>
+#include <type_traits>
 #include <dpp/json_fwd.h>
 #include <dpp/json_interface.h>
 
@@ -2647,7 +2648,7 @@ public:
 	 * @brief Construct a new message object
 	 * @param m Message to move
 	 */
-	message(message&& m) noexcept;
+	message(message&& m) noexcept(std::is_nothrow_move_constructible_v<std::optional<poll>>);
 
 	/**
 	 * @brief Construct a new message object
@@ -2708,7 +2709,7 @@ public:
 	 * @param m Message to move
 	 * @return message& Reference to self
 	 */
-	message &operator=(message&& m) noexcept;
+	message &operator=(message&& m) noexcept(std::is_nothrow_move_assignable_v<std::optional<poll>>);
 
 	/**
 	 * @brief Set the original message reference for replies/crossposts

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -683,9 +683,16 @@ public:
 	 */
 	component();
 
+	/** Copy constructor */
 	component(const component&);
+
+	/** Move constructor */
 	component(component&&) noexcept;
+
+	/** Copy assignment operator */
 	component& operator=(const component&);
+
+	/** Move assignment operator */
 	component& operator=(component&&) noexcept;
 
 	/**
@@ -1189,9 +1196,16 @@ struct DPP_EXPORT embed {
 	 */
 	embed(nlohmann::json* j);
 
+	/** Copy constructor */
 	embed(const embed&);
+
+	/** Move constructor */
 	embed(embed&&) noexcept;
+
+	/** Copy assignment operator */
 	embed& operator=(const embed&);
+
+	/** Move assignment operator */
 	embed& operator=(embed&&) noexcept;
 
 	/**
@@ -2638,15 +2652,16 @@ public:
 	 */
 	message();
 
-	/*
+	/**
 	 * @brief Construct a new message object
 	 * @param m Message to copy
 	 */
 	message(const message& m);
 
-	/*
+	/**
 	 * @brief Construct a new message object
 	 * @param m Message to move
+	 * @note noexcept mirrors the implicit spec: attached_poll is the only member whose move can throw (std::map, on MSVC)
 	 */
 	message(message&& m) noexcept(std::is_nothrow_move_constructible_v<std::optional<poll>>);
 

--- a/include/dpp/prune.h
+++ b/include/dpp/prune.h
@@ -47,6 +47,13 @@ protected:
 	virtual json to_json_impl(bool with_prune_count = false) const;
 
 public:
+	prune() = default;
+
+	prune(const prune&) = default;
+	prune(prune&&) = default;
+	prune& operator=(const prune&) = default;
+	prune& operator=(prune&&) = default;
+
 	/**
 	 * @brief Destroy this prune object
 	 */

--- a/include/dpp/prune.h
+++ b/include/dpp/prune.h
@@ -47,11 +47,20 @@ protected:
 	virtual json to_json_impl(bool with_prune_count = false) const;
 
 public:
+
+	/** Default constructor */
 	prune() = default;
 
+	/** Copy constructor */
 	prune(const prune&) = default;
+
+	/** Move constructor */
 	prune(prune&&) = default;
+
+	/** Copy assignment operator */
 	prune& operator=(const prune&) = default;
+
+	/** Move assignment operator */
 	prune& operator=(prune&&) = default;
 
 	/**

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -200,6 +200,7 @@ typedef std::variant<
 		message_search_result
 	> confirmable_t;
 
+
 /**
  * @brief The details of a field in an error response
  */
@@ -278,7 +279,13 @@ struct DPP_EXPORT confirmation_callback_t {
 	/**
 	 * @brief Construct a new confirmation callback t object.
 	 */
-	confirmation_callback_t() = default;
+	confirmation_callback_t();
+
+	confirmation_callback_t(const confirmation_callback_t&);
+	confirmation_callback_t(confirmation_callback_t&&);
+	confirmation_callback_t& operator=(const confirmation_callback_t&);
+	confirmation_callback_t& operator=(confirmation_callback_t&&);
+	~confirmation_callback_t();
 
 	/**
 	 * @brief Construct a new confirmation callback t object

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -281,10 +281,19 @@ struct DPP_EXPORT confirmation_callback_t {
 	 */
 	confirmation_callback_t();
 
+	/** Copy constructor */
 	confirmation_callback_t(const confirmation_callback_t&);
+
+	/** Move constructor */
 	confirmation_callback_t(confirmation_callback_t&&) noexcept(std::is_nothrow_move_constructible_v<http_request_completion_t> && std::is_nothrow_move_constructible_v<confirmable_t>);
+
+	/** Copy assignment operator */
 	confirmation_callback_t& operator=(const confirmation_callback_t&);
+
+	/** Move assignment operator */
 	confirmation_callback_t& operator=(confirmation_callback_t&&) noexcept(std::is_nothrow_move_assignable_v<http_request_completion_t> && std::is_nothrow_move_assignable_v<confirmable_t>);
+
+	/** Destructor */
 	~confirmation_callback_t();
 
 	/**

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <map>
 #include <variant>
+#include <type_traits>
 #include <dpp/snowflake.h>
 #include <dpp/dispatcher.h>
 #include <dpp/misc-enum.h>
@@ -200,6 +201,20 @@ typedef std::variant<
 		message_search_result
 	> confirmable_t;
 
+// confirmation_callback_t declares its move ops noexcept, and a default function with a mismatched noexcept spec
+// is silently accepted rather than warned, so we assert as noexcept to avoid runtime std::terminate
+static_assert(std::is_nothrow_move_constructible_v<confirmable_t>,
+	"a confirmable_t alternative is not nothrow move constructible; "
+	"confirmation_callback_t's noexcept move would be incorrect");
+static_assert(std::is_nothrow_move_assignable_v<confirmable_t>,
+	"a confirmable_t alternative is not nothrow move assignable; "
+	"confirmation_callback_t's noexcept move assignment would be incorrect");
+static_assert(std::is_nothrow_move_constructible_v<http_request_completion_t>,
+	"http_request_completion_t is not nothrow move constructible; "
+	"confirmation_callback_t's noexcept move would be a lie");
+static_assert(std::is_nothrow_move_assignable_v<http_request_completion_t>,
+	"http_request_completion_t is not nothrow move assignable; "
+	"confirmation_callback_t's noexcept move assignment would be incorrect");
 
 /**
  * @brief The details of a field in an error response
@@ -282,9 +297,9 @@ struct DPP_EXPORT confirmation_callback_t {
 	confirmation_callback_t();
 
 	confirmation_callback_t(const confirmation_callback_t&);
-	confirmation_callback_t(confirmation_callback_t&&);
+	confirmation_callback_t(confirmation_callback_t&&) noexcept;
 	confirmation_callback_t& operator=(const confirmation_callback_t&);
-	confirmation_callback_t& operator=(confirmation_callback_t&&);
+	confirmation_callback_t& operator=(confirmation_callback_t&&) noexcept;
 	~confirmation_callback_t();
 
 	/**

--- a/include/dpp/restresults.h
+++ b/include/dpp/restresults.h
@@ -201,21 +201,6 @@ typedef std::variant<
 		message_search_result
 	> confirmable_t;
 
-// confirmation_callback_t declares its move ops noexcept, and a default function with a mismatched noexcept spec
-// is silently accepted rather than warned, so we assert as noexcept to avoid runtime std::terminate
-static_assert(std::is_nothrow_move_constructible_v<confirmable_t>,
-	"a confirmable_t alternative is not nothrow move constructible; "
-	"confirmation_callback_t's noexcept move would be incorrect");
-static_assert(std::is_nothrow_move_assignable_v<confirmable_t>,
-	"a confirmable_t alternative is not nothrow move assignable; "
-	"confirmation_callback_t's noexcept move assignment would be incorrect");
-static_assert(std::is_nothrow_move_constructible_v<http_request_completion_t>,
-	"http_request_completion_t is not nothrow move constructible; "
-	"confirmation_callback_t's noexcept move would be a lie");
-static_assert(std::is_nothrow_move_assignable_v<http_request_completion_t>,
-	"http_request_completion_t is not nothrow move assignable; "
-	"confirmation_callback_t's noexcept move assignment would be incorrect");
-
 /**
  * @brief The details of a field in an error response
  */
@@ -297,9 +282,9 @@ struct DPP_EXPORT confirmation_callback_t {
 	confirmation_callback_t();
 
 	confirmation_callback_t(const confirmation_callback_t&);
-	confirmation_callback_t(confirmation_callback_t&&) noexcept;
+	confirmation_callback_t(confirmation_callback_t&&) noexcept(std::is_nothrow_move_constructible_v<http_request_completion_t> && std::is_nothrow_move_constructible_v<confirmable_t>);
 	confirmation_callback_t& operator=(const confirmation_callback_t&);
-	confirmation_callback_t& operator=(confirmation_callback_t&&) noexcept;
+	confirmation_callback_t& operator=(confirmation_callback_t&&) noexcept(std::is_nothrow_move_assignable_v<http_request_completion_t> && std::is_nothrow_move_assignable_v<confirmable_t>);
 	~confirmation_callback_t();
 
 	/**

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -1002,9 +1002,16 @@ public:
 	 */
 	application_role_connection_metadata();
 
+	/** Copy constructor */
 	application_role_connection_metadata(const application_role_connection_metadata&) = default;
+
+	/** Move constructor */
 	application_role_connection_metadata(application_role_connection_metadata&&) = default;
+
+	/** Copy assignment operator */
 	application_role_connection_metadata& operator=(const application_role_connection_metadata&) = default;
+
+	/** Move assignment operator */
 	application_role_connection_metadata& operator=(application_role_connection_metadata&&) = default;
 
 	virtual ~application_role_connection_metadata() = default;
@@ -1053,9 +1060,16 @@ public:
 	 */
 	application_role_connection();
 
+	/** Copy constructor */
 	application_role_connection(const application_role_connection&) = default;
+
+	/** Move constructor */
 	application_role_connection(application_role_connection&&) = default;
+
+	/** Copy assignment operator */
 	application_role_connection& operator=(const application_role_connection&) = default;
+
+	/** Move assignment operator */
 	application_role_connection& operator=(application_role_connection&&) = default;
 
 	virtual ~application_role_connection() = default;

--- a/include/dpp/role.h
+++ b/include/dpp/role.h
@@ -1002,6 +1002,11 @@ public:
 	 */
 	application_role_connection_metadata();
 
+	application_role_connection_metadata(const application_role_connection_metadata&) = default;
+	application_role_connection_metadata(application_role_connection_metadata&&) = default;
+	application_role_connection_metadata& operator=(const application_role_connection_metadata&) = default;
+	application_role_connection_metadata& operator=(application_role_connection_metadata&&) = default;
+
 	virtual ~application_role_connection_metadata() = default;
 };
 
@@ -1047,6 +1052,11 @@ public:
 	 * @brief Constructor
 	 */
 	application_role_connection();
+
+	application_role_connection(const application_role_connection&) = default;
+	application_role_connection(application_role_connection&&) = default;
+	application_role_connection& operator=(const application_role_connection&) = default;
+	application_role_connection& operator=(application_role_connection&&) = default;
 
 	virtual ~application_role_connection() = default;
 };

--- a/include/dpp/stage_instance.h
+++ b/include/dpp/stage_instance.h
@@ -97,11 +97,6 @@ public:
 	 * @brief Create a stage_instance object
 	 */
 	stage_instance();
-
-	/**
-	 * @brief Destroy the stage_instance object
-	 */
-	~stage_instance() = default;
 };
 
 /**

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -535,11 +535,6 @@ public:
 	 */
 	user_identified(const user& u);
 
-	/**
-	 * @brief Destroy the user identified object
-	 */
-	virtual ~user_identified() = default;
-
 	using json_interface<user_identified>::fill_from_json;
 	using json_interface<user_identified>::build_json;
 	using json_interface<user_identified>::to_json;

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -227,10 +227,15 @@ public:
 	 */
 	user();
 
+	user(const user&);
+	user(user&&) noexcept;
+	user& operator=(const user&);
+	user& operator=(user&&) noexcept;
+
 	/**
 	 * @brief Destroy the user object
 	 */
-	virtual ~user() = default;
+	~user() override;
 
 	/**
 	 * @brief Create a mentionable user.

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -228,16 +228,16 @@ public:
 	user();
 
 	/** Copy constructor */
-	user(const user&);
+	user(const user&) = default;
 
 	/** Move constructor */
-	user(user&&) noexcept;
+	user(user&&) = default;
 
 	/** Copy assignment operator */
-	user& operator=(const user&);
+	user& operator=(const user&) = default;
 
 	/** Move assignment operator */
-	user& operator=(user&&) noexcept;
+	user& operator=(user&&) = default;
 
 	/**
 	 * @brief Destroy the user object

--- a/include/dpp/user.h
+++ b/include/dpp/user.h
@@ -227,9 +227,16 @@ public:
 	 */
 	user();
 
+	/** Copy constructor */
 	user(const user&);
+
+	/** Move constructor */
 	user(user&&) noexcept;
+
+	/** Copy assignment operator */
 	user& operator=(const user&);
+
+	/** Move assignment operator */
 	user& operator=(user&&) noexcept;
 
 	/**

--- a/include/dpp/voiceregion.h
+++ b/include/dpp/voiceregion.h
@@ -91,9 +91,16 @@ public:
 	 */
 	voiceregion();
 
+	/** Copy constructor */
 	voiceregion(const voiceregion&) = default;
+
+	/** Move constructor */
 	voiceregion(voiceregion&&) = default;
+
+	/** Copy assignment operator */
 	voiceregion& operator=(const voiceregion&) = default;
+
+	/** Move assignment operator */
 	voiceregion& operator=(voiceregion&&) = default;
 
 	/**

--- a/include/dpp/voiceregion.h
+++ b/include/dpp/voiceregion.h
@@ -91,6 +91,11 @@ public:
 	 */
 	voiceregion();
 
+	voiceregion(const voiceregion&) = default;
+	voiceregion(voiceregion&&) = default;
+	voiceregion& operator=(const voiceregion&) = default;
+	voiceregion& operator=(voiceregion&&) = default;
+
 	/**
 	 * @brief Destroy the voiceregion object
 	 */

--- a/include/dpp/voicestate.h
+++ b/include/dpp/voicestate.h
@@ -130,9 +130,16 @@ public:
 	 */
 	voicestate();
 
+	/** Copy constructor */
 	voicestate(const voicestate&) = default;
+
+	/** Move constructor */
 	voicestate(voicestate&&) = default;
+
+	/** Copy assignment operator */
 	voicestate& operator=(const voicestate&) = default;
+
+	/** Move assignment operator */
 	voicestate& operator=(voicestate&&) = default;
 
 	/**

--- a/include/dpp/voicestate.h
+++ b/include/dpp/voicestate.h
@@ -130,6 +130,11 @@ public:
 	 */
 	voicestate();
 
+	voicestate(const voicestate&) = default;
+	voicestate(voicestate&&) = default;
+	voicestate& operator=(const voicestate&) = default;
+	voicestate& operator=(voicestate&&) = default;
+
 	/**
 	 * @brief Destroy the voicestate object
 	 */

--- a/src/dpp/application.cpp
+++ b/src/dpp/application.cpp
@@ -52,8 +52,6 @@ application::application() : managed(0), bot_public(false), bot_require_code_gra
 {
 }
 
-application::~application() = default;
-
 application& application::fill_from_json_impl(nlohmann::json* j) {
 	set_snowflake_not_null(j, "id", id);
 	set_string_not_null(j, "name", name);

--- a/src/dpp/automod.cpp
+++ b/src/dpp/automod.cpp
@@ -130,8 +130,6 @@ automod_rule::automod_rule() : managed(), guild_id(0), creator_id(0), event_type
 {
 }
 
-automod_rule::~automod_rule() = default;
-
 automod_rule& automod_rule::fill_from_json_impl(nlohmann::json* j) {
 	id = snowflake_not_null(j, "id");
 	guild_id = snowflake_not_null(j, "guild_id");

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -115,11 +115,6 @@ channel::channel() :
 channel::~channel(){
 }
 
-channel::channel(const channel&) = default;
-channel::channel(channel&&) noexcept = default;
-channel& channel::operator=(const channel&) = default;
-channel& channel::operator=(channel&&) noexcept = default;
-
 std::string channel::get_mention(const snowflake &id) {
 	return utility::channel_mention(id);
 }

--- a/src/dpp/channel.cpp
+++ b/src/dpp/channel.cpp
@@ -115,6 +115,11 @@ channel::channel() :
 channel::~channel(){
 }
 
+channel::channel(const channel&) = default;
+channel::channel(channel&&) noexcept = default;
+channel& channel::operator=(const channel&) = default;
+channel& channel::operator=(channel&&) noexcept = default;
+
 std::string channel::get_mention(const snowflake &id) {
 	return utility::channel_mention(id);
 }

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -93,10 +93,6 @@ guild::guild() :
 {
 }
 
-guild::guild(const guild&) = default;
-guild::guild(guild&&) noexcept = default;
-guild& guild::operator=(const guild&) = default;
-guild& guild::operator=(guild&&) noexcept = default;
 guild::~guild() = default;
 
 

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -93,6 +93,10 @@ guild::guild() :
 {
 }
 
+guild::guild(const guild&) = default;
+guild::guild(guild&&) noexcept(std::is_nothrow_move_constructible_v<std::map<snowflake, voicestate>>) = default;
+guild& guild::operator=(const guild&) = default;
+guild& guild::operator=(guild&&) noexcept(std::is_nothrow_move_assignable_v<std::map<snowflake, voicestate>>) = default;
 guild::~guild() = default;
 
 
@@ -368,10 +372,6 @@ bool guild_member::has_bypasses_verification() const {
 welcome_channel::welcome_channel(): channel_id(0), emoji_id(0) {
 }
 
-welcome_screen::welcome_screen(const welcome_screen&) = default;
-welcome_screen::welcome_screen(welcome_screen&&) noexcept = default;
-welcome_screen& welcome_screen::operator=(const welcome_screen&) = default;
-welcome_screen& welcome_screen::operator=(welcome_screen&&) noexcept = default;
 welcome_screen::~welcome_screen() = default;
 
 welcome_channel &welcome_channel::fill_from_json_impl(nlohmann::json *j) {

--- a/src/dpp/guild.cpp
+++ b/src/dpp/guild.cpp
@@ -93,6 +93,12 @@ guild::guild() :
 {
 }
 
+guild::guild(const guild&) = default;
+guild::guild(guild&&) noexcept = default;
+guild& guild::operator=(const guild&) = default;
+guild& guild::operator=(guild&&) noexcept = default;
+guild::~guild() = default;
+
 
 guild_member::guild_member() :
 	flags(0),
@@ -365,6 +371,12 @@ bool guild_member::has_bypasses_verification() const {
 
 welcome_channel::welcome_channel(): channel_id(0), emoji_id(0) {
 }
+
+welcome_screen::welcome_screen(const welcome_screen&) = default;
+welcome_screen::welcome_screen(welcome_screen&&) noexcept = default;
+welcome_screen& welcome_screen::operator=(const welcome_screen&) = default;
+welcome_screen& welcome_screen::operator=(welcome_screen&&) noexcept = default;
+welcome_screen::~welcome_screen() = default;
 
 welcome_channel &welcome_channel::fill_from_json_impl(nlohmann::json *j) {
 	channel_id = snowflake_not_null(j, "channel_id");

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -854,6 +854,23 @@ void from_json(const json& j, interaction_metadata_type& i) {
 
 embed::~embed() = default;
 
+component::component(const component&) = default;
+component::component(component&&) noexcept = default;
+component& component::operator=(const component&) = default;
+component& component::operator=(component&&) noexcept = default;
+component::~component() = default;
+
+embed::embed(const embed&) = default;
+embed::embed(embed&&) noexcept = default;
+embed& embed::operator=(const embed&) = default;
+embed& embed::operator=(embed&&) noexcept = default;
+
+message::message(const message&) = default;
+message::message(message&&) noexcept = default;
+message& message::operator=(const message&) = default;
+message& message::operator=(message&&) noexcept = default;
+message::~message() = default;
+
 embed::embed() : timestamp(0) {
 }
 

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -866,9 +866,9 @@ embed& embed::operator=(const embed&) = default;
 embed& embed::operator=(embed&&) noexcept = default;
 
 message::message(const message&) = default;
-message::message(message&&) noexcept = default;
+message::message(message&&) noexcept(std::is_nothrow_move_constructible_v<std::optional<poll>>) = default;
 message& message::operator=(const message&) = default;
-message& message::operator=(message&&) noexcept = default;
+message& message::operator=(message&&) noexcept(std::is_nothrow_move_assignable_v<std::optional<poll>>) = default;
 message::~message() = default;
 
 embed::embed() : timestamp(0) {

--- a/src/dpp/restresults.cpp
+++ b/src/dpp/restresults.cpp
@@ -29,9 +29,9 @@ confirmation_callback_t::confirmation_callback_t()
 }
 
 confirmation_callback_t::confirmation_callback_t(const confirmation_callback_t &) = default;
-confirmation_callback_t::confirmation_callback_t(confirmation_callback_t &&) noexcept = default;
+confirmation_callback_t::confirmation_callback_t(confirmation_callback_t &&) noexcept(std::is_nothrow_move_constructible_v<http_request_completion_t> && std::is_nothrow_move_constructible_v<confirmable_t>) = default;
 confirmation_callback_t &confirmation_callback_t::operator=(const confirmation_callback_t &) = default;
-confirmation_callback_t &confirmation_callback_t::operator=(confirmation_callback_t &&) noexcept = default;
+confirmation_callback_t &confirmation_callback_t::operator=(confirmation_callback_t &&) noexcept(std::is_nothrow_move_assignable_v<http_request_completion_t> && std::is_nothrow_move_assignable_v<confirmable_t>) = default;
 confirmation_callback_t::~confirmation_callback_t() = default;
 
 }

--- a/src/dpp/restresults.cpp
+++ b/src/dpp/restresults.cpp
@@ -1,0 +1,37 @@
+/************************************************************************************
+ *
+ * D++, A Lightweight C++ library for Discord
+ *
+ * Copyright 2021 Craig Edwards and D++ contributors
+ * (https://github.com/brainboxdotcc/DPP/graphs/contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ************************************************************************************/
+
+#include <dpp/restresults.h>
+
+namespace dpp {
+
+confirmation_callback_t::confirmation_callback_t()
+	: http_info{}, value{}, bot(nullptr)
+{
+}
+
+confirmation_callback_t::confirmation_callback_t(const confirmation_callback_t &) = default;
+confirmation_callback_t::confirmation_callback_t(confirmation_callback_t &&) = default;
+confirmation_callback_t &confirmation_callback_t::operator=(const confirmation_callback_t &) = default;
+confirmation_callback_t &confirmation_callback_t::operator=(confirmation_callback_t &&) = default;
+confirmation_callback_t::~confirmation_callback_t() = default;
+
+}

--- a/src/dpp/restresults.cpp
+++ b/src/dpp/restresults.cpp
@@ -29,9 +29,9 @@ confirmation_callback_t::confirmation_callback_t()
 }
 
 confirmation_callback_t::confirmation_callback_t(const confirmation_callback_t &) = default;
-confirmation_callback_t::confirmation_callback_t(confirmation_callback_t &&) = default;
+confirmation_callback_t::confirmation_callback_t(confirmation_callback_t &&) noexcept = default;
 confirmation_callback_t &confirmation_callback_t::operator=(const confirmation_callback_t &) = default;
-confirmation_callback_t &confirmation_callback_t::operator=(confirmation_callback_t &&) = default;
+confirmation_callback_t &confirmation_callback_t::operator=(confirmation_callback_t &&) noexcept = default;
 confirmation_callback_t::~confirmation_callback_t() = default;
 
 }

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -34,10 +34,6 @@ using json = nlohmann::json;
 slashcommand::slashcommand() : managed(), application_id(0), type(ctxm_chat_input), default_permission(true), version(1), default_member_permissions(p_use_application_commands), dm_permission(false), nsfw(false) {
 }
 
-slashcommand::slashcommand(const slashcommand&) = default;
-slashcommand::slashcommand(slashcommand&&) noexcept = default;
-slashcommand& slashcommand::operator=(const slashcommand&) = default;
-slashcommand& slashcommand::operator=(slashcommand&&) noexcept = default;
 slashcommand::~slashcommand() = default;
 
 slashcommand::slashcommand(const std::string &_name, const std::string &_description, const dpp::snowflake _application_id) : slashcommand() {
@@ -376,10 +372,6 @@ command_option::command_option(command_option_type t, const std::string &n, cons
 	}
 }
 
-command_option::command_option(const command_option&) = default;
-command_option::command_option(command_option&&) noexcept = default;
-command_option& command_option::operator=(const command_option&) = default;
-command_option& command_option::operator=(command_option&&) noexcept = default;
 command_option::~command_option() = default;
 
 command_option& command_option::add_choice(const command_option_choice &o)
@@ -485,10 +477,6 @@ slashcommand& slashcommand::add_option(const command_option &o)
 interaction::interaction() : application_id(0), type(0), guild_id(0), channel_id(0), message_id(0), version(0), attachment_size_limit(DEFAULT_ATTACHMENT_SIZE_LIMIT), cache_policy(cache_policy::cpol_default) {
 }
 
-interaction::interaction(const interaction&) = default;
-interaction::interaction(interaction&&) noexcept = default;
-interaction& interaction::operator=(const interaction&) = default;
-interaction& interaction::operator=(interaction&&) noexcept = default;
 interaction::~interaction() = default;
 
 command_interaction interaction::get_command_interaction() const {

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -34,6 +34,12 @@ using json = nlohmann::json;
 slashcommand::slashcommand() : managed(), application_id(0), type(ctxm_chat_input), default_permission(true), version(1), default_member_permissions(p_use_application_commands), dm_permission(false), nsfw(false) {
 }
 
+slashcommand::slashcommand(const slashcommand&) = default;
+slashcommand::slashcommand(slashcommand&&) noexcept = default;
+slashcommand& slashcommand::operator=(const slashcommand&) = default;
+slashcommand& slashcommand::operator=(slashcommand&&) noexcept = default;
+slashcommand::~slashcommand() = default;
+
 slashcommand::slashcommand(const std::string &_name, const std::string &_description, const dpp::snowflake _application_id) : slashcommand() {
 	set_name(_name);
 	set_description(_description);
@@ -370,6 +376,12 @@ command_option::command_option(command_option_type t, const std::string &n, cons
 	}
 }
 
+command_option::command_option(const command_option&) = default;
+command_option::command_option(command_option&&) noexcept = default;
+command_option& command_option::operator=(const command_option&) = default;
+command_option& command_option::operator=(command_option&&) noexcept = default;
+command_option::~command_option() = default;
+
 command_option& command_option::add_choice(const command_option_choice &o)
 {
 	if (this->autocomplete) {
@@ -472,6 +484,12 @@ slashcommand& slashcommand::add_option(const command_option &o)
 
 interaction::interaction() : application_id(0), type(0), guild_id(0), channel_id(0), message_id(0), version(0), attachment_size_limit(DEFAULT_ATTACHMENT_SIZE_LIMIT), cache_policy(cache_policy::cpol_default) {
 }
+
+interaction::interaction(const interaction&) = default;
+interaction::interaction(interaction&&) noexcept = default;
+interaction& interaction::operator=(const interaction&) = default;
+interaction& interaction::operator=(interaction&&) noexcept = default;
+interaction::~interaction() = default;
 
 command_interaction interaction::get_command_interaction() const {
 	if (std::holds_alternative<command_interaction>(data)) {
@@ -821,9 +839,15 @@ interaction_response& interaction_response::add_autocomplete_choice(const comman
 }
 
 
+interaction_response::interaction_response(const interaction_response&) = default;
+interaction_response::interaction_response(interaction_response&&) noexcept = default;
+interaction_response& interaction_response::operator=(const interaction_response&) = default;
+interaction_response& interaction_response::operator=(interaction_response&&) noexcept = default;
+interaction_response::~interaction_response() = default;
+
 interaction_response::interaction_response(interaction_response_type t, const message& m) : type{t}, msg{m} {}
 
-interaction_response::interaction_response(interaction_response_type t, message&& m) : type{t}, msg{m} {}
+interaction_response::interaction_response(interaction_response_type t, message&& m) : type{t}, msg{std::move(m)} {}
 
 interaction_response::interaction_response(interaction_response_type t) : interaction_response() {
 	type = t;

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -828,9 +828,9 @@ interaction_response& interaction_response::add_autocomplete_choice(const comman
 
 
 interaction_response::interaction_response(const interaction_response&) = default;
-interaction_response::interaction_response(interaction_response&&) noexcept = default;
+interaction_response::interaction_response(interaction_response&&) noexcept(std::is_nothrow_move_constructible_v<message>) = default;
 interaction_response& interaction_response::operator=(const interaction_response&) = default;
-interaction_response& interaction_response::operator=(interaction_response&&) noexcept = default;
+interaction_response& interaction_response::operator=(interaction_response&&) noexcept(std::is_nothrow_move_assignable_v<message>) = default;
 interaction_response::~interaction_response() = default;
 
 interaction_response::interaction_response(interaction_response_type t, const message& m) : type{t}, msg{m} {}

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -477,6 +477,10 @@ slashcommand& slashcommand::add_option(const command_option &o)
 interaction::interaction() : application_id(0), type(0), guild_id(0), channel_id(0), message_id(0), version(0), attachment_size_limit(DEFAULT_ATTACHMENT_SIZE_LIMIT), cache_policy(cache_policy::cpol_default) {
 }
 
+interaction::interaction(const interaction&) = default;
+interaction::interaction(interaction&&) noexcept(std::is_nothrow_move_constructible_v<command_resolved> && std::is_nothrow_move_constructible_v<message> && std::is_nothrow_move_constructible_v<std::map<application_integration_types, snowflake>>) = default;
+interaction& interaction::operator=(const interaction&) = default;
+interaction& interaction::operator=(interaction&&) noexcept(std::is_nothrow_move_assignable_v<command_resolved> && std::is_nothrow_move_assignable_v<message> && std::is_nothrow_move_assignable_v<std::map<application_integration_types, snowflake>>) = default;
 interaction::~interaction() = default;
 
 command_interaction interaction::get_command_interaction() const {

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -49,10 +49,6 @@ std::map<uint32_t, dpp::user_flags> usermap = {
 user::user() : managed(), flags(0), discriminator(0), refcount(1) {
 }
 
-user::user(const user&) = default;
-user::user(user&&) noexcept = default;
-user& user::operator=(const user&) = default;
-user& user::operator=(user&&) noexcept = default;
 user::~user() = default;
 
 std::string user::get_mention(const snowflake& id) {

--- a/src/dpp/user.cpp
+++ b/src/dpp/user.cpp
@@ -49,6 +49,12 @@ std::map<uint32_t, dpp::user_flags> usermap = {
 user::user() : managed(), flags(0), discriminator(0), refcount(1) {
 }
 
+user::user(const user&) = default;
+user::user(user&&) noexcept = default;
+user& user::operator=(const user&) = default;
+user& user::operator=(user&&) noexcept = default;
+user::~user() = default;
+
 std::string user::get_mention(const snowflake& id) {
 	return utility::user_mention(id);
 }


### PR DESCRIPTION
TLDR: user-declared dtors were suppressing implicit moves, so the "moves" would copy data. this pr restores proper move semantics without removing the virtual dtors, and defines certain big class special members out of line for a much faster build (for me, 41.8s->12.6s)

---

previously, almost every data class declared a destructor (usually of the form `virtual ~T() = default`). the existence of this user-declared dtor suppresses the implicit move constructor/move assignment, so these "moves" have been copies.

this PR fixes it to have proper move semantics, and moves the definitions out of line to reduce codegen (they are now generated once, instead of in every TU).

all classes still keep their virtual destructors, so deriving from them and deleting through a base pointer is the same as before.

specifically:

- `json_interface` only types: ban, invite, prune, dtemplate, voiceregion, voicestate, auditlog, guild_command_permissions, onboarding, application_role_connection and its nested metadata, automod_metadata
  - the virtual dtor stays, and we declare the full rule of 5 with `default` to get proper moves back
- `managed` derived types: application, integration, stage_instance, sticker, user_identified, automod_rule
  - they already have a virtual dtor via `managed`, so the extra dtor decl is redundant. removing it re-enables the implicit moves.

by doing this, every `confirmable_t` alternative is nothrow moveable (except on msvc, see below), so `confirmation_callback_t` is also nothrow moveable, and the REST results and coro plumbing properly move instead of copy.

for the noexcept specs, two c++17 facts collide:

- an out-of-line defaulted member does not get a computed exception specification: callers only see what the header declares, so the noexcept must be spelled on the declaration, and it must match what the compiler would have computed or the defaulted definition is ill-formed.
- msvc's `std::map` move can throw, unlike libstdc++/libc++, so a type holding a map can't promise unconditional noexcept.

so:

- big types: message, embed, component, interaction, interaction_response, guild, confirmation_callback_t
  - define their special members out of line for the consumer compile speedup
  - the ones with only nothrow-movable members (embed, component) declare plain `noexcept`
  - the ones holding `std::map` directly or transitively (message via `attached_poll`, interaction via `resolved` its integration-owners map and its `msg`, guild via `voice_members`, interaction_response via its `message`, confirmation_callback_t via `confirmable_t`) declare a conditional spec mirroring what the compiler would compute
    - for example, we have the line `message(message&&) noexcept(std::is_nothrow_move_constructible_v<std::optional<poll>>))`: nothrow on gcc/clang, potentially throwing on msvc, valid everywhere
- smaller types: command_option, slashcommand, channel, user, welcome_screen, and all the small rule-of-5 types
  - keep in-class `= default` copy/move members. in-class defaulting gets the computed exception specification automatically, so the compiler produces the right spec per platform with nothing spelled out
  - virtual destructors for command_option, slashcommand, channel, user and welcome_screen still live out of line, since an out-of-line dtor is the class's key function and pins the vtable and typeinfo to a single TU.


I also ran some benchmarks by compiling my bot, to see whether this out-of-lining had benefits (avg of 3 runs):
- before this pr: 41.8s
- this pr, but with no out-of-lining: 38.4s
- this pr: 12.6s

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [ ] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
