### PR TITLE
[fix] Made shardless cluster not cause an assertion error when getting destroyed

### DIFF
--- a/src/dpp/cluster/timer.cpp
+++ b/src/dpp/cluster/timer.cpp
@@ -67,7 +67,7 @@ void cluster::tick_timers() {
 		timer_t cur_timer;
 		{
 			std::lock_guard<std::mutex> l(timer_guard);
-			if (next_timer.top().next_tick > now) {
+			if (next_timer.empty() || next_timer.top().next_tick > now) {
 				/* Nothing to do */
 				break;
 			}


### PR DESCRIPTION
After `cluster.cpp:162` happens, executing `cluster.cpp:163` causes the assertion fail. This also works the other way around.

Shutting down the cluster (`dpp::cluster::shutdown`) before `cluster.cpp:162` or the destruction of the object makes the assertion fail go away.

The issue isn't caused by `dpp::request_queue::~request_queue` directly. This destructor marks queues as terminating which doesn't let new requests come in. Yet after `dpp::cluster::tick_timers` has already been called so it needs to, well, tick all the timers. The timer queue can end up depleting before `tick_timers` finishes its job since in the `while (true)` loop (matching `do` at `timer.cpp:66`) we pop the queue and never check if it's empty. And if it's supposed to be unable to, well, that's exactly what caused this issue in the first place. The only place in that loop's function where we do check is above the `do`, at `timer.cpp:62`. My guess is that these checks happen to be quick enough when there are no shards to cause that assertion fail before the cluster gets to shut down, though I'm not that familiar with the codebase to be able to assert a confident verdict.

Either way, this PR fixes it by simply checking for the `next_timer`'s emptiness before accessing its `.top()`. Since the original check virtually instantly exits `tick_timers` if it succeeds and otherwise accesses the queue anyway, my addition should have no effect on a bot's functionality. Regardless, I tested it with mine for a few minutes and it ran fine.

I decided to maintain the order of the calls in `dpp::cluster`'s destructor in case it was important for graceful exiting.

## Code change checklist

- [X] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [X] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [X] I tested that my change works before raising the PR.
- [X] I have ensured that I did not break any existing API calls.
- [X] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
