### PR TITLE
fix: tighten up shell escaping to handle some edge cases

### DIFF
--- a/src/dpp/utility.cpp
+++ b/src/dpp/utility.cpp
@@ -451,6 +451,18 @@ uint32_t hsl(double h, double s, double l) {
 	return rgb(r, g, b);
 }
 
+static std::string shell_quote(const std::string& value) {
+	std::string out = "'";
+	for (const char c : value) {
+		if (c == '\'') {
+			out += "'\\''";
+		} else {
+			out += c;
+		}
+	}
+	return out + "'";
+}
+
 void exec(const std::string& cmd, std::vector<std::string> parameters, cmd_result_t callback) {
 	auto t = std::thread([cmd, parameters, callback]() {
 		try {
@@ -461,7 +473,11 @@ void exec(const std::string& cmd, std::vector<std::string> parameters, cmd_resul
 			std::stringstream cmd_and_parameters;
 			cmd_and_parameters << cmd;
 			for (auto &parameter: my_parameters) {
+#ifndef _WIN32
+				cmd_and_parameters << " " << shell_quote(parameter);
+#else
 				cmd_and_parameters << " " << std::quoted(parameter);
+#endif
 			}
 			/* Capture stderr */
 			cmd_and_parameters << " 2>&1";


### PR DESCRIPTION
When passing command line parameters to a bourne style shell using `dpp::utility::exec()`, the user could be misled to believe DPP does escaping of \` symbols, `$()`, etc (it did not).

This PR adds support for escaping that properly blocks those bourne behaviours in Linux and other similar operating systems, so that it is a bit more friendly.

Note, this does not absolve the library user of NOT passing user crafted data into `dpp::utility::exec()`. It is not our job to protect the library users from stupidity.

Windows doesn't need this patch, as `std::quoted()` will suffice there.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [x] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
