### PR TITLE
feat: Added file type filtering to slashcommand attachments

### DIFF
--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -295,7 +295,7 @@ public:
 	/**
 	 * @brief File types (dpp::co_attachment) to filter for; can be "image", "video", "audio", or any dot-prefixed extension such as ".pdf" (0-10).
 	 */
-	std::vector <std::string> file_types;
+	std::vector<std::string> file_types;
 
 	/**
 	 * @brief Construct a new command option object

--- a/include/dpp/appcommand.h
+++ b/include/dpp/appcommand.h
@@ -293,6 +293,11 @@ public:
 	std::map<std::string, std::string> description_localizations;
 
 	/**
+	 * @brief File types (dpp::co_attachment) to filter for; can be "image", "video", "audio", or any dot-prefixed extension such as ".pdf" (0-10).
+	 */
+	std::vector <std::string> file_types;
+
+	/**
 	 * @brief Construct a new command option object
 	 */
 	command_option() = default;
@@ -301,6 +306,14 @@ public:
 	 * @brief Destroy the command option object
 	 */
 	virtual ~command_option() = default;
+
+	/**
+	 * @brief Add a file type (dpp::co_attachment) to filter for.
+	 *
+	 * @param file_type The type to filter for ("image"/"video"/"audio" or the file extension (begins with ".")).
+	 * @return command_option& Reference to self
+	 */
+	command_option& add_file_type(std::string_view file_type);
 
 	/**
 	 * @brief Add a localisation for this slash command option

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -568,6 +568,11 @@ public:
 	int32_t max_values;
 
 	/**
+	 * @brief File types (dpp::cot_file_upload) to filter for; can be "image", "video", "audio", or any dot-prefixed extension such as ".pdf" (0-10).
+	 */
+	std::vector <std::string> file_types;
+
+	/**
 	 * @brief Minimum length for text input (0-4000)
 	 */
 	int32_t min_length;
@@ -896,6 +901,14 @@ public:
 	 * @return component& Reference to self
 	 */
 	component& set_max_values(uint32_t max_values);
+
+	/**
+	 * @brief Add a file type (dpp::cot_file_upload) to filter for.
+	 *
+	 * @param file_type The type to filter for ("image"/"video"/"audio" or the file extension (begins with ".")).
+	 * @return component& Reference to self
+	 */
+	component& add_file_type(std::string_view file_type);
 
 	/**
 	 * @brief Set the minimum input length for a text input

--- a/include/dpp/message.h
+++ b/include/dpp/message.h
@@ -570,7 +570,7 @@ public:
 	/**
 	 * @brief File types (dpp::cot_file_upload) to filter for; can be "image", "video", "audio", or any dot-prefixed extension such as ".pdf" (0-10).
 	 */
-	std::vector <std::string> file_types;
+	std::vector<std::string> file_types;
 
 	/**
 	 * @brief Minimum length for text input (0-4000)

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -650,6 +650,11 @@ component& component::set_max_values(uint32_t _max_values) {
 	return *this;
 }
 
+component& component::add_file_type(std::string_view const file_type) {
+	this->file_types.emplace_back(file_type);
+	return *this;
+}
+
 component& component::add_select_option(const select_option &option) {
 	if (options.size() <= 25) {
 		options.emplace_back(option);

--- a/src/dpp/message.cpp
+++ b/src/dpp/message.cpp
@@ -574,6 +574,20 @@ void to_json(json& j, const component& cp) {
 				j["default_values"].push_back(o);
 			}
 		}
+	} else if (cp.type == cot_file_upload) {
+		j["custom_id"] = cp.custom_id;
+		if (cp.min_values >= 0) {
+			j["min_values"] = cp.min_values;
+		}
+		if (cp.max_values >= 0) {
+			j["max_values"] = cp.max_values;
+		}
+		if (cp.required) {
+			j["required"] = cp.required;
+		}
+		if (!cp.file_types.empty()) {
+			j["file_types"] = cp.file_types;
+		}
 	}
 }
 

--- a/src/dpp/slashcommand.cpp
+++ b/src/dpp/slashcommand.cpp
@@ -201,6 +201,10 @@ void to_json(json& j, const command_option& opt) {
 			j["channel_types"].push_back(ch_type);
 		}
 	}
+
+	if (!opt.file_types.empty()) {
+		j["file_types"] = opt.file_types;
+	}
 }
 
 void to_json(nlohmann::json& j, const command_permission& cp) {
@@ -510,6 +514,17 @@ interaction& interaction::fill_from_json_impl(nlohmann::json* j) {
 json interaction::to_json_impl(bool with_id) const {
 	/* There is no facility to build the json of an interaction as bots don't send them, only the API sends them as an event payload */
 	return "";
+}
+
+/**
+ * @brief Add a file type (dpp::co_attachment) to filter for.
+ *
+ * @param file_type The type to filter for ("image"/"video"/"audio" or the file extension (begins with ".")).
+ * @return command_option& Reference to self
+*/
+command_option& command_option::add_file_type(std::string_view const file_type) {
+	this->file_types.emplace_back(file_type);
+	return *this;
 }
 
 slashcommand& slashcommand::add_localization(const std::string& language, const std::string& _name, const std::string& _description) {


### PR DESCRIPTION
Discord's adding a new file type filtering feature to slashcommands and components: https://github.com/discord/discord-api-docs/pull/8506
I'm implementing this change here

## Code change checklist

- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [ ] I tested that my change works before raising the PR.
- [X] I have ensured that I did not break any existing API calls.
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
