### PR TITLE
fix: race condition when destroying voice client

### DIFF
--- a/include/dpp/discordclient.h
+++ b/include/dpp/discordclient.h
@@ -242,9 +242,10 @@ public:
 
 	/**
 	 * @brief Disconnect from the currently connected voice channel
+	 * @param close Whether to close connection
 	 * @return reference to self
 	 */
-	voiceconn& disconnect();
+	voiceconn& disconnect(bool close = true);
 
 	/**
 	 * @brief Reassigns the owner to the given discord_client.

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -596,15 +596,22 @@ bool voiceconn::is_active() const {
 	return voiceclient != nullptr;
 }
 
-voiceconn& voiceconn::disconnect() {
+voiceconn& voiceconn::disconnect(bool close) {
 	if (this->is_active()) {
-		voiceclient.reset();
+		this->voiceclient->terminating = true;
+		this->voiceclient->pause_audio (true);
+		this->voiceclient->stop_audio ();
+		std::this_thread::sleep_for (std::chrono::milliseconds (100));
+		if (close) {
+			this->voiceclient->close ();
+		}
+		this->voiceclient.reset ();
 	}
 	return *this;
 }
 
 voiceconn::~voiceconn() {
-	this->disconnect();
+	this->disconnect(true);
 }
 
 voiceconn& voiceconn::request(bool session_invalid) {
@@ -616,7 +623,7 @@ voiceconn& voiceconn::request(bool session_invalid) {
 		this->session_id.clear();
 		this->websocket_hostname.clear();
 	}
-	this->voiceclient.reset();
+	this->disconnect(false);
 
 	this->request_callback(this->creator);
 	return *this;

--- a/src/dpp/discordclient.cpp
+++ b/src/dpp/discordclient.cpp
@@ -599,13 +599,13 @@ bool voiceconn::is_active() const {
 voiceconn& voiceconn::disconnect(bool close) {
 	if (this->is_active()) {
 		this->voiceclient->terminating = true;
-		this->voiceclient->pause_audio (true);
-		this->voiceclient->stop_audio ();
-		std::this_thread::sleep_for (std::chrono::milliseconds (100));
+		this->voiceclient->pause_audio(true);
+		this->voiceclient->stop_audio();
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		if (close) {
-			this->voiceclient->close ();
+			this->voiceclient->close();
 		}
-		this->voiceclient.reset ();
+		this->voiceclient.reset();
 	}
 	return *this;
 }


### PR DESCRIPTION
# Changes in this PR

In small bot where concurrent reconnection never goes over just a few reconnection the probability of a crash is very tiny.
Tested in Musicat with exactly 41 concurrent reconnection.

- Fix intermittent crash when voiceconn decides to reset voiceclient

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
