### PR TITLE
bound ip discovery address to buffer size before string conversion

### DIFF
--- a/src/dpp/voice/enabled/discover_ip.cpp
+++ b/src/dpp/voice/enabled/discover_ip.cpp
@@ -168,7 +168,7 @@ std::string discord_voice_client::discover_ip() {
 					return "";
 				}
 				ip_discovery_packet inbound_packet(buffer);
-				return {inbound_packet.address};
+				return std::string(inbound_packet.address, strnlen(inbound_packet.address, ip_discovery_packet::ADDRESS_BUFFER_SIZE));
 		}
 	}
 	return {};


### PR DESCRIPTION
discover_ip() reads the IP discovery response off the voice UDP socket into a 74 byte buffer, copies the 64 byte address field into ip_discovery_packet::address, then returns it with std::string(inbound_packet.address). That constructor runs strlen across the buffer, but nothing in the discovery wire format guarantees a NUL inside those 64 bytes. A response whose whole address region is non-zero makes strlen walk past the end of the fixed buffer; ASAN reports a heap-buffer-overflow read of size 65 one byte past the 64 byte region, and whatever it reads lands in the external IP we hand back in the select_protocol payload.

Bound the read with strnlen(address, ADDRESS_BUFFER_SIZE) so the returned string can never span more than the 64 bytes actually received. Building the bound where the string is constructed leaves the packet struct untouched and stops the over-read at the single place the buffer is treated as a C string; a well formed, NUL-terminated address decodes exactly as before.

## Code change checklist

- [x] I have ensured that all methods and functions are **fully documented** using doxygen style comments.
- [x] My code follows the [coding style guide](https://dpp.dev/coding-standards.html).
- [x] I tested that my change works before raising the PR.
- [x] I have ensured that I did not break any existing API calls.
- [ ] I have not built my pull request using AI, a static analysis tool or similar without any human oversight.
