### PR TITLE
docs: Revise vulnerability reporting instructions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,16 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 10.1.x  | ✅ Feature release |
-| 10.0.x  | ✅ Fixes only      |
+| 10.0.x  | ⛔ Deprecated      |
 | 9.0.x   | ⛔ Deprecated      |
 | 1.0.x   | ⛔ Deprecated      |
 
 ## Reporting a Vulnerability
 
-To report a vulnerability please contact the development team confidentially on Discord by contacting `@brain` via a DM on https://discord.gg/dpp - We will discuss via a group chat if necessary and action the fix. Vulnerabilities are actioned and fixed within a 30 day window. Once the fix has been put into a release version, the vulnerability will be disclosed to the public.
+Please report security vulnerabilities using [GitHub's private vulnerability reporting feature](https://github.com/brainboxdotcc/DPP/security/advisories/new).
+
+This creates a confidential report that is only visible to the repository maintainers and allows us to coordinate a fix before public disclosure.
+
+If you are unable to use GitHub's private reporting feature, you may instead contact the development team confidentially via Discord by sending a direct message to `@brain` in the [DPP server](https://discord.gg/dpp)
+
+We aim to investigate and remediate reported vulnerabilities within 30 days where possible. Once a fix has been released in a supported version, the vulnerability will be disclosed publicly.


### PR DESCRIPTION
Updated the vulnerability reporting process to use GitHub's private reporting feature and deprecated 10.0

## Documentation change checklist

- [x] My documentation changes follow the [docs style guide](https://dpp.dev/docs-standards.html) and any code examples follow the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR (via running `doxygen`, and testing examples).
- [x] I have not moved any existing pages or changed any existing URLs without strong justification as to why.
- [x] I have not generated content using AI or a desktop utility such as grammarly.
