### PR TITLE
fix: bound RTP header offsets in voice_courier_loop to packet size

### DIFF
--- a/src/dpp/voice/enabled/courier_loop.cpp
+++ b/src/dpp/voice/enabled/courier_loop.cpp
@@ -186,8 +186,12 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 						 * trailing nonce, otherwise ciphertext_len below underflows.
 						 */
 						if (packet_size < static_cast<size_t>(offset_to_data) + nonce_size) {
-							/* Invalid Discord RTP payload. */
-							return;
+							/*
+							 * Invalid Discord RTP payload. Consume it and move on to the
+							 * next parked payload, like the pop at the end of this iteration.
+							 */
+							d.parked_payloads.pop();
+							continue;
 						}
 
 						size_t total_header_len = offset_to_data;
@@ -202,8 +206,12 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 							 * it is present before reading it and subtracting it from ciphertext_len.
 							 */
 							if (ciphertext_len < sizeof(uint16_t) * 2) {
-								/* Invalid Discord RTP payload. */
-								return;
+								/*
+								 * Invalid Discord RTP payload. Consume it and move on to the
+								 * next parked payload, like the pop at the end of this iteration.
+								 */
+								d.parked_payloads.pop();
+								continue;
 							}
 							/**
 							 * Get the RTP Extensions size, we only get the size here because

--- a/src/dpp/voice/enabled/courier_loop.cpp
+++ b/src/dpp/voice/enabled/courier_loop.cpp
@@ -179,6 +179,17 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 						const size_t csrc_count = buffer[0] & 0b0000'1111;
 						/* Skip to the encrypted voice data */
 						const ptrdiff_t offset_to_data = header_size + sizeof(uint32_t) * csrc_count;
+
+						/*
+						 * csrc_count comes from the first byte of the datagram, so the packet
+						 * has to actually be long enough to hold the header it describes plus the
+						 * trailing nonce, otherwise ciphertext_len below underflows.
+						 */
+						if (packet_size < static_cast<size_t>(offset_to_data) + nonce_size) {
+							/* Invalid Discord RTP payload. */
+							return;
+						}
+
 						size_t total_header_len = offset_to_data;
 
 						uint8_t *ciphertext = buffer + offset_to_data;
@@ -186,6 +197,14 @@ void discord_voice_client::voice_courier_loop(discord_voice_client& client, cour
 
 						size_t ext_len = 0;
 						if ([[maybe_unused]] const bool uses_extension = (buffer[0] >> 4) & 0b0001) {
+							/*
+							 * The 4 byte extension header sits past offset_to_data, so make sure
+							 * it is present before reading it and subtracting it from ciphertext_len.
+							 */
+							if (ciphertext_len < sizeof(uint16_t) * 2) {
+								/* Invalid Discord RTP payload. */
+								return;
+							}
 							/**
 							 * Get the RTP Extensions size, we only get the size here because
 							 * the extension itself is encrypted along with the opus packet


### PR DESCRIPTION
ASan, replaying the courier's header block against a 44 byte datagram whose first byte is 0x1F (extension bit set, CSRC count 15), the shortest packet `read_ready()` forwards:

    ciphertext_len = 18446744073709551584

    ERROR: AddressSanitizer: heap-buffer-overflow
    READ of size 2 at 0x60400000041a thread T0
        #0 __asan_memcpy
        #1 in <courier header block> ... memcpy(&ext_len_in_words, &ciphertext[2], sizeof(uint16_t))
    0x60400000041a is located 30 bytes after 44-byte region [0x6040000003d0,0x6040000003fc)

`offset_to_data` is `12 + 4 * csrc_count` and reaches 72, while `read_ready()` only guarantees 44 bytes, so `ciphertext_len` wraps, the extension length is read off the end of the vector holding the datagram, and `total_header_len` walks the AEAD past that same allocation for its AAD. The voice UDP socket is bound without a `connect()` and read with `recv()`, so the sender is any host that can reach the port, and none of this sits behind the Poly1305 check. Drop the packet when the header its first byte describes does not fit in what actually arrived.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [ ] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
